### PR TITLE
Fix permission issues for first time users

### DIFF
--- a/clickhouse-config/Dockerfile
+++ b/clickhouse-config/Dockerfile
@@ -1,0 +1,10 @@
+FROM clickhouse/clickhouse-server:latest
+
+# Copy the initialization scripts
+COPY setup/ /docker-entrypoint-initdb.d/
+
+# Make all shell scripts executable
+RUN chmod +x /docker-entrypoint-initdb.d/*.sh
+
+# Set the correct user (same as base image)
+USER 101:101

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,9 @@ services:
       - 3006:80
 
   clickhouse:
-    image: clickhouse/clickhouse-server:latest
+    build:
+      context: ./clickhouse-config
+      dockerfile: Dockerfile
     user: 101:101
     ports:
       - "0.0.0.0:8123:8123" # HTTP interface - access /play for testing
@@ -25,11 +27,24 @@ services:
       - clickhouse_users:/etc/clickhouse-server/users.d/
       - ./clickhouse-logs:/var/log/clickhouse-server/
       - ./clickhouse-config/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
-      - ./clickhouse-config/setup/:/docker-entrypoint-initdb.d/
     ulimits:
       nofile:
         soft: 262144
         hard: 262144
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:8123/ping",
+        ]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 30s
 
   postgres:
     image: postgres:latest

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "docs": "pnpm --filter docs dev",
     "build": "pnpm --filter dashboard build",
     "start": "pnpm --filter dashboard start",
-    "compose": "docker compose up -d && pnpm run migrate && pnpm run generate",
+    "compose": "docker compose up -d --wait && pnpm run migrate && pnpm run generate",
     "compose-down": "docker compose down",
     "migrate": "pnpm run migrate-dashboard && pnpm run migrate-clickhouse",
     "migrate-dashboard": "pnpm --filter dashboard migrate",


### PR DESCRIPTION
## Changes

- [x] Fix an issue with where this file `clickhouse-config/setup/init-users.sh` would not have sufficient permissions to be actually run after the git clone causing missing users in the seeding of the db.

This `CLICKHOUSE_BACKEND_USER` was not initialized.
This `CLICKHOUSE_DASHBOARD_USER` was not initialized properly.

The clean fix is not to force a chmod on the user, but do it through a dockerfile `clickhouse-config/Dockerfile`

- [x] Fixes an issue where we would try to apply the migrations without waiting on clickhouse to be live. They expose a `/ping` endpoint that we can use for that


<img width="1664" alt="image" src="https://github.com/user-attachments/assets/d845d741-2129-4e1c-b555-2d6220a76025" />

<img width="1175" alt="image" src="https://github.com/user-attachments/assets/cd8a0b74-fc6a-49c8-bef8-6544a4fc41b8" />
