### PR TITLE
Fixed unique visitor query

### DIFF
--- a/dashboard/src/lib/ba-query.ts
+++ b/dashboard/src/lib/ba-query.ts
@@ -46,7 +46,7 @@ const granularityIntervalMapper = {
   minute: GranularityIntervalSchema.enum['1 MINUTE'],
 };
 
-const DateColumnSchema = z.enum(['timestamp', 'date']);
+const DateColumnSchema = z.enum(['timestamp', 'date', 'custom_date']);
 
 /**
  * Returns SQL function to be used for granularity.


### PR DESCRIPTION
The query counted the unique visitor within every timestamp, meaning you'd see him appear for every single interval where he was active. He is now counted only once at his initial appearence.

Closes #274 