### PR TITLE
Localize country-flags

### DIFF
--- a/dashboard/src/app/[locale]/(landing)/components/featureCards/worldMapCard.tsx
+++ b/dashboard/src/app/[locale]/(landing)/components/featureCards/worldMapCard.tsx
@@ -3,12 +3,17 @@ import LeafletMap from '@/components/map/LeafletMap';
 import { FlagIcon, FlagIconProps } from '@/components/icons';
 import { MOCK_WORLD_GEOVISITORS } from '@/constants/geographyData';
 import { GeoVisitor } from '@/entities/geography';
-import { getTranslations } from 'next-intl/server';
+import { getLocale, getTranslations } from 'next-intl/server';
+import { SupportedLanguages } from '@/constants/i18n';
+import { getCountryName } from '@/utils/countryCodes';
 
-const CountryCol = ({ geoVisitor }: { geoVisitor: GeoVisitor }) => (
+const CountryCol = ({ geoVisitor, locale }: { geoVisitor: GeoVisitor; locale: SupportedLanguages }) => (
   <div className='flex py-2 text-xs' key={geoVisitor.country_code}>
     <div className='flex items-center gap-0.75'>
-      <FlagIcon countryCode={geoVisitor.country_code as FlagIconProps['countryCode']} />
+      <FlagIcon
+        countryCode={geoVisitor.country_code as FlagIconProps['countryCode']}
+        countryName={getCountryName(geoVisitor.country_code, locale)}
+      />
       <span className='font-medium'>{geoVisitor.country_code}</span>
     </div>
     <span className='text-muted-foreground ml-1 flex items-center'>{geoVisitor.visitors}</span>
@@ -17,6 +22,8 @@ const CountryCol = ({ geoVisitor }: { geoVisitor: GeoVisitor }) => (
 
 export default async function WorldMapCard() {
   const t = await getTranslations('public.landing.cards.worldMap');
+  const locale = await getLocale();
+
   return (
     <Card>
       <CardHeader className='pb-0'>
@@ -40,7 +47,11 @@ export default async function WorldMapCard() {
             <span className='text-muted-foreground'>{t('topCountries')}</span>
             <div className='grid auto-cols-[70px] grid-flow-col justify-end gap-1 overflow-hidden'>
               {Array.from({ length: 2 }).map((_, i) => (
-                <CountryCol key={MOCK_WORLD_GEOVISITORS[i].country_code} geoVisitor={MOCK_WORLD_GEOVISITORS[i]} />
+                <CountryCol
+                  key={MOCK_WORLD_GEOVISITORS[i].country_code}
+                  geoVisitor={MOCK_WORLD_GEOVISITORS[i]}
+                  locale={locale}
+                />
               ))}
             </div>
           </div>

--- a/dashboard/src/app/dashboard/[dashboardId]/(dashboard)/GeographySection.tsx
+++ b/dashboard/src/app/dashboard/[dashboardId]/(dashboard)/GeographySection.tsx
@@ -5,7 +5,7 @@ import type { getTopCountryVisitsAction, getWorldMapDataAlpha2 } from '@/app/act
 import { getCountryName } from '@/utils/countryCodes';
 import { use } from 'react';
 import { FlagIcon, FlagIconProps } from '@/components/icons';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 
 type GeographySectionProps = {
   worldMapPromise: ReturnType<typeof getWorldMapDataAlpha2>;
@@ -16,6 +16,7 @@ export default function GeographySection({ worldMapPromise, topCountriesPromise 
   const worldMapData = use(worldMapPromise);
   const topCountries = use(topCountriesPromise);
   const t = useTranslations('dashboard');
+  const locale = useLocale();
 
   return (
     <MultiProgressTable
@@ -26,11 +27,16 @@ export default function GeographySection({ worldMapPromise, topCountriesPromise 
           key: 'countries',
           label: t('tabs.topCountries'),
           data: topCountries.map((country) => ({
-            label: getCountryName(country.country_code),
+            label: getCountryName(country.country_code, locale),
             value: country.current.visitors,
             trendPercentage: country.change?.visitors,
             comparisonValue: country.compare?.visitors,
-            icon: <FlagIcon countryCode={country.country_code as FlagIconProps['countryCode']} />,
+            icon: (
+              <FlagIcon
+                countryCode={country.country_code as FlagIconProps['countryCode']}
+                countryName={getCountryName(country.country_code, locale)}
+              />
+            ),
           })),
           emptyMessage: t('emptyStates.noCountryData'),
         },

--- a/dashboard/src/app/dashboard/[dashboardId]/events/EventLogItem.tsx
+++ b/dashboard/src/app/dashboard/[dashboardId]/events/EventLogItem.tsx
@@ -4,6 +4,8 @@ import { Badge } from '@/components/ui/badge';
 import { EventLogEntry } from '@/entities/events';
 import { formatTimeAgo } from '@/utils/dateFormatters';
 import { DeviceIcon, BrowserIcon, FlagIcon, FlagIconProps } from '@/components/icons';
+import { useLocale } from 'next-intl';
+import { getCountryName } from '@/utils/countryCodes';
 
 const MAX_PROPERTIES_DISPLAY = 3;
 
@@ -63,6 +65,8 @@ const MetadataItem = React.memo(
 MetadataItem.displayName = 'MetadataItem';
 
 export const EventLogItem = React.memo(function EventLogItem({ event, isNearEnd, onRef }: EventLogItemProps) {
+  const locale = useLocale();
+
   return (
     <div
       className='group hover:bg-muted/40 hover:border-l-primary/50 relative border-l-2 border-l-transparent p-4 transition-all duration-200'
@@ -102,7 +106,14 @@ export const EventLogItem = React.memo(function EventLogItem({ event, isNearEnd,
             )}
 
             {event.country_code && (
-              <MetadataItem icon={<FlagIcon countryCode={event.country_code as FlagIconProps['countryCode']} />}>
+              <MetadataItem
+                icon={
+                  <FlagIcon
+                    countryCode={event.country_code as FlagIconProps['countryCode']}
+                    countryName={getCountryName(event.country_code, locale)}
+                  />
+                }
+              >
                 <span className='font-medium uppercase'>{event.country_code}</span>
               </MetadataItem>
             )}

--- a/dashboard/src/components/icons/FlagIcon.tsx
+++ b/dashboard/src/components/icons/FlagIcon.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import * as Flags from 'country-flag-icons/react/3x2';
-import { getCountryName } from '@/utils/countryCodes';
 import { HelpCircle } from 'lucide-react';
 
 export type FlagIconProps = {
   countryCode: keyof typeof Flags;
-  countryName?: string;
+  countryName: string;
 } & Flags.ElementAttributes<Flags.HTMLSVGElement>;
 
-function FlagIconComponent({ countryCode, countryName = getCountryName(countryCode), ...props }: FlagIconProps) {
+function FlagIconComponent({ countryCode, countryName, ...props }: FlagIconProps) {
   const FlagComponent = Flags[countryCode];
 
   if (!FlagComponent) {

--- a/dashboard/src/components/language/CountryDisplay.tsx
+++ b/dashboard/src/components/language/CountryDisplay.tsx
@@ -2,26 +2,24 @@ import React from 'react';
 import { FlagIcon, FlagIconProps } from '@/components/icons';
 import { getCountryName } from '@/utils/countryCodes';
 import { cn } from '@/lib/utils';
+import { useLocale } from 'next-intl';
 
 type CountryDisplayProps = {
   countryCode: FlagIconProps['countryCode'];
-  countryName?: string;  // Defaults to result of getCountryName
+  countryName?: string; // Defaults to result of getCountryName w. current locale
   className?: string;
 };
 
-export const CountryDisplay = ({ 
-  countryCode, 
-  countryName = getCountryName(countryCode),
-  className,
-}: CountryDisplayProps) => {
+export const CountryDisplay = ({ countryCode, countryName, className }: CountryDisplayProps) => {
+  if (!countryName) {
+    const locale = useLocale();
+    console.log('locale is', locale);
+    countryName = getCountryName(countryCode, locale);
+  }
   return (
-    <div className={cn(className, 'm-0 flex items-center gap-2 p-0 overflow-hidden')}>
-      <FlagIcon
-        countryCode={countryCode} 
-        countryName={countryName}
-        className='flex-shrink-0' 
-      />
-      <span className='truncate max-w-full'>{countryName}</span>
+    <div className={cn(className, 'm-0 flex items-center gap-2 overflow-hidden p-0')}>
+      <FlagIcon countryCode={countryCode} countryName={countryName} className='flex-shrink-0' />
+      <span className='max-w-full truncate'>{countryName}</span>
     </div>
-  )
-}
+  );
+};

--- a/dashboard/src/components/map/MapCountryGeoJSON.tsx
+++ b/dashboard/src/components/map/MapCountryGeoJSON.tsx
@@ -6,6 +6,7 @@ import React, { useCallback, useEffect, useRef } from 'react';
 import { createRoot } from 'react-dom/client';
 import type { GeoJSON } from 'react-leaflet';
 import MapTooltipContent from './tooltip/MapTooltipContent';
+import { useLocale, useTranslations } from 'next-intl';
 
 interface MapCountryGeoJSONProps {
   GeoJSON: typeof GeoJSON;
@@ -31,7 +32,8 @@ export default function MapCountryGeoJSON({
   style,
 }: MapCountryGeoJSONProps) {
   const { setMapSelection } = useMapSelection();
-
+  const locale = useLocale();
+  const t = useTranslations('components.geography');
   const ref = useRef({ setMapSelection });
   useEffect(() => {
     ref.current = { setMapSelection };
@@ -70,7 +72,9 @@ export default function MapCountryGeoJSON({
           if (!(popupContainer as any)._reactRoot) {
             (popupContainer as any)._reactRoot = createRoot(popupContainer);
           }
-          (popupContainer as any)._reactRoot.render(<MapTooltipContent geoVisitor={geoVisitor} size={size} />);
+          (popupContainer as any)._reactRoot.render(
+            <MapTooltipContent locale={locale} geoVisitor={geoVisitor} size={size} label={t('visitors')} />,
+          );
 
           requestAnimationFrame(() => {
             layer.getPopup()?.update();

--- a/dashboard/src/components/map/tooltip/MapStickyTooltip.tsx
+++ b/dashboard/src/components/map/tooltip/MapStickyTooltip.tsx
@@ -5,6 +5,7 @@ import { useMap } from 'react-leaflet/hooks';
 import MapTooltipContent from './MapTooltipContent';
 import MapTooltipTip from './MapTooltipTip';
 import { cn } from '@/lib/utils';
+import { useLocale, useTranslations } from 'next-intl';
 
 export type MapStickyTooltip = {
   size?: 'sm' | 'lg';
@@ -14,6 +15,8 @@ export default function MapStickyTooltip({ size = 'sm' }: MapStickyTooltip) {
   const { hoveredFeature, clickedFeature: selectedFeature } = useMapSelection();
   const map = useMap();
   const tooltipId = useId();
+  const locale = useLocale();
+  const t = useTranslations('components.geography');
 
   const tooltipRef = useRef<HTMLElement | null>(null);
   const latestMouseRef = useRef({ x: 0, y: 0 });
@@ -54,7 +57,12 @@ export default function MapStickyTooltip({ size = 'sm' }: MapStickyTooltip) {
       )}
     >
       <div className='leaflet-popup-content'>
-        <MapTooltipContent geoVisitor={hoveredFeature?.geoVisitor} size={size} />
+        <MapTooltipContent
+          geoVisitor={hoveredFeature?.geoVisitor}
+          size={size}
+          locale={locale}
+          label={t('visitors')}
+        />
       </div>
       <MapTooltipTip />
     </section>,

--- a/dashboard/src/components/map/tooltip/MapTooltipContent.tsx
+++ b/dashboard/src/components/map/tooltip/MapTooltipContent.tsx
@@ -1,5 +1,6 @@
 import { FlagIconProps } from '@/components/icons';
 import { CountryDisplay } from '@/components/language/CountryDisplay';
+import { SupportedLanguages } from '@/constants/i18n';
 import { GeoVisitor } from '@/entities/geography';
 import { cn } from '@/lib/utils';
 import { getCountryName } from '@/utils/countryCodes';
@@ -8,10 +9,12 @@ import React from 'react';
 export type MapTooltipContentProps = {
   geoVisitor?: GeoVisitor;
   className?: string;
+  label: string;
+  locale: SupportedLanguages;
   size: 'sm' | 'lg';
 };
 
-function MapTooltipContent({ geoVisitor, size, className }: MapTooltipContentProps) {
+function MapTooltipContent({ geoVisitor, size, className, label, locale }: MapTooltipContentProps) {
   if (!geoVisitor) return null;
 
   return (
@@ -25,10 +28,10 @@ function MapTooltipContent({ geoVisitor, size, className }: MapTooltipContentPro
       <CountryDisplay
         className='text-sm font-bold'
         countryCode={geoVisitor.country_code as FlagIconProps['countryCode']}
-        countryName={getCountryName(geoVisitor.country_code)}
+        countryName={getCountryName(geoVisitor.country_code, locale)}
       />
       <div className='flex gap-1 text-sm whitespace-nowrap'>
-        <span className='text-muted-foreground'>Visitors:</span>
+        <span className='text-muted-foreground'>{label}:</span>
         <span className='text-foreground'>{geoVisitor.visitors}</span>
       </div>
     </div>

--- a/dashboard/src/utils/countryCodes.ts
+++ b/dashboard/src/utils/countryCodes.ts
@@ -1,7 +1,15 @@
+import { SupportedLanguages, SUPPORTED_LANGUAGES } from '@/constants/i18n';
 import countries from 'i18n-iso-countries';
-import enLocale from 'i18n-iso-countries/langs/en.json';
 
-countries.registerLocale(enLocale);
+async function registerLocales() {
+  await Promise.all(
+    SUPPORTED_LANGUAGES.map(async (lang) => {
+      countries.registerLocale((await import(`i18n-iso-countries/langs/${lang}.json`)).default);
+    }),
+  );
+}
+
+registerLocales();
 
 /**
  * Converts an ISO 3166-1 alpha-2 country code to alpha-3
@@ -24,9 +32,10 @@ export function alpha3ToAlpha2Code(alpha3: string): string | undefined {
 /**
  * Converts an ISO 3166-1 alpha-2 country code to country name
  * @param alpha2 The two-letter country code (e.g., 'DK')
+ * @param locale The locale for the country name (e.g., 'en', 'it', 'da')
  * @returns The country name (e.g., 'Denmark') or 'Unknown' if not found
  */
-export function getCountryName(alpha2: string): string {
-  const name = countries.getName(alpha2.toUpperCase(), 'en');
+export function getCountryName(alpha2: string, locale: SupportedLanguages): string {
+  const name = countries.getName(alpha2.toUpperCase(), locale);
   return name || 'Unknown';
 }


### PR DESCRIPTION
Closes #472 

I have localized country-flags, and dynamically loaded the libraries for `getCountryName` to ensure it automatically updates, when we add a new supported-language.

Note that it's necessary to explicitly pass the locale to the `MapTooltip` as it's rendered inside LeafletContext, which doesn't have access to the next-intl-provider.