### PR TITLE
Add ability to delete dashboard

### DIFF
--- a/dashboard/src/app/actions/dashboard.ts
+++ b/dashboard/src/app/actions/dashboard.ts
@@ -3,12 +3,16 @@
 import { Dashboard } from '@/entities/dashboard';
 import { withUserAuth, withDashboardAuthContext } from '@/auth/auth-actions';
 import { createNewDashboard, getAllUserDashboards, getUserDashboardStats } from '@/services/dashboard';
-import { findFirstUserDashboard, findDashboardById } from '@/repositories/postgres/dashboard';
+import { findFirstUserDashboard, findDashboardById, deleteDashboard } from '@/repositories/postgres/dashboard';
 import { User } from 'next-auth';
 import { AuthContext } from '@/entities/authContext';
 
 export const createDashboardAction = withUserAuth(async (user: User, domain: string): Promise<Dashboard> => {
   return createNewDashboard(domain, user.id);
+});
+
+export const deleteDashboardAction = withDashboardAuthContext(async (ctx: AuthContext): Promise<void> => {
+  return deleteDashboard(ctx.dashboardId);
 });
 
 export const getFirstUserDashboardAction = withUserAuth(async (user: User): Promise<Dashboard | null> => {

--- a/dashboard/src/app/dashboard/[dashboardId]/settings/SettingsSection.tsx
+++ b/dashboard/src/app/dashboard/[dashboardId]/settings/SettingsSection.tsx
@@ -10,6 +10,7 @@ import { useDashboardId } from '@/hooks/use-dashboard-id';
 import { updateDashboardSettingsAction } from '@/app/actions/dashboardSettings';
 import { DashboardSettingsUpdate } from '@/entities/dashboardSettings';
 import DataDashboardSettings from '@/components/dashboardSettings/DashboardDataSettings';
+import DangerZoneDashboardSettings from '@/components/dashboardSettings/DashboardDangerZoneSettings';
 
 interface SettingsTabConfig {
   id: string;
@@ -42,6 +43,11 @@ const SETTINGS_TABS: SettingsTabConfig[] = [
     component: AlertDashboardSettings,
   },
   */
+  {
+    id: 'danger',
+    label: 'Danger Zone',
+    component: DangerZoneDashboardSettings,
+  },
 ];
 
 export default function SettingsSection() {

--- a/dashboard/src/app/dashboards/DashboardCard.tsx
+++ b/dashboard/src/app/dashboards/DashboardCard.tsx
@@ -83,7 +83,7 @@ export default function DashboardCard({ dashboard }: DashboardCardProps) {
               </div>
               <span className='text-muted-foreground text-xs'>Created {formattedDate}</span>
             </div>
-            <div className='flex w-8 justify-center' onClick={(e) => e.stopPropagation()}>
+            <div className='flex justify-center' onClick={(e) => e.stopPropagation()}>
               <Link
                 href={`/dashboard/${dashboard.id}/settings`}
                 className='hover:bg-muted inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md p-0 transition-colors'
@@ -93,8 +93,12 @@ export default function DashboardCard({ dashboard }: DashboardCardProps) {
               </Link>
               <AlertDialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
                 <AlertDialogTrigger asChild>
-                  <Button variant='destructive' size='sm' className='ml-2 cursor-pointer' title='Delete Dashboard'>
-                    <Trash2 className='h-4 w-4' />
+                  <Button
+                    variant='link'
+                    className='hover:bg-destructive/10 inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md p-0 transition-colors'
+                    title='Delete Dashboard'
+                  >
+                    <Trash2 className='text-destructive h-4 w-4' />
                   </Button>
                 </AlertDialogTrigger>
                 <AlertDialogContent>

--- a/dashboard/src/app/dashboards/DashboardCard.tsx
+++ b/dashboard/src/app/dashboards/DashboardCard.tsx
@@ -2,9 +2,24 @@
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { startTransition, useState } from 'react';
+import { toast } from 'sonner';
+import { deleteDashboardAction } from '@/app/actions/dashboard';
 import { Dashboard } from '@/entities/dashboard';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { ExternalLink, Globe, Calendar, Settings } from 'lucide-react';
+import { AlertTriangle, Calendar, ExternalLink, Globe, Settings, Trash2 } from 'lucide-react';
 
 interface DashboardCardProps {
   dashboard: Dashboard;
@@ -12,6 +27,7 @@ interface DashboardCardProps {
 
 export default function DashboardCard({ dashboard }: DashboardCardProps) {
   const router = useRouter();
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   const formattedDate = dashboard.createdAt
     ? new Date(dashboard.createdAt).toLocaleDateString(undefined, {
@@ -23,6 +39,19 @@ export default function DashboardCard({ dashboard }: DashboardCardProps) {
 
   const handleCardClick = () => {
     router.push(`/dashboard/${dashboard.id}`);
+  };
+
+  const handleDeleteDashboard = async () => {
+    startTransition(async () => {
+      try {
+        await deleteDashboardAction(dashboard.id);
+        toast.success('Dashboard deleted successfully');
+        router.refresh();
+      } catch (error) {
+        console.error('Failed to delete dashboard:', error);
+        toast.error('Failed to delete dashboard. Please try again.');
+      }
+    });
   };
 
   return (
@@ -54,15 +83,42 @@ export default function DashboardCard({ dashboard }: DashboardCardProps) {
               </div>
               <span className='text-muted-foreground text-xs'>Created {formattedDate}</span>
             </div>
-            <div className='flex w-8 justify-center'>
+            <div className='flex w-8 justify-center' onClick={(e) => e.stopPropagation()}>
               <Link
                 href={`/dashboard/${dashboard.id}/settings`}
                 className='hover:bg-muted inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md p-0 transition-colors'
                 title='Dashboard Settings'
-                onClick={(e) => e.stopPropagation()}
               >
                 <Settings className='text-muted-foreground h-4 w-4' />
               </Link>
+              <AlertDialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+                <AlertDialogTrigger asChild>
+                  <Button variant='destructive' size='sm' className='ml-2 cursor-pointer' title='Delete Dashboard'>
+                    <Trash2 className='h-4 w-4' />
+                  </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle className='flex items-center gap-2'>
+                      <AlertTriangle className='text-destructive h-5 w-5' />
+                      Delete Dashboard
+                    </AlertDialogTitle>
+                    <AlertDialogDescription>
+                      Are you sure you want to delete "{dashboard.domain}"? This action cannot be undone.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                    <AlertDialogAction
+                      onClick={handleDeleteDashboard}
+                      className='bg-destructive text-destructive-foreground hover:bg-destructive/90'
+                    >
+                      <Trash2 className='mr-2 h-4 w-4' />
+                      Delete Dashboard
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
             </div>
           </div>
         </CardContent>

--- a/dashboard/src/app/dashboards/DashboardCard.tsx
+++ b/dashboard/src/app/dashboards/DashboardCard.tsx
@@ -2,24 +2,9 @@
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { startTransition, useState } from 'react';
-import { toast } from 'sonner';
-import { deleteDashboardAction } from '@/app/actions/dashboard';
 import { Dashboard } from '@/entities/dashboard';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/alert-dialog';
-import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { AlertTriangle, Calendar, ExternalLink, Globe, Settings, Trash2 } from 'lucide-react';
+import { ExternalLink, Globe, Calendar, Settings } from 'lucide-react';
 
 interface DashboardCardProps {
   dashboard: Dashboard;
@@ -27,7 +12,6 @@ interface DashboardCardProps {
 
 export default function DashboardCard({ dashboard }: DashboardCardProps) {
   const router = useRouter();
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   const formattedDate = dashboard.createdAt
     ? new Date(dashboard.createdAt).toLocaleDateString(undefined, {
@@ -39,19 +23,6 @@ export default function DashboardCard({ dashboard }: DashboardCardProps) {
 
   const handleCardClick = () => {
     router.push(`/dashboard/${dashboard.id}`);
-  };
-
-  const handleDeleteDashboard = async () => {
-    startTransition(async () => {
-      try {
-        await deleteDashboardAction(dashboard.id);
-        toast.success('Dashboard deleted successfully');
-        router.refresh();
-      } catch (error) {
-        console.error('Failed to delete dashboard:', error);
-        toast.error('Failed to delete dashboard. Please try again.');
-      }
-    });
   };
 
   return (
@@ -83,46 +54,15 @@ export default function DashboardCard({ dashboard }: DashboardCardProps) {
               </div>
               <span className='text-muted-foreground text-xs'>Created {formattedDate}</span>
             </div>
-            <div className='flex justify-center' onClick={(e) => e.stopPropagation()}>
+            <div className='flex w-8 justify-center'>
               <Link
                 href={`/dashboard/${dashboard.id}/settings`}
                 className='hover:bg-muted inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md p-0 transition-colors'
                 title='Dashboard Settings'
+                onClick={(e) => e.stopPropagation()}
               >
                 <Settings className='text-muted-foreground h-4 w-4' />
               </Link>
-              <AlertDialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
-                <AlertDialogTrigger asChild>
-                  <Button
-                    variant='link'
-                    className='hover:bg-destructive/10 inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md p-0 transition-colors'
-                    title='Delete Dashboard'
-                  >
-                    <Trash2 className='text-destructive h-4 w-4' />
-                  </Button>
-                </AlertDialogTrigger>
-                <AlertDialogContent>
-                  <AlertDialogHeader>
-                    <AlertDialogTitle className='flex items-center gap-2'>
-                      <AlertTriangle className='text-destructive h-5 w-5' />
-                      Delete Dashboard
-                    </AlertDialogTitle>
-                    <AlertDialogDescription>
-                      Are you sure you want to delete "{dashboard.domain}"? This action cannot be undone.
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-                  <AlertDialogFooter>
-                    <AlertDialogCancel>Cancel</AlertDialogCancel>
-                    <AlertDialogAction
-                      onClick={handleDeleteDashboard}
-                      className='bg-destructive text-destructive-foreground hover:bg-destructive/90'
-                    >
-                      <Trash2 className='mr-2 h-4 w-4' />
-                      Delete Dashboard
-                    </AlertDialogAction>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
             </div>
           </div>
         </CardContent>

--- a/dashboard/src/components/dashboardSettings/DashboardDangerZoneSettings.tsx
+++ b/dashboard/src/components/dashboardSettings/DashboardDangerZoneSettings.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { deleteDashboardAction } from '@/app/actions';
+import SettingsCard from '@/components/SettingsCard';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import { DashboardSettingsUpdate } from '@/entities/dashboardSettings';
+import { useDashboardId } from '@/hooks/use-dashboard-id';
+import { AlertTriangle, Trash2 } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { startTransition, useState } from 'react';
+import { toast } from 'sonner';
+
+type DangerZoneSettingsProps = {
+  formData: DashboardSettingsUpdate;
+  onUpdate: (updates: Partial<DashboardSettingsUpdate>) => void;
+};
+
+export default function DangerZoneSettings({}: DangerZoneSettingsProps) {
+  const dashboardId = useDashboardId();
+  const router = useRouter();
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  const handleDeleteDashboard = async () => {
+    startTransition(async () => {
+      try {
+        await deleteDashboardAction(dashboardId);
+        toast.success('Dashboard deleted successfully');
+        router.push('/dashboards');
+      } catch (error) {
+        console.error('Failed to delete dashboard:', error);
+        toast.error('Failed to delete dashboard. Please try again.');
+      }
+    });
+  };
+
+  return (
+    <SettingsCard icon={Trash2} title='Delete Dashboard' description={'Permanently delete dashboard'}>
+      <div className='space-y-4'>
+        <div className='border-destructive/20 bg-destructive/5 flex items-start gap-3 rounded-lg border p-4'>
+          <AlertTriangle className='text-destructive h-5 w-5 flex-shrink-0' />
+          <div className='text-sm'>
+            <p className='text-destructive font-medium'>Warning: This action cannot be undone</p>
+          </div>
+        </div>
+
+        <AlertDialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+          <AlertDialogTrigger asChild>
+            <Button variant='destructive' className='w-full sm:w-auto'>
+              <Trash2 className='h-4 w-4' />
+              Delete Dashboard
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle className='flex items-center gap-2'>
+                <AlertTriangle className='text-destructive h-5 w-5' />
+                Delete Dashboard
+              </AlertDialogTitle>
+              <AlertDialogDescription>
+                Are you sure you want to delete this dashboard? This action cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={handleDeleteDashboard}
+                className='bg-destructive text-destructive-foreground hover:bg-destructive/90'
+              >
+                <Trash2 className='mr-2 h-4 w-4' />
+                Delete Dashboard
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </div>
+    </SettingsCard>
+  );
+}

--- a/dashboard/src/repositories/postgres/dashboard.ts
+++ b/dashboard/src/repositories/postgres/dashboard.ts
@@ -138,3 +138,14 @@ export async function getUserSiteIds(userId: string): Promise<string[]> {
     return [];
   }
 }
+
+export async function deleteDashboard(dashboardId: string): Promise<void> {
+  try {
+    await prisma.dashboard.delete({
+      where: { id: dashboardId },
+    });
+  } catch (error) {
+    console.error(`Error deleting dashboard ${dashboardId}:`, error);
+    throw new Error(`Failed to delete dashboard ${dashboardId}.`);
+  }
+}


### PR DESCRIPTION
## Description

Add the ability to delete a dashboard ~via 2 methods~:
~1. On the dashboards page, using the newly added trash icon in the `DashboardCard`~
2. On the dashboard's advanced settings page, in the newly added "Danger Zone" section in `SettingsSection`

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Style/UI changes

## Testing

- [x] Tests pass locally
- [ ] Added new tests
- [x] Manual testing completed
- [ ] Performance impact assessed

## Screenshots (if applicable)

### ~Method 1: Dashboards page~
~https://github.com/user-attachments/assets/caa5fbd5-6289-4576-8aa3-7dc2661f3d41~

### Method 2: Dashboard Advanced Settings
https://github.com/user-attachments/assets/32cc4451-a5de-4b92-a603-d55f1fd15d3f