### PR TITLE
Created a singleton stripe instance using proxy to avoid having to ca…

### DIFF
--- a/dashboard/src/app/api/webhooks/stripe/route.ts
+++ b/dashboard/src/app/api/webhooks/stripe/route.ts
@@ -9,9 +9,15 @@ import {
   handleSubscriptionUpdated,
 } from '@/services/webhookHandlers';
 import { env } from '@/lib/env';
+import { isFeatureEnabled } from '@/lib/feature-flags';
 
 export async function POST(req: NextRequest) {
   try {
+    if (!isFeatureEnabled('enableBilling')) {
+      console.log('Billing is disabled, ignoring webhook');
+      return NextResponse.json({ message: 'Billing is disabled' }, { status: 200 });
+    }
+
     const body = await req.text();
     const headersList = await headers();
     const stripeSignature = headersList.get('stripe-signature');

--- a/dashboard/src/lib/billing/stripe.ts
+++ b/dashboard/src/lib/billing/stripe.ts
@@ -1,6 +1,34 @@
 import Stripe from 'stripe';
 import { env } from '../env';
+import { isFeatureEnabled } from '../feature-flags';
 
-export const stripe = new Stripe(env.STRIPE_SECRET_KEY, {
-  typescript: true,
+let _stripe: Stripe | null = null;
+
+function createStripeInstance(): Stripe {
+  if (!isFeatureEnabled('enableBilling')) {
+    throw new Error('Billing is disabled');
+  }
+
+  if (!env.STRIPE_SECRET_KEY) {
+    throw new Error('Stripe secret key is not configured');
+  }
+
+  return new Stripe(env.STRIPE_SECRET_KEY, {
+    typescript: true,
+  });
+}
+
+export function getStripe(): Stripe {
+  if (!_stripe) {
+    _stripe = createStripeInstance();
+  }
+  return _stripe;
+}
+
+export const stripe = new Proxy({} as Stripe, {
+  get(_target, prop) {
+    const stripeInstance = getStripe();
+    const value = stripeInstance[prop as keyof Stripe];
+    return typeof value === 'function' ? value.bind(stripeInstance) : value;
+  },
 });

--- a/dashboard/src/lib/env.ts
+++ b/dashboard/src/lib/env.ts
@@ -27,6 +27,11 @@ const envSchema = z.object({
     .optional()
     .default('false')
     .transform((val) => val === 'true'),
+  ENABLE_BILLING: z
+    .enum(['true', 'false'])
+    .optional()
+    .default('false')
+    .transform((val) => val === 'true'),
   NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string().optional().default(''),
   STRIPE_SECRET_KEY: z.string().optional().default(''),
   STRIPE_WEBHOOK_SECRET: z.string().optional().default(''),

--- a/dashboard/src/lib/feature-flags.ts
+++ b/dashboard/src/lib/feature-flags.ts
@@ -8,6 +8,7 @@ export const featureFlags = {
   enableRegistration: env.ENABLE_REGISTRATION,
   enableEmails: env.ENABLE_EMAILS,
   enableEmailPreview: env.ENABLE_MAIL_PREVIEW_PAGE,
+  enableBilling: env.ENABLE_BILLING,
 } as const;
 
 export function isFeatureEnabled(flag: keyof typeof featureFlags): boolean {


### PR DESCRIPTION
…ll getStripe() everywhere

Created a singleton instance of stripe that throws an error upon initialization with incorrect configs instead of blocking HMR. Used a proxy to avoid having to call getStripe() everywhere

Closes #270 