### PR TITLE
Fixed improper metadata for auth pages

### DIFF
--- a/dashboard/src/app/forgot-password/page.tsx
+++ b/dashboard/src/app/forgot-password/page.tsx
@@ -1,9 +1,31 @@
 import { redirect } from 'next/navigation';
+import type { Metadata } from 'next';
+import { generateSEO } from '@/lib/seo';
 import { authOptions } from '@/lib/auth';
 import ForgotPasswordForm from '@/components/auth/ForgotPasswordForm';
 import Logo from '@/components/logo';
 import { getServerSession } from 'next-auth';
 import Link from 'next/link';
+
+export const metadata: Metadata = {
+  ...generateSEO({
+    title: 'Forgot your password? | Betterlytics',
+    description: 'Reset your Betterlytics password securely. Enter your email to receive a password reset link.',
+    keywords: ['Forgot Password', 'Password Reset', 'Account Recovery', 'Betterlytics'],
+    path: '/forgot-password',
+  }),
+  robots: {
+    index: false,
+    follow: false,
+    googleBot: {
+      index: false,
+      follow: false,
+      'max-image-preview': 'none',
+      'max-snippet': 0,
+      'max-video-preview': 0,
+    },
+  },
+};
 
 export default async function ForgotPasswordPage() {
   const session = await getServerSession(authOptions);

--- a/dashboard/src/app/register/page.tsx
+++ b/dashboard/src/app/register/page.tsx
@@ -1,10 +1,40 @@
 import { redirect } from 'next/navigation';
+import type { Metadata } from 'next';
+import { generateSEO } from '@/lib/seo';
 import { authOptions } from '@/lib/auth';
 import RegisterForm from '@/app/register/RegisterForm';
 import Logo from '@/components/logo';
 import { getServerSession } from 'next-auth';
 import Link from 'next/link';
 import { isFeatureEnabled } from '@/lib/feature-flags';
+
+export const metadata: Metadata = {
+  ...generateSEO({
+    title: 'Get started for free — Create your Betterlytics account',
+    description:
+      'Get started for free with Betterlytics. Create your account for privacy-first, cookieless analytics for websites and apps.',
+    keywords: [
+      'Register',
+      'Create Account',
+      'Sign up',
+      'Betterlytics',
+      'Web Analytics',
+      'Google Analytics Alternative',
+    ],
+    path: '/register',
+  }),
+  robots: {
+    index: false,
+    follow: false,
+    googleBot: {
+      index: false,
+      follow: false,
+      'max-image-preview': 'none',
+      'max-snippet': 0,
+      'max-video-preview': 0,
+    },
+  },
+};
 
 export default async function RegisterPage() {
   const session = await getServerSession(authOptions);
@@ -44,7 +74,9 @@ export default async function RegisterPage() {
             <Logo variant='full' width={200} height={60} priority />
           </div>
           <h2 className='text-foreground mt-6 text-2xl font-semibold'>Create your account</h2>
-          <p className='text-muted-foreground mt-2 text-sm'>Start tracking your analytics today</p>
+          <p className='text-muted-foreground mt-2 text-sm'>
+            Get started for free — set up your analytics in minutes
+          </p>
         </div>
         <div className='bg-card rounded-lg border p-8 shadow-sm'>
           <RegisterForm />

--- a/dashboard/src/app/reset-password/page.tsx
+++ b/dashboard/src/app/reset-password/page.tsx
@@ -1,10 +1,32 @@
 import { redirect } from 'next/navigation';
+import type { Metadata } from 'next';
+import { generateSEO } from '@/lib/seo';
 import { authOptions } from '@/lib/auth';
 import ResetPasswordForm from '@/components/auth/ResetPasswordForm';
 import Logo from '@/components/logo';
 import { getServerSession } from 'next-auth';
 import Link from 'next/link';
 import { validateResetTokenAction } from '@/app/actions/passwordReset';
+
+export const metadata: Metadata = {
+  ...generateSEO({
+    title: 'Reset your password | Betterlytics',
+    description: 'Set a new password for your Betterlytics account using your secure reset link.',
+    keywords: ['Reset Password', 'Password Reset', 'Account Recovery', 'Betterlytics'],
+    path: '/reset-password',
+  }),
+  robots: {
+    index: false,
+    follow: false,
+    googleBot: {
+      index: false,
+      follow: false,
+      'max-image-preview': 'none',
+      'max-snippet': 0,
+      'max-video-preview': 0,
+    },
+  },
+};
 
 interface ResetPasswordPageProps {
   searchParams: Promise<{

--- a/dashboard/src/app/signin/page.tsx
+++ b/dashboard/src/app/signin/page.tsx
@@ -1,4 +1,6 @@
 import { redirect } from 'next/navigation';
+import type { Metadata } from 'next';
+import { generateSEO } from '@/lib/seo';
 import { authOptions } from '@/lib/auth';
 import LoginForm from '@/components/auth/LoginForm';
 import Logo from '@/components/logo';
@@ -14,6 +16,34 @@ interface SignInPageProps {
     verified?: string;
   }>;
 }
+
+export const metadata: Metadata = {
+  ...generateSEO({
+    title: 'Sign in to Betterlytics',
+    description:
+      'Sign in to access your Betterlytics analytics dashboard. Secure, privacy-first, cookieless web analytics.',
+    keywords: [
+      'Sign in',
+      'Login',
+      'Betterlytics Account',
+      'Analytics Dashboard',
+      'Privacy-First Analytics',
+      'Google Analytics Alternative',
+    ],
+    path: '/signin',
+  }),
+  robots: {
+    index: false,
+    follow: false,
+    googleBot: {
+      index: false,
+      follow: false,
+      'max-image-preview': 'none',
+      'max-snippet': 0,
+      'max-video-preview': 0,
+    },
+  },
+};
 
 export default async function SignInPage({ searchParams }: SignInPageProps) {
   const session = await getServerSession(authOptions);


### PR DESCRIPTION
Signup and register shows our generic metadata. I've added tailored metadata to those for better search results. Note that in the following picture, the title for the /register page is "Simple, Cookieless, Privacy ..."

<img width="752" height="186" alt="image" src="https://github.com/user-attachments/assets/35a2c465-dde8-4a5b-be06-425f56d08cb8" />
