### PR TITLE
Ensure IP is never logged

### DIFF
--- a/backend/src/geoip/mod.rs
+++ b/backend/src/geoip/mod.rs
@@ -121,11 +121,11 @@ impl GeoIpService {
         }
 
         if let Some(cached_result) = self.ip_cache.get(ip_address) {
-            debug!("GeoIP cache hit for IP: {}", ip_address);
+            debug!("GeoIP cache hit");
             return cached_result;
         }
 
-        debug!("GeoIP cache miss for IP: {}", ip_address);
+        debug!("GeoIP cache miss");
 
         self.update_reader_if_changed();
 
@@ -135,7 +135,7 @@ impl GeoIpService {
         let ip: IpAddr = match ip_address.parse() {
             Ok(ip) => ip,
             Err(e) => {
-                warn!("Failed to parse IP address '{}': {}", ip_address, e);
+                warn!("Failed to parse IP address: {}", e);
                 self.ip_cache.insert(ip_address.to_string(), None);
                 return None;
             }
@@ -147,7 +147,7 @@ impl GeoIpService {
                 .and_then(|country_data| country_data.iso_code)
                 .map(|s| s.to_string()),
             Err(e) => {
-                warn!("GeoIP lookup failed for IP {}: {}", ip_address, e);
+                warn!("GeoIP lookup failed: {}", e);
                 None
             }
         };

--- a/backend/src/processing/mod.rs
+++ b/backend/src/processing/mod.rs
@@ -189,7 +189,7 @@ impl EventProcessor {
 
     /// Get geolocation data for the IP
     async fn get_geolocation(&self, processed: &mut ProcessedEvent) -> Result<()> {
-        debug!("Getting geolocation data for IP: {}", processed.event.ip_address);
+        debug!("Performing Geolocation lookup");
         processed.country_code = self.geoip_service.lookup_country_code(&processed.event.ip_address);
         if processed.country_code.is_some() {
             debug!("Geolocation successful: {:?}", processed.country_code);

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -28,6 +28,7 @@ server {
     location = /analytics.js {
         root /usr/share/nginx/html;
         access_log off;
+        error_log /dev/null crit;
     }
 
     location /metrics {
@@ -40,6 +41,9 @@ server {
 
     location /track {        
         limit_req zone=track_zone burst=30 nodelay;
+
+        access_log off;
+        error_log /dev/null crit;
         
         proxy_pass http://backend:3001;
         proxy_set_header Host $host;


### PR DESCRIPTION
Removed any IP prints I could find.

Ensure NGINX doesn't print any output for `/analytics.js` and `/track`.
This seems to be the most transparent/privacy focused approach, from what I could find.