### PR TITLE
Added public action for fetching public environment variables

### DIFF
--- a/dashboard/src/app/actions/environment.ts
+++ b/dashboard/src/app/actions/environment.ts
@@ -1,0 +1,6 @@
+'use server';
+import { getPublicEnvironmentVaraibles } from '@/services/environment.service';
+
+export async function fetchPublicEnvironmentVariablesAction() {
+  return getPublicEnvironmentVaraibles();
+}

--- a/dashboard/src/app/actions/index.ts
+++ b/dashboard/src/app/actions/index.ts
@@ -11,3 +11,4 @@ export * from './referrers';
 export * from './site';
 export * from './userJourney';
 export * from './verification';
+export * from './environment';

--- a/dashboard/src/app/dashboard/[dashboardId]/TrackingScript.tsx
+++ b/dashboard/src/app/dashboard/[dashboardId]/TrackingScript.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { usePublicEnvironmentVariablesContext } from '@/contexts/PublicEnvironmentVariablesContextProvider';
 import { useEffect } from 'react';
 
 type TrackingScriptProps = {
@@ -7,12 +8,15 @@ type TrackingScriptProps = {
 };
 
 export function TrackingScript({ siteId }: TrackingScriptProps) {
+  const { NEXT_PUBLIC_ANALYTICS_BASE_URL, NEXT_PUBLIC_TRACKING_SERVER_ENDPOINT } =
+    usePublicEnvironmentVariablesContext();
+
   useEffect(() => {
     const script = document.createElement('script');
     script.async = true;
-    script.src = `${process.env.NEXT_PUBLIC_ANALYTICS_BASE_URL}/analytics.js`;
+    script.src = `${NEXT_PUBLIC_ANALYTICS_BASE_URL}/analytics.js`;
     script.setAttribute('data-site-id', siteId);
-    script.setAttribute('data-server-url', `${process.env.NEXT_PUBLIC_TRACKING_SERVER_ENDPOINT}/track`);
+    script.setAttribute('data-server-url', `${NEXT_PUBLIC_TRACKING_SERVER_ENDPOINT}/track`);
     script.setAttribute('data-dynamic-urls', '/dashboard/*');
     document.head.appendChild(script);
 
@@ -21,7 +25,7 @@ export function TrackingScript({ siteId }: TrackingScriptProps) {
         document.head.removeChild(script);
       }
     };
-  }, [siteId]);
+  }, [siteId, NEXT_PUBLIC_ANALYTICS_BASE_URL, NEXT_PUBLIC_TRACKING_SERVER_ENDPOINT]);
 
   return null;
 }

--- a/dashboard/src/components/integration/IntegrationSheet.tsx
+++ b/dashboard/src/components/integration/IntegrationSheet.tsx
@@ -15,6 +15,7 @@ import { fetchSiteId } from '@/app/actions';
 import { useTrackingVerification } from '@/hooks/use-tracking-verification';
 import React from 'react';
 import { Separator } from '@/components/ui/separator';
+import { usePublicEnvironmentVariablesContext } from '@/contexts/PublicEnvironmentVariablesContextProvider';
 
 interface IntegrationSheetProps {
   open: boolean;
@@ -35,6 +36,9 @@ export function IntegrationSheet({ open, onOpenChange }: IntegrationSheetProps) 
     dataReceiving: false,
   });
 
+  const { NEXT_PUBLIC_ANALYTICS_BASE_URL, NEXT_PUBLIC_TRACKING_SERVER_ENDPOINT } =
+    usePublicEnvironmentVariablesContext();
+
   const dashboardId = useDashboardId();
   const { isVerifying, isVerified, verify } = useTrackingVerification();
 
@@ -51,7 +55,7 @@ export function IntegrationSheet({ open, onOpenChange }: IntegrationSheetProps) 
   }, [isVerified]);
 
   const trackingScript = siteId
