### PR TITLE
Browser, devices and OS icons

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -15,6 +15,7 @@
     "schema": "./prisma/schema.prisma"
   },
   "dependencies": {
+    "@iconify/react": "^6.0.0",
     "@next-auth/prisma-adapter": "^1.0.7",
     "@prisma/client": "^6.8.2",
     "@prisma/extension-accelerate": "^1.3.0",

--- a/dashboard/src/app/dashboard/[dashboardId]/(dashboard)/DevicesSection.tsx
+++ b/dashboard/src/app/dashboard/[dashboardId]/(dashboard)/DevicesSection.tsx
@@ -1,39 +1,54 @@
-"use client";
+'use client';
 import MultiProgressTable from '@/components/MultiProgressTable';
-import { fetchDeviceBreakdownCombinedAction } from "@/app/actions/devices";
+import { fetchDeviceBreakdownCombinedAction } from '@/app/actions/devices';
 import { use } from 'react';
+import { BrowserIcon } from '@/components/icons/BrowserIcon';
+import { DeviceIcon } from '@/components/icons/DeviceIcon';
+import { OSIcon } from '@/components/icons/OSIcon';
 
 type DevicesSectionProps = {
-  deviceBreakdownCombinedPromise: ReturnType<typeof fetchDeviceBreakdownCombinedAction>
-}
+  deviceBreakdownCombinedPromise: ReturnType<typeof fetchDeviceBreakdownCombinedAction>;
+};
 
 export default function DevicesSection({ deviceBreakdownCombinedPromise }: DevicesSectionProps) {
   const deviceBreakdownCombined = use(deviceBreakdownCombinedPromise);
 
   return (
-    <MultiProgressTable 
-      title="Devices Breakdown"
-      defaultTab="browsers"
+    <MultiProgressTable
+      title='Devices Breakdown'
+      defaultTab='browsers'
       tabs={[
         {
-          key: "browsers",
-          label: "Browsers",
-          data: deviceBreakdownCombined.browsers.map(item => ({ label: item.browser, value: item.visitors })),
-          emptyMessage: "No browser data available"
+          key: 'browsers',
+          label: 'Browsers',
+          data: deviceBreakdownCombined.browsers.map((item) => ({
+            label: item.browser,
+            value: item.visitors,
+            icon: <BrowserIcon name={item.browser} className='h-4 w-4' />,
+          })),
+          emptyMessage: 'No browser data available',
         },
         {
-          key: "devices",
-          label: "Devices", 
-          data: deviceBreakdownCombined.devices.map(item => ({ label: item.device_type, value: item.visitors })),
-          emptyMessage: "No device data available"
+          key: 'devices',
+          label: 'Devices',
+          data: deviceBreakdownCombined.devices.map((item) => ({
+            label: item.device_type,
+            value: item.visitors,
+            icon: <DeviceIcon type={item.device_type} className='h-4 w-4' />,
+          })),
+          emptyMessage: 'No device data available',
         },
         {
-          key: "os",
-          label: "Operating Systems",
-          data: deviceBreakdownCombined.operatingSystems.map(item => ({ label: item.os, value: item.visitors })),
-          emptyMessage: "No operating system data available"
-        }
+          key: 'os',
+          label: 'Operating Systems',
+          data: deviceBreakdownCombined.operatingSystems.map((item) => ({
+            label: item.os,
+            value: item.visitors,
+            icon: <OSIcon name={item.os} className='h-4 w-4' />,
+          })),
+          emptyMessage: 'No operating system data available',
+        },
       ]}
     />
   );
-} 
+}

--- a/dashboard/src/app/dashboard/[dashboardId]/devices/DeviceUsageTrendChart.tsx
+++ b/dashboard/src/app/dashboard/[dashboardId]/devices/DeviceUsageTrendChart.tsx
@@ -8,17 +8,32 @@ import {
   YAxis,
   CartesianGrid,
   Tooltip as RechartsTooltip,
-  Legend,
 } from 'recharts';
+import React, { useMemo } from 'react';
 import { DeviceUsageTrendRow } from '@/entities/devices';
 import { getDeviceColor } from '@/utils/deviceColors';
-import { useMemo } from 'react';
+import { DeviceIcon } from '@/components/icons';
 import { format } from 'date-fns';
 import { capitalizeFirstLetter } from '@/utils/formatters';
 
 interface DeviceUsageTrendChartProps {
   data?: DeviceUsageTrendRow[];
 }
