### PR TITLE
22 add rate limiting to server endpoints

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -61,7 +61,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -194,11 +194,13 @@ dependencies = [
  "tokio",
  "tower",
  "tower-http",
+ "tower_governor",
  "tracing",
  "tracing-subscriber",
  "uaparser",
  "url",
  "uuid",
+ "validator",
 ]
 
 [[package]]
@@ -312,7 +314,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -444,6 +446,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,7 +469,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -474,7 +490,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -582,6 +598,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "forwarded-header-value"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
+dependencies = [
+ "nonempty",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,7 +663,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -651,6 +677,12 @@ name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -712,9 +744,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -722,6 +756,29 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "governor"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be93b4ec2e4710b04d9264c0c7350cdd62a8c20e5e4ac732552ebb8f0debe8eb"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "getrandom 0.3.3",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand 0.9.1",
+ "smallvec",
+ "spinning_top",
+ "web-time",
+]
 
 [[package]]
 name = "h2"
@@ -1015,6 +1072,16 @@ dependencies = [
 
 [[package]]
 name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
@@ -1033,6 +1100,12 @@ dependencies = [
  "icu_normalizer",
  "icu_properties",
 ]
+
+[[package]]
+name = "if_chain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
 
 [[package]]
 name = "indexmap"
@@ -1288,7 +1361,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
 dependencies = [
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1307,6 +1380,24 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
+name = "nonempty"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "ntapi"
@@ -1393,7 +1484,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1496,7 +1587,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1507,6 +1598,26 @@ checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
 dependencies = [
  "pest",
  "sha2",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1549,6 +1660,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -1632,8 +1767,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1643,7 +1788,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1653,6 +1808,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -1916,7 +2080,7 @@ checksum = "22f968c5ea23d555e670b449c1c5e7b2fc399fdaec1d304a17cd48e288abc107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1965,7 +2129,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1976,7 +2140,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2009,7 +2173,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2104,6 +2268,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2131,7 +2304,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2139,6 +2312,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -2168,7 +2352,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2262,7 +2446,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2273,7 +2457,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2305,6 +2489,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2332,7 +2531,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2459,6 +2658,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
+name = "tower_governor"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84e6672c7510df74859726427edea641674dad1aeeb30057b87335b1ba23b843"
+dependencies = [
+ "axum",
+ "forwarded-header-value",
+ "governor",
+ "http",
+ "pin-project",
+ "thiserror 2.0.12",
+ "tower",
+ "tracing",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2478,7 +2693,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2559,10 +2774,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -2589,7 +2819,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 1.0.3",
  "percent-encoding",
 ]
 
@@ -2608,6 +2838,48 @@ dependencies = [
  "getrandom 0.3.3",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "validator"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b92f40481c04ff1f4f61f304d61793c7b56ff76ac1469f1beb199b1445b253bd"
+dependencies = [
+ "idna 0.4.0",
+ "lazy_static",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
+ "validator_derive",
+]
+
+[[package]]
+name = "validator_derive"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc44ca3088bb3ba384d9aecf40c6a23a676ce23e09bdaca2073d99c207f864af"
+dependencies = [
+ "if_chain",
+ "lazy_static",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 1.0.109",
+ "validator_types",
+]
+
+[[package]]
+name = "validator_types"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "111abfe30072511849c5910134e8baf8dc05de4c0e5903d681cbd5c9c4d611e3"
+dependencies = [
+ "proc-macro2",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2674,7 +2946,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
  "wasm-bindgen-shared",
 ]
 
@@ -2709,7 +2981,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2741,6 +3013,16 @@ name = "web-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2822,7 +3104,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2833,7 +3115,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3110,7 +3392,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
  "synstructure",
 ]
 
@@ -3131,7 +3413,7 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3151,7 +3433,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
  "synstructure",
 ]
 
@@ -3191,5 +3473,5 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -64,3 +64,7 @@ strum = "0.27.1"
 # Prometheus metrics  
 prometheus = "0.14.0"
 sysinfo = "0.35.2"
+
+# Validation and Rate Limiting
+validator = { version = "0.16", features = ["derive"] }
+tower_governor = "0.7.0"

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -4,7 +4,8 @@ use axum::{
 use std::sync::Arc;
 use std::{net::SocketAddr, net::IpAddr, str::FromStr};
 use tower_http::cors::CorsLayer;
-use tracing::{info, error};
+use tower_governor::{governor::GovernorConfigBuilder, GovernorLayer};
+use tracing::{info, error, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 mod config;
@@ -19,6 +20,7 @@ mod referrer;
 mod campaign;
 mod ua_parser;
 mod metrics;
+mod validation;
 
 use analytics::{AnalyticsEvent, RawTrackingEvent, generate_site_id};
 use db::{Database, SharedDatabase};
@@ -26,6 +28,7 @@ use processing::EventProcessor;
 use geoip::GeoIpService;
 use geoip_updater::GeoIpUpdater;
 use metrics::MetricsCollector;
+use validation::{EventValidator, ValidationConfig};
 
 #[tokio::main]
 async fn main() {
@@ -56,6 +59,9 @@ async fn main() {
 
     let _updater_handle = tokio::spawn(Arc::clone(&updater).run());
 
+    let validation_config = ValidationConfig::default();
+    let validator = Arc::new(EventValidator::new(validation_config));
+
     let db = Database::new(config.clone()).await.expect("Failed to initialize database");
     db.validate_schema().await.expect("Invalid database schema");
     let db = Arc::new(db);
@@ -83,12 +89,24 @@ async fn main() {
         }
     });
 
+    let rate_limit_config = Arc::new(
+        GovernorConfigBuilder::default()
+            .per_second(10)      // 10 requests per second per IP
+            .burst_size(30)      // Allow burst of 30 requests per IP
+            .finish()
+            .unwrap(),
+    );
+
     let app = Router::new()
         .route("/health", get(health_check))
         .route("/track", post(track_event))
         .route("/site-id", get(generate_site_id_handler))
         .route("/metrics", get(metrics_handler))
-        .with_state((db, processor, metrics_collector))
+        .fallback(fallback_handler)
+        .with_state((db, processor, metrics_collector, validator))
+        .layer(GovernorLayer {
+            config: rate_limit_config,
+        })
         .layer(CorsLayer::permissive());
 
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
@@ -97,7 +115,7 @@ async fn main() {
 }
 
 async fn health_check(
-    State((db, _, _)): State<(SharedDatabase, Arc<EventProcessor>, Option<Arc<MetricsCollector>>)>,
+    State((db, _, _, _)): State<(SharedDatabase, Arc<EventProcessor>, Option<Arc<MetricsCollector>>, Arc<EventValidator>)>,
 ) -> Result<impl IntoResponse, String> {
     match db.check_connection().await {
         Ok(_) => Ok(Json(serde_json::json!({
@@ -112,26 +130,34 @@ async fn health_check(
 }
 
 async fn track_event(
-    State((_db, processor, metrics)): State<(SharedDatabase, Arc<EventProcessor>, Option<Arc<MetricsCollector>>)>,
+    State((_db, processor, metrics, validator)): State<(SharedDatabase, Arc<EventProcessor>, Option<Arc<MetricsCollector>>, Arc<EventValidator>)>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
     Json(raw_event): Json<RawTrackingEvent>,
 ) -> Result<StatusCode, (StatusCode, String)> {
-    if raw_event.site_id.is_empty() {
-        return Err((StatusCode::BAD_REQUEST, "site_id is required".to_string()));
-    }
-    if raw_event.url.is_empty() {
-        return Err((StatusCode::BAD_REQUEST, "url is required".to_string()));
-    }
-    if raw_event.event_name.is_empty() {
-        return Err((StatusCode::BAD_REQUEST, "event name is required".to_string()));
-    }
-
-    let event = AnalyticsEvent::new(raw_event, parse_ip(headers).unwrap_or(addr.ip()).to_string());
-
     let start_time = std::time::Instant::now();
+    
+    let ip_address = parse_ip(headers).unwrap_or(addr.ip()).to_string();
+    
+    // Validate and sanitize event
+    let validated_event = match validator.validate_event(raw_event, ip_address.clone()).await {
+        Ok(validated) => validated,
+        Err(e) => {
+            warn!("Event validation failed: {}", e);
+            
+            let status = match &e {
+                validation::ValidationError::PayloadTooLarge(_) => StatusCode::PAYLOAD_TOO_LARGE,
+                _ => StatusCode::BAD_REQUEST,
+            };
+            
+            return Err((status, e.to_string()));
+        }
+    };
+
+    let event = AnalyticsEvent::new(validated_event.raw, validated_event.ip_address);
+
     if let Err(e) = processor.process_event(event).await {
-        error!("Failed to process event: {}", e);
+        error!("Failed to process validated event: {}", e);
         return Ok(StatusCode::OK);
     }
     
@@ -145,7 +171,7 @@ async fn track_event(
 }
 
 async fn metrics_handler(
-    State((_, _, metrics)): State<(SharedDatabase, Arc<EventProcessor>, Option<Arc<MetricsCollector>>)>,
+    State((_, _, metrics, _)): State<(SharedDatabase, Arc<EventProcessor>, Option<Arc<MetricsCollector>>, Arc<EventValidator>)>,
 ) -> impl IntoResponse {
     match metrics {
         Some(metrics_collector) => {
@@ -159,6 +185,11 @@ async fn metrics_handler(
         }
         None => (StatusCode::NOT_FOUND, "Metrics disabled".to_string())
     }
+}
+
+async fn fallback_handler() -> impl IntoResponse {
+    warn!("Request to unknown route");
+    (StatusCode::NOT_FOUND, "Not found")
 }
 
 pub fn parse_ip(headers: HeaderMap) -> Result<IpAddr, ()> {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,5 +1,5 @@
 use axum::{
-    extract::{ConnectInfo, State}, http::{HeaderMap, StatusCode}, response::IntoResponse, routing::{get, post}, Json, Router
+    extract::{ConnectInfo, State}, http::{HeaderMap, StatusCode, Request}, response::IntoResponse, routing::{get, post}, Json, Router, middleware
 };
 use std::sync::Arc;
 use std::{net::SocketAddr, net::IpAddr, str::FromStr};
@@ -103,10 +103,16 @@ async fn main() {
         .route("/site-id", get(generate_site_id_handler))
         .route("/metrics", get(metrics_handler))
         .fallback(fallback_handler)
+        .layer(tower::ServiceBuilder::new()
+            .layer(middleware::from_fn_with_state(
+                metrics_collector.clone(),
+                rate_limit_metrics_middleware
+            ))
+            .layer(GovernorLayer {
+                config: rate_limit_config,
+            })
+        )
         .with_state((db, processor, metrics_collector, validator))
-        .layer(GovernorLayer {
-            config: rate_limit_config,
-        })
         .layer(CorsLayer::permissive());
 
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
@@ -139,10 +145,16 @@ async fn track_event(
     
     let ip_address = parse_ip(headers).unwrap_or(addr.ip()).to_string();
     
+    let validation_start = std::time::Instant::now();
+
     // Validate and sanitize event
     let validated_event = match validator.validate_event(raw_event, ip_address.clone()).await {
         Ok(validated) => validated,
         Err(e) => {
+            if let Some(metrics_collector) = &metrics {
+                metrics_collector.increment_events_rejected(&validator.get_rejection_reason(&e));
+            }
+            
             warn!("Event validation failed: {}", e);
             
             let status = match &e {
@@ -153,6 +165,10 @@ async fn track_event(
             return Err((status, e.to_string()));
         }
     };
+    
+    if let Some(metrics_collector) = &metrics {
+        metrics_collector.record_validation_duration(validation_start.elapsed());
+    }
 
     let event = AnalyticsEvent::new(validated_event.raw, validated_event.ip_address);
 
@@ -210,4 +226,21 @@ pub fn parse_ip(headers: HeaderMap) -> Result<IpAddr, ()> {
 /// Temporary endpoint to generate a site ID
 async fn generate_site_id_handler() -> impl IntoResponse {
     Json(generate_site_id())
+}
+
+/// Middleware to track rate limiting metrics
+async fn rate_limit_metrics_middleware(
+    State(metrics): State<Option<Arc<MetricsCollector>>>,
+    request: Request<axum::body::Body>,
+    next: middleware::Next,
+) -> axum::response::Response {
+    let response = next.run(request).await;
+    
+    if response.status() == StatusCode::TOO_MANY_REQUESTS {
+        if let Some(metrics_collector) = metrics {
+            metrics_collector.increment_rate_limit_exceeded();
+        }
+    }
+    
+    response
 }

--- a/backend/src/validation/mod.rs
+++ b/backend/src/validation/mod.rs
@@ -1,0 +1,192 @@
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use std::net::IpAddr;
+use std::str::FromStr;
+use url::Url;
+use crate::analytics::RawTrackingEvent;
+
+#[derive(Debug, Clone)]
+pub struct ValidationConfig {
+    pub max_custom_properties_size: usize,
+    pub max_url_length: usize,
+    pub max_event_name_length: usize,
+    pub max_site_id_length: usize,
+    pub max_user_agent_length: usize,
+    pub max_timestamp_drift_seconds: i64,
+}
+
+impl Default for ValidationConfig {
+    fn default() -> Self {
+        Self {
+            max_custom_properties_size: 10 * 1024,    // 10KB - pretty generous in my opinion
+            max_url_length: 2048,                     // This is a common limit for URLs
+            max_event_name_length: 100,               // Event name is usually short, but we should keep leeway for extra long event names
+            max_site_id_length: 100,                  // Site ID is usually short, but we should keep leeway for extra long domain names
+            max_user_agent_length: 8 * 1024,          // 8192 bytes - same limit that apache uses (https://httpd.apache.org/docs/2.2/mod/core.html#limitrequestfieldsize)
+            max_timestamp_drift_seconds: 300,         // 5 minutes - we should allow for some clock drift to account for packet latency
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ValidationError {
+    #[error("Invalid site ID: {0}")]
+    InvalidSiteId(String),
+    #[error("Invalid URL: {0}")]
+    InvalidUrl(String),
+    #[error("Invalid event name: {0}")]
+    InvalidEventName(String),
+    #[error("Invalid timestamp: {0}")]
+    InvalidTimestamp(String),
+    #[error("Invalid IP address: {0}")]
+    InvalidIpAddress(String),
+    #[error("Invalid user agent: {0}")]
+    InvalidUserAgent(String),
+    #[error("Payload too large: {0}")]
+    PayloadTooLarge(String),
+    #[error("Invalid JSON: {0}")]
+    InvalidJson(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct ValidatedTrackingEvent {
+    pub raw: RawTrackingEvent,
+    pub ip_address: String,
+}
+
+pub struct EventValidator {
+    config: ValidationConfig,
+}
+
+impl EventValidator {
+    pub fn new(config: ValidationConfig) -> Self {
+        Self { config }
+    }
+
+    pub async fn validate_event(
+        &self,
+        raw_event: RawTrackingEvent,
+        ip_address: String,
+    ) -> Result<ValidatedTrackingEvent, ValidationError> {
+        self.validate_required_fields(&raw_event)?;
+        self.validate_payload_sizes(&raw_event)?;
+        self.validate_formats(&raw_event, &ip_address)?;
+
+        // only present for custom events
+        if !raw_event.properties.is_empty() {
+            self.validate_properties_json(&raw_event.properties)?;
+        }
+
+        Ok(ValidatedTrackingEvent {
+            raw: raw_event,
+            ip_address,
+        })
+    }
+
+    /// Validate required fields are not empty and don't contain control characters
+    fn validate_required_fields(&self, raw_event: &RawTrackingEvent) -> Result<(), ValidationError> {
+        if raw_event.site_id.is_empty() {
+            return Err(ValidationError::InvalidSiteId("Site ID cannot be empty".to_string()));
+        }
+        if raw_event.url.is_empty() {
+            return Err(ValidationError::InvalidUrl("URL cannot be empty".to_string()));
+        }
+        if raw_event.event_name.is_empty() {
+            return Err(ValidationError::InvalidEventName("Event name cannot be empty".to_string()));
+        }
+        if raw_event.user_agent.is_empty() {
+            return Err(ValidationError::InvalidUserAgent("User agent cannot be empty".to_string()));
+        }
+
+        if contains_control_characters(&raw_event.site_id) {
+            return Err(ValidationError::InvalidSiteId("Site ID contains invalid control characters".to_string()));
+        }
+        if contains_control_characters(&raw_event.url) {
+            return Err(ValidationError::InvalidUrl("URL contains invalid control characters".to_string()));
+        }
+        if contains_control_characters(&raw_event.event_name) {
+            return Err(ValidationError::InvalidEventName("Event name contains invalid control characters".to_string()));
+        }
+        if contains_control_characters(&raw_event.user_agent) {
+            return Err(ValidationError::InvalidUserAgent("User agent contains invalid control characters".to_string()));
+        }
+        if let Some(ref referrer) = raw_event.referrer {
+            if contains_control_characters(referrer) {
+                return Err(ValidationError::InvalidUrl("Referrer contains invalid control characters".to_string()));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Validate payload sizes to reject excessively large payloads
+    fn validate_payload_sizes(&self, raw_event: &RawTrackingEvent) -> Result<(), ValidationError> {
+        if raw_event.site_id.len() > self.config.max_site_id_length {
+            return Err(ValidationError::InvalidSiteId("Site ID too long".to_string()));
+        }
+        if raw_event.url.len() > self.config.max_url_length {
+            return Err(ValidationError::InvalidUrl("URL too long".to_string()));
+        }
+        if raw_event.event_name.len() > self.config.max_event_name_length {
+            return Err(ValidationError::InvalidEventName("Event name too long".to_string()));
+        }
+        if raw_event.user_agent.len() > self.config.max_user_agent_length {
+            return Err(ValidationError::InvalidUserAgent("User agent too long".to_string()));
+        }
+        if raw_event.properties.len() > self.config.max_custom_properties_size {
+            return Err(ValidationError::PayloadTooLarge("Properties payload too large".to_string()));
+        }
+        Ok(())
+    }
+
+    /// Basic format validation
+    fn validate_formats(&self, raw_event: &RawTrackingEvent, ip_address: &str) -> Result<(), ValidationError> {
+        // Validate URL format
+        if let Err(_) = Url::parse(&raw_event.url) {
+            return Err(ValidationError::InvalidUrl("Invalid URL format".to_string()));
+        }
+
+        // Validate IP address format
+        if IpAddr::from_str(ip_address).is_err() {
+            return Err(ValidationError::InvalidIpAddress("Invalid IP address format".to_string()));
+        }
+
+        // Validate timestamp is reasonable (config allows for some clock drift to account for packet latency)
+        if let Some(event_time) = DateTime::from_timestamp(raw_event.timestamp as i64, 0) {
+            let now = Utc::now();
+            let drift = (event_time - now).num_seconds().abs();
+            if drift > self.config.max_timestamp_drift_seconds {
+                return Err(ValidationError::InvalidTimestamp("Timestamp too far from current time".to_string()));
+            }
+        } else {
+            return Err(ValidationError::InvalidTimestamp("Invalid timestamp".to_string()));
+        }
+
+        Ok(())
+    }
+
+    /// Validate properties JSON structure
+    fn validate_properties_json(&self, properties: &str) -> Result<(), ValidationError> {
+        // For custom properties, we're more lenient with control characters
+        // (allow newlines/tabs in case someone tracks form texts)
+        // but we still disallow and reject dangerous control characters
+        if contains_dangerous_control_characters(properties) {
+            return Err(ValidationError::InvalidJson("Properties contain dangerous control characters".to_string()));
+        }
+
+        match serde_json::from_str::<serde_json::Value>(properties) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(ValidationError::InvalidJson(format!("Invalid JSON: {}", e))),
+        }
+    }
+}
+
+/// Check if a string contains any control characters
+fn contains_control_characters(input: &str) -> bool {
+    input.chars().any(|c| c.is_control())
+}
+
+/// Check if a string contains control characters (excluding newlines and tabs for custom properties)
+fn contains_dangerous_control_characters(input: &str) -> bool {
+    input.chars().any(|c| c.is_control() && c != '\n' && c != '\t')
+}


### PR DESCRIPTION
Implements rate-limit (Up to 30 requests immediately, then 10 requests per second thereafter).

Implements event validation that limits length of properties, validates correct input such as proper IP & URL, existing user agent & event name, JSON-parsable payload for custom events, control characters, timestamps are not older than 5 minutes etc.

Added metric logs and output so that we can monitor reason for reject events, how many exceeds rate limits and the time it takes to validate input.

Example log output for promtail:
2025-07-17T14:15:09.930807Z  WARN betterlytics::validation: Event rejected by validation rejection_reason="invalid_user_agent" site_id=test-md781oez event_name=product-clicked ip_hash=12ca17b49af22894 url_domain=localhost url_path=/dashboard user_agent_prefix= properties_size=23
2025-07-17T14:15:09.930819Z  WARN betterlytics::validation: Event rejected by validation rejection_reason="invalid_user_agent" site_id=test-md781oez event_name=pageview ip_hash=12ca17b49af22894 url_domain=localhost url_path=/dashboard user_agent_prefix= properties_size=2
2025-07-17T14:15:09.930846Z  WARN betterlytics::validation: Event rejected by validation rejection_reason="invalid_user_agent" site_id=test-md781oez event_name=pageview ip_hash=12ca17b49af22894 url_domain=localhost url_path=/dashboard user_agent_prefix= properties_size=2
2025-07-17T14:15:09.930884Z  WARN betterlytics::validation: Event rejected by validation rejection_reason="invalid_user_agent" site_id=test-md781oez event_name=pageview ip_hash=12ca17b49af22894 url_domain=localhost url_path=/dashboard user_agent_prefix= properties_size=2

Closes #22 