### PR TITLE
Added missing canonical urls for docs

### DIFF
--- a/docs/src/app/[[...mdxPath]]/page.tsx
+++ b/docs/src/app/[[...mdxPath]]/page.tsx
@@ -8,7 +8,20 @@ export async function generateMetadata(props: {
 }) {
   const params = await props.params;
   const { metadata } = await importPage(params.mdxPath);
-  return metadata;
+  if (metadata?.alternates?.canonical) return metadata;
+
+  const canonicalPath =
+    Array.isArray(params.mdxPath) && params.mdxPath.length > 0
+      ? `/docs/${params.mdxPath.join("/")}`
+      : "/docs";
+
+  return {
+    ...metadata,
+    alternates: {
+      ...(metadata?.alternates ?? {}),
+      canonical: canonicalPath,
+    },
+  };
 }
 
 const Wrapper = getMDXComponents().wrapper;


### PR DESCRIPTION
All docs pages are missing canonical urls:

<img width="951" height="653" alt="image" src="https://github.com/user-attachments/assets/25bb0f48-24af-49b8-98d4-933269edde5f" />

This PR adds the missing canonical urls.