### PR TITLE
avgTime is now properly handled for pages query where avg duration be…

### DIFF
--- a/dashboard/src/repositories/clickhouse/pages.ts
+++ b/dashboard/src/repositories/clickhouse/pages.ts
@@ -717,7 +717,15 @@ export async function getDailyAverageTimeOnPage(
     })
     .toPromise()) as unknown[];
 
-  return result.map((row) => DailyAverageTimeRowSchema.parse(row));
+  const parsedResult = result.map((row) => {
+    const parsedRow = DailyAverageTimeRowSchema.parse(row);
+    return {
+      ...parsedRow,
+      avgTime: Number(parsedRow.avgTime ?? 0),
+    };
+  });
+
+  return parsedResult;
 }
 
 export async function getDailyBounceRate(


### PR DESCRIPTION
…comes null

I believe the issue is caused by session duration becoming null when it's unable to calculate a duration. Can happen in cases where a page has a single view that bounced, then next_timestamp from Clickhouse leadInFrame does not exist and it will become null.

Closes #221 