### PR TITLE
Resolve overflow issues of buttons in filter

### DIFF
--- a/dashboard/src/components/TimeRangeSelector/TimeRangeSelector.tsx
+++ b/dashboard/src/components/TimeRangeSelector/TimeRangeSelector.tsx
@@ -99,7 +99,7 @@ export function TimeRangeSelector({
           <ChevronDownIcon className={`ml-2 h-4 w-4 shrink-0 opacity-50`} />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className='w-96 space-y-6 p-6' align='end'>
+      <PopoverContent className='w-96 max-w-[calc(100svw-48px)] space-y-6 p-6' align='end'>
         <QuickSelectSection selectedRange={tempState.range} onRangeSelect={handleQuickSelect} />
 
         <GranularitySection

--- a/dashboard/src/components/dashboard/DashboardFilters.tsx
+++ b/dashboard/src/components/dashboard/DashboardFilters.tsx
@@ -11,7 +11,7 @@ interface DashboardFiltersProps {
 export default function DashboardFilters({ showComparison = true }: DashboardFiltersProps) {
   return (
     <div className='space-y-2'>
-      <div className='flex flex-col justify-end gap-x-4 gap-y-1 md:flex-row'>
+      <div className='flex flex-col-reverse justify-end gap-x-4 gap-y-1 md:flex-row'>
         <QueryFiltersSelector />
         <TimeRangeSelector showComparison={showComparison} />
       </div>

--- a/dashboard/src/components/filters/QueryFiltersSelector.tsx
+++ b/dashboard/src/components/filters/QueryFiltersSelector.tsx
@@ -55,7 +55,7 @@ export default function QueryFiltersSelector() {
           <ChevronDownIcon className={`ml-2 h-4 w-4 shrink-0 opacity-50`} />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className='w-[592px] max-w-[90svw] border py-4 shadow-2xl' align='end'>
+      <PopoverContent className='w-[620px] max-w-[calc(100svw-48px)] border py-4 shadow-2xl' align='end'>
         {queryFilters.length > 0 || isFiltersModified ? (
           <div className='space-y-2'>
             <div className='space-y-3'>

--- a/dashboard/src/components/filters/QueryFiltersSelector.tsx
+++ b/dashboard/src/components/filters/QueryFiltersSelector.tsx
@@ -55,7 +55,7 @@ export default function QueryFiltersSelector() {
           <ChevronDownIcon className={`ml-2 h-4 w-4 shrink-0 opacity-50`} />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className='w-[620px] max-w-[90svw] border py-4 shadow-2xl' align='end'>
+      <PopoverContent className='w-[592px] max-w-[90svw] border py-4 shadow-2xl' align='end'>
         {queryFilters.length > 0 || isFiltersModified ? (
           <div className='space-y-2'>
             <div className='space-y-3'>
@@ -74,21 +74,21 @@ export default function QueryFiltersSelector() {
               )}
             </div>
             <Separator />
-            <div className='flex justify-between'>
-              <Button className='h-8 w-28' onClick={addEmptyQueryFilter} variant='outline'>
+            <div className='flex flex-col gap-2 md:flex-row md:items-center md:justify-between'>
+              <Button className='h-8 w-full md:w-28' onClick={addEmptyQueryFilter} variant='outline'>
                 Add filter
               </Button>
-              <div className='flex items-center justify-end gap-3'>
+              <div className='flex w-full justify-between gap-2 md:w-auto md:justify-end md:gap-3'>
                 <Button
-                  className='h-8 w-28'
-                  disabled={isFiltersModified === false}
+                  className='h-8 w-[48%] max-w-[110px]'
+                  disabled={!isFiltersModified}
                   onClick={cancelFilters}
                   variant={isFiltersModified ? 'destructive' : 'ghost'}
                 >
                   Cancel
                 </Button>
                 <Button
-                  className='h-8 w-28'
+                  className='h-8 w-[48%] max-w-[110px]'
                   disabled={isFiltersModified === false}
                   onClick={saveFilters}
                   variant={isFiltersModified ? 'default' : 'ghost'}


### PR DESCRIPTION
Closes #371 

### Changes
* Place filter below the time range selector on smaller screens
* Flex to two rows on smaller screens for filter selector
* Adjust max-w for filter selectors to match width of dashboard padding

### UI Screenshots
<img width="970" height="1707" alt="image" src="https://github.com/user-attachments/assets/ff5c2808-fc92-43ba-898d-e7696e373c9c" />

Still flexes to row with time-filter on right on md or larger
<img width="3107" height="520" alt="image" src="https://github.com/user-attachments/assets/ec801cc4-fe46-41d7-bf60-245e91440321" />

<img width="940" height="1680" alt="image" src="https://github.com/user-attachments/assets/02cc1121-d52c-4177-8f5d-9c83a56137a7" />
