### PR TITLE
Fixed inconsistent date picker

### DIFF
--- a/dashboard/src/components/TimeRangeSelector/ComparePeriodSection.tsx
+++ b/dashboard/src/components/TimeRangeSelector/ComparePeriodSection.tsx
@@ -53,7 +53,11 @@ export function ComparePeriodSection({
                 label='End date'
                 date={compareEndDate}
                 onDateSelect={(date) => date && onCompareEndDateSelect(date)}
-                disabled={(date) => date > new Date()}
+                disabled={(date) => {
+                  if (date > new Date()) return true;
+                  if (compareStartDate && date < compareStartDate) return true;
+                  return false;
+                }}
                 id='compareEndDateInput'
               />
             </div>

--- a/dashboard/src/components/TimeRangeSelector/DateRangeSection.tsx
+++ b/dashboard/src/components/TimeRangeSelector/DateRangeSection.tsx
@@ -31,7 +31,11 @@ export function DateRangeSection({
           label='End date'
           date={endDate}
           onDateSelect={(date) => date && onEndDateSelect(date)}
-          disabled={(date) => date > new Date()}
+          disabled={(date) => {
+            if (date > new Date()) return true;
+            if (startDate && date < startDate) return true;
+            return false;
+          }}
           id='endDateInput'
         />
       </div>

--- a/dashboard/src/components/TimeRangeSelector/hooks/useTimeRangeHandlers.ts
+++ b/dashboard/src/components/TimeRangeSelector/hooks/useTimeRangeHandlers.ts
@@ -122,13 +122,26 @@ export function useTimeRangeHandlers({
   const handleStartDateSelect = useCallback(
     (date: Date | undefined) => {
       if (!date) return;
+      const newStart = startOfDay(date);
+      let newEnd = tempState.customEnd && endOfDay(tempState.customEnd);
+
+      // Preserve duration by default when moving the start date
+      if (tempState.customStart && tempState.customEnd) {
+        const previousDurationMs =
+          endOfDay(tempState.customEnd).getTime() - startOfDay(tempState.customStart).getTime();
+        const safeDurationMs = Math.max(previousDurationMs, 0);
+        const computedEnd = new Date(newStart.getTime() + safeDurationMs);
+        const todayEnd = endOfDay(new Date());
+        newEnd = computedEnd.getTime() > todayEnd.getTime() ? todayEnd : endOfDay(computedEnd);
+      }
+
       updateTempState({
         range: 'custom',
-        customStart: startOfDay(date),
-        customEnd: tempState.customEnd && endOfDay(tempState.customEnd),
+        customStart: newStart,
+        customEnd: newEnd,
       });
     },
-    [updateTempState, tempState.customEnd],
+    [updateTempState, tempState.customStart, tempState.customEnd],
   );
 
   const handleEndDateSelect = useCallback(


### PR DESCRIPTION
Implements:

- [x] Selecting a new start date updates the end date to preserve the existing duration (If the new start date is after the old end date, the end date moves forward automatically to maintain duration and validity)
- [x] End date picker disables dates earlier than the start date.
- [x] Selecting a later end date simply extends the range.
- [x] Start date picker allows any selectable date.
- [x] End date cannot be pushed further than today's date.

Closes #448 