### PR TITLE
Fix country flags on Safari

### DIFF
--- a/dashboard/src/components/icons/FlagIcon.tsx
+++ b/dashboard/src/components/icons/FlagIcon.tsx
@@ -33,7 +33,7 @@ function FlagIconComponent({ countryCode, countryName = getCountryName(countryCo
         style={{
           border: 'var(--flagicon-border) solid 0.5px',
           height: '1em',
-          width: 'fit-content',
+          aspectRatio: '3/2',
         }}
       />
     </span>

--- a/dashboard/src/components/language/CountryDisplay.tsx
+++ b/dashboard/src/components/language/CountryDisplay.tsx
@@ -19,7 +19,7 @@ export const CountryDisplay = ({
       <FlagIcon
         countryCode={countryCode} 
         countryName={countryName}
-        className='flex-shrink-0 w-[1lvw]' 
+        className='flex-shrink-0 aspect-[3/2] w-auto!' 
       />
       <span className='truncate max-w-full'>{countryName}</span>
     </div>

--- a/dashboard/src/components/language/CountryDisplay.tsx
+++ b/dashboard/src/components/language/CountryDisplay.tsx
@@ -19,7 +19,7 @@ export const CountryDisplay = ({
       <FlagIcon
         countryCode={countryCode} 
         countryName={countryName}
-        className='flex-shrink-0 aspect-[3/2] w-auto!' 
+        className='flex-shrink-0' 
       />
       <span className='truncate max-w-full'>{countryName}</span>
     </div>


### PR DESCRIPTION
## Description

Fix the width of country flags on Safari spanning more than it should. Since we're using `country-flag-icons/react/3x2`, hardcoding the flags' aspect ration to 3/2 seems to fix the issue

Closes #408

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Style/UI changes

## Testing

- [x] Tests pass locally
- [ ] Added new tests
- [x] Manual testing completed
- [ ] Performance impact assessed

## Screenshots

<img width="1392" height="832" alt="image" src="https://github.com/user-attachments/assets/3572e473-180c-4c08-a37f-9a1529c63f75" />