+
+const CustomLegend = React.memo(({ deviceTypes }: { deviceTypes: string[] }) => (
+  <div className='mt-4 flex justify-center gap-4'>
+    {deviceTypes.map((deviceType) => (
+      <div key={deviceType} className='flex items-center gap-1 text-sm'>
+        <span
+          className='inline-block h-3 w-3 rounded-full'
+          style={{ backgroundColor: getDeviceColor(deviceType) }}
+        />
+        <DeviceIcon type={deviceType} className='h-4 w-4' />
+        <span className='text-foreground font-medium'>{capitalizeFirstLetter(deviceType)}</span>
+      </div>
+    ))}
+  </div>
+));
 
 const calculateDeviceTypeTotals = (data: DeviceUsageTrendRow[]): Record<string, number> => {
   if (!data || data.length === 0) {
@@ -115,42 +130,44 @@ export default function DeviceUsageTrendChart({ data }: DeviceUsageTrendChartPro
   }
 
   return (
-    <div className='h-[300px] w-full'>
-      <ResponsiveContainer width='100%' height='100%'>
-        <AreaChart data={chartData} margin={{ top: 10, right: 10, left: 0, bottom: 5 }}>
-          <CartesianGrid strokeDasharray='3 3' vertical={false} stroke='#f1f5f9' />
-          <XAxis
-            dataKey='date'
-            tickLine={false}
-            axisLine={false}
-            tick={{ fontSize: 12 }}
-            tickMargin={10}
-            tickFormatter={(value) => format(new Date(value), 'MMM dd')}
-          />
-          <YAxis
-            tickLine={false}
-            axisLine={false}
-            tick={{ fontSize: 12 }}
-            tickMargin={10}
-            tickFormatter={(val) => val.toLocaleString()}
-          />
-          <RechartsTooltip content={<CustomTooltip />} />
-          <Legend verticalAlign='bottom' height={36} />
-
-          {sortedDeviceTypes.map((deviceType) => (
-            <Area
-              key={deviceType}
-              type='monotone'
-              dataKey={deviceType}
-              stackId='1'
-              stroke={getDeviceColor(deviceType)}
-              fill={getDeviceColor(deviceType)}
-              fillOpacity={0.7}
-              name={capitalizeFirstLetter(deviceType)}
+    <div className='w-full'>
+      <div className='h-[250px] w-full'>
+        <ResponsiveContainer width='100%' height='100%'>
+          <AreaChart data={chartData} margin={{ top: 10, right: 10, left: 0, bottom: 5 }}>
+            <CartesianGrid strokeDasharray='3 3' vertical={false} stroke='#f1f5f9' />
+            <XAxis
+              dataKey='date'
+              tickLine={false}
+              axisLine={false}
+              tick={{ fontSize: 12 }}
+              tickMargin={10}
+              tickFormatter={(value) => format(new Date(value), 'MMM dd')}
             />
-          ))}
-        </AreaChart>
-      </ResponsiveContainer>
+            <YAxis
+              tickLine={false}
+              axisLine={false}
+              tick={{ fontSize: 12 }}
+              tickMargin={10}
+              tickFormatter={(val) => val.toLocaleString()}
+            />
+            <RechartsTooltip content={<CustomTooltip />} />
+
+            {sortedDeviceTypes.map((deviceType) => (
+              <Area
+                key={deviceType}
+                type='monotone'
+                dataKey={deviceType}
+                stackId='1'
+                stroke={getDeviceColor(deviceType)}
+                fill={getDeviceColor(deviceType)}
+                fillOpacity={0.7}
+                name={capitalizeFirstLetter(deviceType)}
+              />
+            ))}
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+      <CustomLegend deviceTypes={sortedDeviceTypes} />
     </div>
   );
 }

--- a/dashboard/src/app/dashboard/[dashboardId]/devices/DevicesSummarySection.tsx
+++ b/dashboard/src/app/dashboard/[dashboardId]/devices/DevicesSummarySection.tsx
@@ -2,6 +2,8 @@ import { use } from 'react';
 import { fetchDeviceSummaryAction } from '@/app/actions';
 import SummaryCardsSection, { SummaryCardData } from '@/components/dashboard/SummaryCardsSection';
 import { formatPercentage } from '@/utils/formatters';
+import { DeviceIcon, BrowserIcon, OSIcon } from '@/components/icons';
+import { Monitor } from 'lucide-react';
 
 type DevicesSummarySectionProps = {
   deviceSummaryPromise: ReturnType<typeof fetchDeviceSummaryAction>;
@@ -14,18 +16,22 @@ export default function DevicesSummarySection({ deviceSummaryPromise }: DevicesS
     {
       title: 'Distinct Device Types',
       value: deviceSummary.distinctDeviceCount.toString(),
+      icon: <Monitor className='h-4 w-4' />,
     },
     {
       title: 'Most Popular Device',
       value: `${deviceSummary.topDevice.name} (${formatPercentage(deviceSummary.topDevice.percentage)})`,
+      icon: <DeviceIcon type={deviceSummary.topDevice.name} className='h-4 w-4' />,
     },
     {
       title: 'Most Popular Operating System',
       value: `${deviceSummary.topOs.name} (${formatPercentage(deviceSummary.topOs.percentage)})`,
+      icon: <OSIcon name={deviceSummary.topOs.name} className='h-4 w-4' />,
     },
     {
       title: 'Most Popular Browser',
       value: `${deviceSummary.topBrowser.name} (${formatPercentage(deviceSummary.topBrowser.percentage)})`,
+      icon: <BrowserIcon name={deviceSummary.topBrowser.name} className='h-4 w-4' />,
     },
   ];
 

--- a/dashboard/src/app/dashboard/[dashboardId]/devices/page.tsx
+++ b/dashboard/src/app/dashboard/[dashboardId]/devices/page.tsx
@@ -50,7 +50,7 @@ export default async function DevicesPage({ params, searchParams }: DevicesPageP
         <div className='flex flex-col justify-between gap-y-4 lg:flex-row lg:items-center'>
           <div>
             <h1 className='text-foreground mb-1 text-2xl font-bold'>Devices</h1>
-            <p className='text-muted-foreground text-sm'>Analytics and insights for your website</p>
+            <p className='text-muted-foreground text-sm'>Visitor device breakdown and usage analytics</p>
           </div>
           <DashboardFilters />
         </div>

--- a/dashboard/src/app/dashboard/[dashboardId]/events/EventLogItem.tsx
+++ b/dashboard/src/app/dashboard/[dashboardId]/events/EventLogItem.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { Globe, Monitor, User, ExternalLink, Activity } from 'lucide-react';
+import { Globe, User, ExternalLink, Activity } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { EventLogEntry } from '@/entities/events';
 import { formatTimeAgo } from '@/utils/dateFormatters';
+import { DeviceIcon, BrowserIcon } from '@/components/icons';
 
 const MAX_PROPERTIES_DISPLAY = 3;
 
@@ -15,12 +16,14 @@ interface EventLogItemProps {
 const formatEventProperties = (jsonString: string) => {
   try {
     const props = JSON.parse(jsonString);
-    return Object.entries(props).slice(0, MAX_PROPERTIES_DISPLAY).map(([key, value]) => (
-      <Badge key={key} variant="secondary" className="text-xs font-normal">
-        <span className="text-muted-foreground">{key}:</span>
-        <span className="ml-1">{String(value)}</span>
-      </Badge>
-    ));
+    return Object.entries(props)
+      .slice(0, MAX_PROPERTIES_DISPLAY)
+      .map(([key, value]) => (
+        <Badge key={key} variant='secondary' className='text-xs font-normal'>
+          <span className='text-muted-foreground'>{key}:</span>
+          <span className='ml-1'>{String(value)}</span>
+        </Badge>
+      ));
   } catch {
     return null;
   }
@@ -36,72 +39,82 @@ const formatUrl = (url: string) => {
   }
 };
 
-const MetadataItem = ({ icon: Icon, children, className = "" }: { 
-  icon: React.ComponentType<{ className?: string }>, 
-  children: React.ReactNode,
-  className?: string 
+const MetadataItem = ({
+  icon,
+  children,
+  className = '',
+}: {
+  icon: React.ComponentType<{ className?: string }> | React.ReactElement;
+  children: React.ReactNode;
+  className?: string;
 }) => (
-  <div className={`flex items-center gap-1.5 text-muted-foreground ${className}`}>
-    <Icon className="h-3.5 w-3.5" />
+  <div className={`text-muted-foreground flex items-center gap-1.5 ${className}`}>
+    {React.isValidElement(icon)
+      ? icon
+      : React.createElement(icon as React.ComponentType<{ className?: string }>, { className: 'h-3.5 w-3.5' })}
     {children}
   </div>
 );
 
 export const EventLogItem = React.memo(function EventLogItem({ event, isNearEnd, onRef }: EventLogItemProps) {
   return (
-    <div 
-      className="group relative p-4 hover:bg-muted/40 transition-all duration-200 border-l-2 border-l-transparent hover:border-l-primary/50"
+    <div
+      className='group hover:bg-muted/40 hover:border-l-primary/50 relative border-l-2 border-l-transparent p-4 transition-all duration-200'
       ref={isNearEnd ? onRef : null}
     >
-      <div className="relative flex items-start gap-4">
-        <div className="flex-shrink-0 w-8 h-8 rounded-lg bg-muted/50 flex items-center justify-center border border-border/30">
-          <Activity className="h-3.5 w-3.5 text-primary" />
+      <div className='relative flex items-start gap-4'>
+        <div className='bg-muted/50 border-border/30 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg border'>
+          <Activity className='text-primary h-3.5 w-3.5' />
         </div>
-        
-        <div className="flex-1 min-w-0 space-y-3">
-          <div className="flex items-center justify-between gap-3">
-            <div className="flex items-center gap-2">
-              <h3 className="font-semibold text-foreground text-sm leading-tight">
-                {event.event_name}
-              </h3>
-              <div className="h-1 w-1 rounded-full bg-muted-foreground/40" />
-              <Badge variant="secondary" className="text-xs font-medium">
+
+        <div className='min-w-0 flex-1 space-y-3'>
+          <div className='flex items-center justify-between gap-3'>
+            <div className='flex items-center gap-2'>
+              <h3 className='text-foreground text-sm leading-tight font-semibold'>{event.event_name}</h3>
+              <div className='bg-muted-foreground/40 h-1 w-1 rounded-full' />
+              <Badge variant='secondary' className='text-xs font-medium'>
                 {formatTimeAgo(new Date(event.timestamp))}
               </Badge>
             </div>
           </div>
-          
-          <div className="flex items-center gap-4 text-xs flex-wrap">
+
+          <div className='flex flex-wrap items-center gap-4 text-xs'>
             <MetadataItem icon={User}>
-              <span className="font-mono bg-muted/60 px-1.5 py-0.5 rounded text-[10px] font-medium">
+              <span className='bg-muted/60 rounded px-1.5 py-0.5 font-mono text-[10px] font-medium'>
                 {event.visitor_id.slice(-6)}
               </span>
             </MetadataItem>
-            
-            <MetadataItem icon={Monitor}> {/* TODO: Add device icon */}
-              <span className="capitalize">{event.device_type}</span>
+
+            <MetadataItem icon={<DeviceIcon type={event.device_type} />}>
+              <span className='capitalize'>{event.device_type}</span>
             </MetadataItem>
-            
-            {event.country_code && (
-              <MetadataItem icon={Globe}> {/* TODO: Add flag icon */}
-                <span className="uppercase font-medium">{event.country_code}</span>
+
+            {event.browser && (
+              <MetadataItem icon={<BrowserIcon name={event.browser} />}>
+                <span className='capitalize'>{event.browser}</span>
               </MetadataItem>
             )}
-            
+
+            {event.country_code && (
+              <MetadataItem icon={Globe}>
+                {' '}
+                {/* TODO: Add flag icon */}
+                <span className='font-medium uppercase'>{event.country_code}</span>
+              </MetadataItem>
+            )}
+
             <MetadataItem icon={ExternalLink}>
-              <span className="font-mono bg-muted/60 px-1.5 py-0.5 rounded text-[10px] font-medium">
+              <span className='bg-muted/60 rounded px-1.5 py-0.5 font-mono text-[10px] font-medium'>
                 {formatUrl(event.url)}
               </span>
             </MetadataItem>
           </div>
 
           {event.custom_event_json && event.custom_event_json !== '{}' && (
-            <div className="flex flex-wrap gap-2 pt-1">
-              {formatEventProperties(event.custom_event_json)}
-            </div>
+            <div className='flex flex-wrap gap-2 pt-1'>{formatEventProperties(event.custom_event_json)}</div>
           )}
         </div>
       </div>
     </div>
   );
-}); 
+});

--- a/dashboard/src/components/MultiProgressTable.tsx
+++ b/dashboard/src/components/MultiProgressTable.tsx
@@ -8,6 +8,7 @@ import { PropertyValueBar } from '@/components/events/PropertyValueBar';
 interface ProgressBarData {
   label: string;
   value: number;
+  icon?: React.ReactElement;
 }
 
 interface TabConfig<T extends ProgressBarData> {
@@ -47,10 +48,12 @@ function MultiProgressTable<T extends ProgressBarData>({ title, tabs, defaultTab
             <div key={item.label} className='group relative'>
               <PropertyValueBar
                 value={{
-                  value: `${index + 1}. ${item.label}`,
+                  value: item.label,
                   count: item.value,
                   percentage: Math.max(percentage, 2),
                 }}
+                icon={item.icon}
+                index={index + 1}
               />
             </div>
           );

--- a/dashboard/src/components/SummaryCard.tsx
+++ b/dashboard/src/components/SummaryCard.tsx
@@ -14,6 +14,7 @@ interface ChartData {
 interface SummaryCardProps<T extends ChartData = ChartData> {
   title: React.ReactNode;
   value: React.ReactNode;
+  icon?: React.ReactNode;
 
   // Mini chart data
   rawChartData?: T[];
@@ -58,6 +59,7 @@ const SummaryCard = React.memo(
   <T extends ChartData = ChartData>({
     title,
     value,
+    icon,
     rawChartData,
     valueField,
     chartColor = 'var(--chart-1)',
@@ -114,6 +116,7 @@ const SummaryCard = React.memo(
             )}
           </div>
           <div className='flex items-center gap-2'>
+            {icon && <div className='text-muted-foreground pt-1'>{icon}</div>}
             <span className='text-foreground text-2xl font-bold tracking-tight'>{value}</span>
             {trendData && trendData.direction !== 'neutral' && (
               <Badge

--- a/dashboard/src/components/analytics/BrowserTable.tsx
+++ b/dashboard/src/components/analytics/BrowserTable.tsx
@@ -3,6 +3,7 @@
 import { BrowserStats } from '@/entities/devices';
 import { DataTable } from '@/components/DataTable';
 import { ColumnDef } from '@tanstack/react-table';
+import { BrowserIcon } from '@/components/icons';
 
 interface BrowserTableProps {
   data: BrowserStats[];
@@ -13,6 +14,12 @@ export default function BrowserTable({ data }: BrowserTableProps) {
     {
       accessorKey: 'browser',
       header: 'Browser',
+      cell: ({ row }) => (
+        <div className='flex items-center gap-2'>
+          <BrowserIcon name={row.original.browser} className='h-4 w-4' />
+          <span>{row.original.browser}</span>
+        </div>
+      ),
     },
     {
       accessorKey: 'visitors',

--- a/dashboard/src/components/analytics/DeviceTypeChart.tsx
+++ b/dashboard/src/components/analytics/DeviceTypeChart.tsx
@@ -3,6 +3,7 @@
 import { DeviceType } from '@/entities/devices';
 import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from 'recharts';
 import { getDeviceLabel, getDeviceColor } from '@/constants/deviceTypes';
+import { DeviceIcon } from '@/components/icons';
 import { useMemo } from 'react';
 
 interface DeviceTypeChartProps {
@@ -47,6 +48,7 @@ export default function DeviceTypeChart({ data }: DeviceTypeChartProps) {
         {chartData.map((entry) => (
           <div key={entry.label} className='flex items-center gap-1 text-sm'>
             <span className='inline-block h-3 w-3 rounded-full' style={{ backgroundColor: entry.color }}></span>
+            <DeviceIcon type={entry.device_type} className='h-4 w-4' />
             <span className='text-foreground font-medium'>{entry.label}</span>
             <span className='text-muted-foreground'>{entry.percent}%</span>
           </div>

--- a/dashboard/src/components/analytics/OperatingSystemTable.tsx
+++ b/dashboard/src/components/analytics/OperatingSystemTable.tsx
@@ -3,6 +3,7 @@
 import { OperatingSystemStats } from '@/entities/devices';
 import { DataTable } from '@/components/DataTable';
 import { ColumnDef } from '@tanstack/react-table';
+import { OSIcon } from '@/components/icons';
 
 interface OperatingSystemTableProps {
   data: OperatingSystemStats[];
@@ -13,6 +14,12 @@ export default function OperatingSystemTable({ data }: OperatingSystemTableProps
     {
       accessorKey: 'os',
       header: 'Operating System',
+      cell: ({ row }) => (
+        <div className='flex items-center gap-2'>
+          <OSIcon name={row.original.os} className='h-4 w-4' />
+          <span>{row.original.os}</span>
+        </div>
+      ),
     },
     {
       accessorKey: 'visitors',

--- a/dashboard/src/components/dashboard/SummaryCardsSection.tsx
+++ b/dashboard/src/components/dashboard/SummaryCardsSection.tsx
@@ -4,6 +4,7 @@ import SummaryCard from '@/components/SummaryCard';
 export interface SummaryCardData {
   title: string;
   value: ReactNode;
+  icon?: ReactNode;
   rawChartData?: any[];
   valueField?: string;
   chartColor?: string;
@@ -24,6 +25,7 @@ export default function SummaryCardsSection({ cards, className }: SummaryCardsSe
           key={`${card.title}-${index}`}
           title={card.title}
           value={card.value}
+          icon={card.icon}
           rawChartData={card.rawChartData}
           valueField={card.valueField}
           chartColor={card.chartColor}

--- a/dashboard/src/components/events/PropertyValueBar.tsx
+++ b/dashboard/src/components/events/PropertyValueBar.tsx
@@ -1,27 +1,33 @@
-import { EventPropertyValue } from "@/entities/events";
-import { formatPercentage } from "@/utils/formatters";
-import { Progress } from "@/components/ui/progress";
+import { EventPropertyValue } from '@/entities/events';
+import { formatPercentage } from '@/utils/formatters';
+import { Progress } from '@/components/ui/progress';
 
 interface PropertyValueBarProps {
   value: EventPropertyValue;
+  icon?: React.ReactElement;
+  index?: number;
 }
 
-export function PropertyValueBar({ value }: PropertyValueBarProps) {
+export function PropertyValueBar({ value, icon, index }: PropertyValueBarProps) {
   return (
-    <div className="relative group hover:bg-muted/20 transition-colors duration-200 rounded-sm">
-      <div className="h-7 relative overflow-hidden rounded-sm">
-        <Progress 
+    <div className='group hover:bg-muted/20 relative rounded-sm transition-colors duration-200'>
+      <div className='relative h-7 overflow-hidden rounded-sm'>
+        <Progress
           value={Math.max(value.percentage, 2)}
-          className="h-full bg-muted/30 group-hover:bg-muted/40 transition-colors duration-200 [&>div]:bg-primary/30 rounded-sm"
+          className='bg-muted/30 group-hover:bg-muted/40 [&>div]:bg-primary/30 h-full rounded-sm transition-colors duration-200'
         />
-        
-        <div className="absolute inset-0 flex items-center justify-between px-3 z-10">
-          <span className="text-sm font-medium text-foreground font-mono truncate">
-            {value.value}
-          </span>
-          
-          <div className="flex items-center gap-2 text-xs text-muted-foreground font-mono">
-            <span className="opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+
+        <div className='absolute inset-0 z-10 flex items-center justify-between px-3'>
+          <div className='flex items-center gap-2'>
+            {typeof index === 'number' && (
+              <span className='text-foreground font-mono text-sm font-medium'>{index}.</span>
+            )}
+            {icon && <span className='flex-shrink-0'>{icon}</span>}
+            <span className='text-foreground truncate font-mono text-sm font-medium'>{value.value}</span>
+          </div>
+
+          <div className='text-muted-foreground flex items-center gap-2 font-mono text-xs'>
+            <span className='opacity-0 transition-opacity duration-200 group-hover:opacity-100'>
               {formatPercentage(value.percentage)}
             </span>
             <span>{value.count.toLocaleString()}</span>
@@ -30,4 +36,4 @@ export function PropertyValueBar({ value }: PropertyValueBarProps) {
       </div>
     </div>
   );
-} 
+}

--- a/dashboard/src/components/icons/BrowserIcon.tsx
+++ b/dashboard/src/components/icons/BrowserIcon.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Globe } from 'lucide-react';
+import { Icon } from '@iconify/react';
+import { browserIconNames, browserLabels, type BrowserType } from '@/constants/browserIcons';
+
+interface BrowserIconProps {
+  name: string;
+  className?: string;
+}
+
+export const BrowserIcon = React.memo<BrowserIconProps>(({ name, className = 'h-3.5 w-3.5' }) => {
+  const normalizedName = name.toLowerCase().replace(/\s+/g, '') as BrowserType;
+  const iconName = browserIconNames[normalizedName];
+
+  if (!iconName) {
+    return <Globe className={className} />;
+  }
+
+  return <Icon icon={iconName} className={className} />;
+});
+
+BrowserIcon.displayName = 'BrowserIcon';
+
+export const getBrowserLabel = (browserName: string): string => {
+  return browserLabels[browserName.toLowerCase().replace(/\s+/g, '')] || browserName;
+};

--- a/dashboard/src/components/icons/DeviceIcon.tsx
+++ b/dashboard/src/components/icons/DeviceIcon.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Monitor } from 'lucide-react';
+import { deviceIcons, deviceLabels, type DeviceType } from '@/constants/deviceIcons';
+
+interface DeviceIconProps {
+  type: string;
+  className?: string;
+}
+
+export const DeviceIcon = React.memo<DeviceIconProps>(({ type, className = 'h-3.5 w-3.5' }) => {
+  const normalizedType = type.toLowerCase() as DeviceType;
+  const IconComponent = deviceIcons[normalizedType] || Monitor;
+  return <IconComponent className={className} />;
+});
+
+DeviceIcon.displayName = 'DeviceIcon';
+
+export const getDeviceTypeLabel = (deviceType: string): string => {
+  return deviceLabels[deviceType.toLowerCase()] || deviceType;
+};

--- a/dashboard/src/components/icons/OSIcon.tsx
+++ b/dashboard/src/components/icons/OSIcon.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import React from 'react';
+import { Monitor } from 'lucide-react';
+import { Icon } from '@iconify/react';
+import { useTheme } from 'next-themes';
+import { osIconNamesThemed, osLabels, type OSType } from '@/constants/operatingSystemIcons';
+
+interface OSIconProps {
+  name: string;
+  className?: string;
+}
+
+export const OSIcon = React.memo<OSIconProps>(({ name, className = 'h-3.5 w-3.5' }) => {
+  const { theme } = useTheme();
+
+  const iconName = React.useMemo(() => {
+    const normalizedName = name.toLowerCase().replace(/\s+/g, '') as OSType;
+    const iconVariants = osIconNamesThemed[normalizedName];
+
+    if (!iconVariants) return null;
+
+    return theme === 'dark' ? iconVariants.dark : iconVariants.light;
+  }, [name, theme]);
+
+  if (!iconName) {
+    return <Monitor className={className} />;
+  }
+
+  return <Icon icon={iconName} className={className} />;
+});
+
+OSIcon.displayName = 'OSIcon';
+
+export const getOSLabel = (osName: string): string => {
+  return osLabels[osName.toLowerCase().replace(/\s+/g, '')] || osName;
+};

--- a/dashboard/src/components/icons/index.ts
+++ b/dashboard/src/components/icons/index.ts
@@ -1,0 +1,7 @@
+export { DeviceIcon, getDeviceTypeLabel } from './DeviceIcon';
+export { BrowserIcon, getBrowserLabel } from './BrowserIcon';
+export { OSIcon, getOSLabel } from './OSIcon';
+
+export type { DeviceType } from '@/constants/deviceIcons';
+export type { BrowserType } from '@/constants/browserIcons';
+export type { OSType } from '@/constants/operatingSystemIcons';

--- a/dashboard/src/constants/browserIcons.ts
+++ b/dashboard/src/constants/browserIcons.ts
@@ -1,0 +1,23 @@
+export const browserIconNames = {
+  chrome: 'logos:chrome',
+  firefox: 'logos:firefox',
+  safari: 'logos:safari',
+  edge: 'logos:microsoft-edge',
+  opera: 'logos:opera',
+  brave: 'logos:brave',
+  vivaldi: 'logos:vivaldi',
+  arc: 'simple-icons:arc',
+} as const;
+
+export type BrowserType = keyof typeof browserIconNames;
+
+export const browserLabels: Record<string, string> = {
+  chrome: 'Google Chrome',
+  firefox: 'Mozilla Firefox',
+  safari: 'Safari',
+  edge: 'Microsoft Edge',
+  opera: 'Opera',
+  brave: 'Brave',
+  vivaldi: 'Vivaldi',
+  arc: 'Arc',
+};

--- a/dashboard/src/constants/deviceIcons.ts
+++ b/dashboard/src/constants/deviceIcons.ts
@@ -1,0 +1,17 @@
+import { Monitor, Smartphone, Tablet, Laptop } from 'lucide-react';
+
+export const deviceIcons = {
+  desktop: Monitor,
+  mobile: Smartphone,
+  tablet: Tablet,
+  laptop: Laptop,
+} as const;
+
+export type DeviceType = keyof typeof deviceIcons;
+
+export const deviceLabels: Record<string, string> = {
+  desktop: 'Desktop',
+  mobile: 'Mobile',
+  tablet: 'Tablet',
+  laptop: 'Laptop',
+};

--- a/dashboard/src/constants/operatingSystemIcons.ts
+++ b/dashboard/src/constants/operatingSystemIcons.ts
@@ -1,0 +1,37 @@
+export const osIconNamesThemed = {
+  windows: {
+    light: 'mdi:microsoft-windows',
+    dark: 'mdi:microsoft-windows',
+  },
+  macos: {
+    light: 'logos:apple',
+    dark: 'simple-icons:apple',
+  },
+  ios: {
+    light: 'logos:apple',
+    dark: 'simple-icons:apple',
+  },
+  android: {
+    light: 'logos:android-icon',
+    dark: 'logos:android-icon',
+  },
+  linux: {
+    light: 'logos:linux-tux',
+    dark: 'simple-icons:linux',
+  },
+  ubuntu: {
+    light: 'logos:ubuntu',
+    dark: 'logos:ubuntu',
+  },
+} as const;
+
+export type OSType = keyof typeof osIconNamesThemed;
+
+export const osLabels: Record<string, string> = {
+  windows: 'Windows',
+  macos: 'macOS',
+  ios: 'iOS',
+  android: 'Android',
+  linux: 'Linux',
+  ubuntu: 'Ubuntu',
+};

--- a/dashboard/src/constants/operatingSystemIcons.ts
+++ b/dashboard/src/constants/operatingSystemIcons.ts
@@ -3,6 +3,22 @@ export const osIconNamesThemed = {
     light: 'mdi:microsoft-windows',
     dark: 'mdi:microsoft-windows',
   },
+  windows11: {
+    light: 'mdi:microsoft-windows',
+    dark: 'mdi:microsoft-windows',
+  },
+  windows10: {
+    light: 'mdi:microsoft-windows',
+    dark: 'mdi:microsoft-windows',
+  },
+  windows8: {
+    light: 'mdi:microsoft-windows',
+    dark: 'mdi:microsoft-windows',
+  },
+  windows7: {
+    light: 'mdi:microsoft-windows',
+    dark: 'mdi:microsoft-windows',
+  },
   macos: {
     light: 'logos:apple',
     dark: 'simple-icons:apple',
@@ -29,6 +45,10 @@ export type OSType = keyof typeof osIconNamesThemed;
 
 export const osLabels: Record<string, string> = {
   windows: 'Windows',
+  windows11: 'Windows 11',
+  windows10: 'Windows 10',
+  windows8: 'Windows 8',
+  windows7: 'Windows 7',
   macos: 'macOS',
   ios: 'iOS',
   android: 'Android',


### PR DESCRIPTION
Please do let me know if there's a smarter way to go about this, or some better practice.

I created three distinct reusable components for OS, Devices and Browser icons. The icons are fetched through iconify CDN, which means they're not part of our bundle and are fetched on client-side. 

I added fallbacks for icons where mapping is missing or incorrect. We'll have to update in the future as we get more test-data to see which OS/Browsers mappings are missing.

Images for where I placed the icons:
![image](https://github.com/user-attachments/assets/2110856e-4d98-4896-bf57-46f8380ff2bc)
![image](https://github.com/user-attachments/assets/d014ea39-49b8-4eb8-a8c6-60a6e6492339)
![image](https://github.com/user-attachments/assets/1ce00c5d-35c3-4044-99f5-df536d2d9943)

Closes #158 
Closes #155 
Closes #156 
