### PR TITLE
Style adjustments for Flag icons, LeafletMap tooltips and LeafletMap legend

### DIFF
--- a/dashboard/src/app/(landing)/components/featureCards/worldMapCard.tsx
+++ b/dashboard/src/app/(landing)/components/featureCards/worldMapCard.tsx
@@ -5,7 +5,7 @@ import { MOCK_WORLD_GEOVISITORS } from '@/constants/geographyData';
 import { GeoVisitor } from '@/entities/geography';
 
 const CountryRow = ({ geoVisitor }: { geoVisitor: GeoVisitor }) => (
-  <div className='text-xxs flex px-1.5 py-2' key={geoVisitor.country_code}>
+  <div className='flex px-1.5 py-2 text-xs' key={geoVisitor.country_code}>
     <div className='flex items-center gap-0.75'>
       <FlagIcon countryCode={geoVisitor.country_code as FlagIconProps['countryCode']} />
       <span className='font-medium'>{geoVisitor.country_code}</span>

--- a/dashboard/src/app/(landing)/components/featureCards/worldMapCard.tsx
+++ b/dashboard/src/app/(landing)/components/featureCards/worldMapCard.tsx
@@ -4,7 +4,7 @@ import { FlagIcon, FlagIconProps } from '@/components/icons';
 import { MOCK_WORLD_GEOVISITORS } from '@/constants/geographyData';
 import { GeoVisitor } from '@/entities/geography';
 
-const CountryRow = ({ geoVisitor }: { geoVisitor: GeoVisitor }) => (
+const CountryCol = ({ geoVisitor }: { geoVisitor: GeoVisitor }) => (
   <div className='flex py-2 text-xs' key={geoVisitor.country_code}>
     <div className='flex items-center gap-0.75'>
       <FlagIcon countryCode={geoVisitor.country_code as FlagIconProps['countryCode']} />
@@ -38,9 +38,9 @@ export default function WorldMapCard() {
         <div className='border-border/60 border-t pt-3'>
           <div className='flex items-center justify-between text-xs'>
             <span className='text-muted-foreground'>Top Countries</span>
-            <div className='grid auto-cols-[70px] grid-flow-col justify-end overflow-hidden'>
+            <div className='grid auto-cols-[70px] grid-flow-col justify-end gap-1 overflow-hidden'>
               {Array.from({ length: 2 }).map((_, i) => (
-                <CountryRow key={MOCK_WORLD_GEOVISITORS[i].country_code} geoVisitor={MOCK_WORLD_GEOVISITORS[i]} />
+                <CountryCol key={MOCK_WORLD_GEOVISITORS[i].country_code} geoVisitor={MOCK_WORLD_GEOVISITORS[i]} />
               ))}
             </div>
           </div>

--- a/dashboard/src/app/(landing)/components/featureCards/worldMapCard.tsx
+++ b/dashboard/src/app/(landing)/components/featureCards/worldMapCard.tsx
@@ -5,7 +5,7 @@ import { MOCK_WORLD_GEOVISITORS } from '@/constants/geographyData';
 import { GeoVisitor } from '@/entities/geography';
 
 const CountryRow = ({ geoVisitor }: { geoVisitor: GeoVisitor }) => (
-  <div className='flex px-1.5 py-2 text-xs' key={geoVisitor.country_code}>
+  <div className='flex py-2 text-xs' key={geoVisitor.country_code}>
     <div className='flex items-center gap-0.75'>
       <FlagIcon countryCode={geoVisitor.country_code as FlagIconProps['countryCode']} />
       <span className='font-medium'>{geoVisitor.country_code}</span>

--- a/dashboard/src/app/dashboard/[dashboardId]/geography/GeographySection.tsx
+++ b/dashboard/src/app/dashboard/[dashboardId]/geography/GeographySection.tsx
@@ -14,7 +14,12 @@ export default function GeographySection({ worldMapPromise }: GeographySectionPr
   return (
     <>
       <div className='h-full w-full'>
-        <LeafletMap visitorData={mapData.visitorData} maxVisitors={mapData.maxVisitors} showZoomControls={true} />
+        <LeafletMap
+          visitorData={mapData.visitorData}
+          maxVisitors={mapData.maxVisitors}
+          showZoomControls={true}
+          size='lg'
+        />
       </div>
 
       {mapData.visitorData.length === 0 && (

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -90,6 +90,8 @@
   --sidebar-accent-foreground: oklch(0.3 0 0);
   --sidebar-border: oklch(93% 0 0);
   --sidebar-ring: oklch(74% 0.118 268.64);
+
+  --flagicon-border: oklch(0.5 0 0 / 0.5);
 }
 
 .dark {
@@ -136,6 +138,8 @@
   --sidebar-accent-foreground: oklch(0.95 0.01 265);
   --sidebar-border: oklch(0.3 0.02 266);
   --sidebar-ring: oklch(50% 0.222 268.78); /* blue-800 */
+
+  --flagicon-border: oklch(0.75 0.02 265 / 0.5); /* Semi-transparent muted border for flag icons */
 }
 
 @layer base {
@@ -171,9 +175,4 @@
 .leaflet-top,
 .leaflet-bottom {
   z-index: 0 !important;
-}
-
-.text-xxs {
-  font-size: 11px;
-  line-height: var(--tw-leading, 11px);
 }

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -139,7 +139,7 @@
   --sidebar-border: oklch(0.3 0.02 266);
   --sidebar-ring: oklch(50% 0.222 268.78); /* blue-800 */
 
-  --flagicon-border: oklch(0.75 0.02 265 / 0.5); /* Semi-transparent muted border for flag icons */
+  --flagicon-border: oklch(0.75 0.02 265 / 0.5);
 }
 
 @layer base {

--- a/dashboard/src/components/LeafletMap.tsx
+++ b/dashboard/src/components/LeafletMap.tsx
@@ -132,13 +132,16 @@ const LeafletMap = ({
     const visitors = visitorEntry ? visitorEntry.visitors.toLocaleString() : '0';
 
     const popupHtml = renderToString(
-      <div className='space-y-1'>
+      <div className='text-foreground space-y-1'>
         <CountryDisplay
           className='font-bold'
           countryCode={featureId as FlagIconProps['countryCode']}
           countryName={getCountryName(featureId)}
         />
-        <div className='text-muted-foreground text-sm'>Visitors: {visitors}</div>
+        <div className='flex gap-1 text-sm text-nowrap'>
+          <div className='text-muted-foreground'>Visitors:</div>
+          <span className='text-foreground'>{visitors}</span>
+        </div>
       </div>,
     );
 
@@ -177,10 +180,15 @@ const LeafletMap = ({
           display: inline-block;
           width: fit-content !important;
         }
+        .leaflet-popup-content-wrapper,
+        .leaflet-popup-tip {
+          background-color: var(--accent);
+          border: 1px solid var(--border);
+        }
         .leaflet-popup-content {
           white-space: normal;
           width: fit-content !important;
-          max-width: 50vw;
+          max-width: 180px;
           min-width: 100px; // Min-width ensure 'Visitors: x' stays on one row
         }
       `}</style>

--- a/dashboard/src/components/LeafletMap.tsx
+++ b/dashboard/src/components/LeafletMap.tsx
@@ -182,8 +182,9 @@ const LeafletMap = ({
         }
         .leaflet-popup-content-wrapper,
         .leaflet-popup-tip {
-          background-color: var(--accent);
-          border: 1px solid var(--border);
+          background-color: var(--card);
+          border: 0.5px solid var(--border);
+          box-shadow: 0 1px 3px var(--color-sidebar-accent-foreground);
         }
         .leaflet-popup-content {
           white-space: normal;

--- a/dashboard/src/components/LeafletMap.tsx
+++ b/dashboard/src/components/LeafletMap.tsx
@@ -184,7 +184,7 @@ const LeafletMap = ({
         .leaflet-popup-tip {
           background-color: var(--card);
           border: 0.5px solid var(--border);
-          box-shadow: 0 1px 3px var(--color-sidebar-accent-foreground);
+          box-shadow: 0 0.5px 2px var(--color-sidebar-accent-foreground);
         }
         .leaflet-popup-content {
           white-space: normal;

--- a/dashboard/src/components/LeafletMap.tsx
+++ b/dashboard/src/components/LeafletMap.tsx
@@ -17,6 +17,7 @@ interface LeafletMapProps {
   showZoomControls?: boolean;
   showLegend?: boolean;
   initialZoom?: number;
+  size?: 'sm' | 'lg';
 }
 
 const geoJsonOptions = {
@@ -41,6 +42,7 @@ const LeafletMap = ({
   maxVisitors,
   showZoomControls,
   showLegend = true,
+  size = 'sm',
   initialZoom,
 }: LeafletMapProps) => {
   const [worldGeoJson, setWorldGeoJson] = useState<GeoJSON.FeatureCollection | null>(null);
@@ -189,7 +191,7 @@ const LeafletMap = ({
         .leaflet-popup-content {
           white-space: normal;
           width: fit-content !important;
-          max-width: 180px;
+          max-width: ${size === 'sm' ? '180px' : '40vw'};
           min-width: 100px; // Min-width ensure 'Visitors: x' stays on one row
         }
       `}</style>

--- a/dashboard/src/components/icons/FlagIcon.tsx
+++ b/dashboard/src/components/icons/FlagIcon.tsx
@@ -17,7 +17,7 @@ function FlagIconComponent({ countryCode, countryName = getCountryName(countryCo
         <HelpCircle
           size='1em'
           style={{
-            color: '#9ca3af',
+            color: 'var(--foreground)',
             height: '1em',
             width: 'fit-content',
           }}

--- a/dashboard/src/components/icons/FlagIcon.tsx
+++ b/dashboard/src/components/icons/FlagIcon.tsx
@@ -18,8 +18,8 @@ function FlagIconComponent({ countryCode, countryName = getCountryName(countryCo
           size='1em'
           style={{
             color: '#9ca3af',
-            height: 'fit-content',
-            width: '1em',
+            height: '1em',
+            width: 'fit-content',
           }}
         />
       </span>
@@ -31,9 +31,9 @@ function FlagIconComponent({ countryCode, countryName = getCountryName(countryCo
       <FlagComponent
         {...props}
         style={{
-          border: 'var(--popover-foreground) solid 0.1px',
-          height: 'fit-content',
-          width: '1em',
+          border: 'var(--flagicon-border) solid 0.5px',
+          height: '1em',
+          width: 'fit-content',
         }}
       />
     </span>

--- a/docs/src/app/globals.css
+++ b/docs/src/app/globals.css
@@ -88,8 +88,6 @@
   --sidebar-accent-foreground: oklch(0.3 0 0);
   --sidebar-border: oklch(93% 0 0);
   --sidebar-ring: oklch(74% 0.118 268.64);
-  
-  --flagicon-border: oklch(0.75 0.02 265 / 0.5); /* Semi-transparent muted border for flag icons */
 }
 
 .dark {
@@ -136,8 +134,6 @@
   --sidebar-accent-foreground: oklch(0.95 0.01 265);
   --sidebar-border: oklch(0.3 0.02 266);
   --sidebar-ring: oklch(50% 0.222 268.78); /* blue-800 */
-
-  --flagicon-border: oklch(0.75 0.02 265 / 0.5);
 }
 
 @layer base {

--- a/docs/src/app/globals.css
+++ b/docs/src/app/globals.css
@@ -88,6 +88,8 @@
   --sidebar-accent-foreground: oklch(0.3 0 0);
   --sidebar-border: oklch(93% 0 0);
   --sidebar-ring: oklch(74% 0.118 268.64);
+  
+  --flagicon-border: oklch(0.75 0.02 265 / 0.5); /* Semi-transparent muted border for flag icons */
 }
 
 .dark {
@@ -134,6 +136,8 @@
   --sidebar-accent-foreground: oklch(0.95 0.01 265);
   --sidebar-border: oklch(0.3 0.02 266);
   --sidebar-ring: oklch(50% 0.222 268.78); /* blue-800 */
+
+  --flagicon-border: oklch(0.75 0.02 265 / 0.5);
 }
 
 @layer base {


### PR DESCRIPTION
Addressing some small style misalignments introduced by my previous PRs. 

### Changes
* The Flag icons are a little bit too small on all devices, and their borders are too thick and overwhelming.
   * Make flag-icons slightly larger
   * Add opacity to flag-borders
   * FlagIcon fallback icon are now colored by the Theme

* Public page's Map's legend-text is too small - xss is simply unreadable, so I have removed it
* Leaflet Map tooltips are wrapping 'Visitors: x' on two lines on some countries for public page
   * I have set max-width of tooltips to a fixed width, as 50vw is simply too large to play nicely if its not fullscreen
* The colors on the Leaflet Map's tooltips now follow the theme (dark, light etc.)

### Screenshots
<img width="487" height="468" alt="image" src="https://github.com/user-attachments/assets/884310e5-3436-4725-be37-ce883ce21124" />

<img width="494" height="469" alt="image" src="https://github.com/user-attachments/assets/042b0e4a-31cb-466f-ac2b-62f2f8a3d6cd" />

<img width="403" height="495" alt="image" src="https://github.com/user-attachments/assets/3e03d772-aab3-48f0-a933-87f698b0cb5b" />
<img width="413" height="493" alt="image" src="https://github.com/user-attachments/assets/6828925a-d888-40cb-8422-07ad907bf9ae" />

<img width="1284" height="949" alt="image" src="https://github.com/user-attachments/assets/df5f45e7-f3aa-4463-b281-9121e4688224" />

<img width="1292" height="971" alt="image" src="https://github.com/user-attachments/assets/6bf65e3d-b9d0-4c98-9bb8-96aaed11b70f" />

<img width="194" height="103" alt="image" src="https://github.com/user-attachments/assets/71d23587-2e70-4ba3-9296-51b132df975e" />
<img width="176" height="100" alt="image" src="https://github.com/user-attachments/assets/6cac2d6c-6fa4-4614-a09b-853003b0cfac" />