-    ? `<script async src="${process.env.NEXT_PUBLIC_ANALYTICS_BASE_URL}/analytics.js" data-site-id="${siteId}" data-server-url="${process.env.NEXT_PUBLIC_TRACKING_SERVER_ENDPOINT}/track"></script>`
+    ? `<script async src="${NEXT_PUBLIC_ANALYTICS_BASE_URL}/analytics.js" data-site-id="${siteId}" data-server-url="${NEXT_PUBLIC_TRACKING_SERVER_ENDPOINT}/track"></script>`
     : '';
 
   const handleVerifyInstallation = async () => {
@@ -96,9 +100,9 @@ export default function RootLayout({
       <head>
         <Script
           async
-          src="${process.env.NEXT_PUBLIC_ANALYTICS_BASE_URL}/analytics.js"
+          src="${NEXT_PUBLIC_ANALYTICS_BASE_URL}/analytics.js"
           data-site-id="${siteId}"
-          data-server-url="${process.env.NEXT_PUBLIC_TRACKING_SERVER_ENDPOINT}/track"
+          data-server-url="${NEXT_PUBLIC_TRACKING_SERVER_ENDPOINT}/track"
         />
       </head>
       <body>{children}</body>
@@ -112,9 +116,9 @@ function App() {
   useEffect(() => {
     const script = document.createElement('script');
     script.async = true;
-    script.src = "${process.env.NEXT_PUBLIC_ANALYTICS_BASE_URL}/analytics.js";
+    script.src = "${NEXT_PUBLIC_ANALYTICS_BASE_URL}/analytics.js";
     script.setAttribute('data-site-id', "${siteId}");
-    script.setAttribute('data-server-url', "${process.env.NEXT_PUBLIC_TRACKING_SERVER_ENDPOINT}/track")
+    script.setAttribute('data-server-url', "${NEXT_PUBLIC_TRACKING_SERVER_ENDPOINT}/track")
     document.head.appendChild(script);
 
     return () => {

--- a/dashboard/src/contexts/PublicEnvironmentVariablesContextProvider.tsx
+++ b/dashboard/src/contexts/PublicEnvironmentVariablesContextProvider.tsx
@@ -1,0 +1,36 @@
+'use client';
+import React from 'react';
+import type { fetchPublicEnvironmentVariablesAction } from '@/app/actions/environment';
+
+type PublicEnvironmentVariablesContextProps = {
+  publicEnvironmentVariables: Awaited<ReturnType<typeof fetchPublicEnvironmentVariablesAction>>;
+};
+
+const PublicEnvironmentVariablesContext = React.createContext<PublicEnvironmentVariablesContextProps>(
+  {} as PublicEnvironmentVariablesContextProps,
+);
+
+type PublicEnvironmentVariablesProviderProps = {
+  children: React.ReactNode;
+  publicEnvironmentVariables: Awaited<ReturnType<typeof fetchPublicEnvironmentVariablesAction>>;
+};
+
+export function PublicEnvironmentVariablesProvider({
+  children,
+  publicEnvironmentVariables,
+}: PublicEnvironmentVariablesProviderProps) {
+  return (
+    <PublicEnvironmentVariablesContext.Provider value={{ publicEnvironmentVariables }}>
+      {children}
+    </PublicEnvironmentVariablesContext.Provider>
+  );
+}
+
+export function usePublicEnvironmentVariablesContext() {
+  const context = React.useContext(PublicEnvironmentVariablesContext);
+  if (!context) {
+    throw new Error('usePublicEnvironmentVariablesContext must be used within PublicEnvironmentVariablesProvider');
+  }
+
+  return context.publicEnvironmentVariables;
+}

--- a/dashboard/src/services/environment.service.ts
+++ b/dashboard/src/services/environment.service.ts
@@ -1,0 +1,26 @@
+'server only';
+import { env } from '@/lib/env';
+
+export const PUBLIC_ENVIRONMENT_VARIABLES_KEYS = [
+  'NEXT_PUBLIC_TRACKING_SERVER_ENDPOINT',
+  'NEXT_PUBLIC_ANALYTICS_BASE_URL',
+  'NEXT_PUBLIC_BASE_URL',
+  'NEXT_PUBLIC_IS_CLOUD',
+  'NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY',
+] as const;
+
+type PublicEnvironmentVariableKeys = (typeof PUBLIC_ENVIRONMENT_VARIABLES_KEYS)[number];
+
+export type PublicEnvironmentVariables = {
+  [K in PublicEnvironmentVariableKeys]: (typeof env)[K];
+};
+
+export function getPublicEnvironmentVaraibles() {
+  return PUBLIC_ENVIRONMENT_VARIABLES_KEYS.reduce(
+    (vars, key) => ({
+      ...vars,
+      [key]: env[key],
+    }),
+    {} as PublicEnvironmentVariables,
+  );
+}


### PR DESCRIPTION
Closes #396 

Instead of now using `process.env.NEXT_PUBLIC_*` for accessing public environment variables, they are now accessible though a context. The environment variables are fetched from the backend to ensure that the variables wont get baked into the source code on build time.