### PR TITLE
Resolve bug with legend on dashboard overview geography map

### DIFF
--- a/dashboard/src/app/dashboard/[dashboardId]/(dashboard)/GeographySection.tsx
+++ b/dashboard/src/app/dashboard/[dashboardId]/(dashboard)/GeographySection.tsx
@@ -41,7 +41,11 @@ export default function GeographySection({ worldMapPromise, topCountriesPromise 
           emptyMessage: dictionary.t('dashboard.emptyStates.noWorldMapData'),
           customContent: worldMapData ? (
             <div className='h-[280px] w-full'>
-              <LeafletMap visitorData={worldMapData.visitorData} showZoomControls={false} />
+              <LeafletMap
+                visitorData={worldMapData.visitorData}
+                maxVisitors={worldMapData.maxVisitors}
+                showZoomControls={false}
+              />
             </div>
           ) : (
             <div className='text-muted-foreground py-12 text-center'>


### PR DESCRIPTION
Closes #461 

The legend now displays the value correctly again. The issue were that the leaflet-map weren't receiving the actual maxVisitors, so it just defaulted to 1.