### PR TITLE
Fixed scrolling issue between pages

### DIFF
--- a/dashboard/src/app/dashboard/[dashboardId]/layout.tsx
+++ b/dashboard/src/app/dashboard/[dashboardId]/layout.tsx
@@ -14,6 +14,7 @@ import UsageUpgradeBanner from '@/components/billing/UsageUpgradeBanner';
 import { getUserBillingData } from '@/actions/billing';
 import { Suspense } from 'react';
 import BATopbar from '@/components/topbar/BATopbar';
+import ScrollReset from '@/components/ScrollReset';
 
 type DashboardLayoutProps = {
   params: Promise<{ dashboardId: string }>;
@@ -49,6 +50,7 @@ export default async function DashboardLayout({ children, params }: DashboardLay
           <BASidebar dashboardId={dashboardId} />
           <BAMobileSidebarTrigger />
           <main className='bg-background w-full overflow-x-hidden'>
+            <ScrollReset />
             {billingEnabled && (
               <Suspense fallback={null}>
                 <UsageUpgradeBanner billingDataPromise={getUserBillingData()} />

--- a/dashboard/src/components/ScrollReset.tsx
+++ b/dashboard/src/components/ScrollReset.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+
+/**
+ * There's a known bug that scroll does not reset between pages in Next
+ * https://github.com/vercel/next.js/issues/45187
+ *
+ * This is component implementation is a recommended workaround to that
+ */
+export default function ScrollReset() {
+  const pathname = usePathname();
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
How the bug used to occur: when a user would visit a scrollable page, scroll down, then visit another scrollable page, then the page would already be scrolled down. 

This turns out to be a know bug in NextJS
