### PR TITLE
Canonalize UA agent browsers seen in production

### DIFF
--- a/backend/src/ua_parser/mod.rs
+++ b/backend/src/ua_parser/mod.rs
@@ -54,8 +54,8 @@ pub fn parse_user_agent(user_agent: &str) -> ParsedUserAgent {
     
     let parser = USER_AGENT_PARSER.get().expect("User agent parser not initialized. Call initialize() first.");
     let client = parser.parse(user_agent);
-    
-    let browser = client.user_agent.family.to_string();
+
+    let browser = canonicalize_browser_family(&client.user_agent.family);
     let browser_version = client.user_agent.major.map(|v| v.to_string());
     let os = client.os.family.to_string();
     
@@ -71,4 +71,55 @@ pub fn parse_user_agent(user_agent: &str) -> ParsedUserAgent {
         browser_version,
         os,
     }
+}
+
+/// Normalize/Canonicalize browser family names to a small set of common brands for UI/icon mapping.
+/// Examples:
+/// - "Chrome Mobile iOS" -> "Chrome"
+/// - "Mobile Safari" -> "Safari"
+/// - "Firefox Mobile" / "FxiOS" -> "Firefox"
+/// - "Microsoft Edge" / "Edg" -> "Edge"
+/// - "OPR" / "Opera Mobile" -> "Opera"
+fn canonicalize_browser_family(family: &str) -> String {
+    let f = family.to_lowercase();
+
+    // Preserve specific Chromium-based brands first
+    if f.contains("brave") {
+        return "Brave".to_string();
+    }
+    if f.contains("vivaldi") {
+        return "Vivaldi".to_string();
+    }
+    if f.contains("arc") {
+        return "Arc".to_string();
+    }
+
+    // Major families
+    if f.contains("edg") || f.contains("edge") {
+        return "Edge".to_string();
+    }
+    if f.contains("opr") || f.contains("opera") {
+        return "Opera".to_string();
+    }
+    if f.contains("firefox") || f == "fxios" {
+        return "Firefox".to_string();
+    }
+    if f.contains("safari") {
+        return "Safari".to_string();
+    }
+    if f.contains("chrome") || f.contains("chromium") || f == "crios" {
+        return "Chrome".to_string();
+    }
+    if f.contains("duckduckgo") {
+        return "DuckDuckGo".to_string();
+    }
+    if f.contains("opera") {
+        return "Opera".to_string();
+    }
+    if f.contains("ecosia") {
+        return "Ecosia".to_string();
+    }
+
+    // Default to original family if no mapping found
+    family.to_string()
 }

--- a/dashboard/src/components/icons/BrowserIcon.tsx
+++ b/dashboard/src/components/icons/BrowserIcon.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Globe } from 'lucide-react';
 import { Icon } from '@iconify/react';
-import { browserIconNames, browserLabels, type BrowserType } from '@/constants/browserIcons';
+import { browserIconNames, normalizeBrowserKey } from '@/constants/browserIcons';
 
 interface BrowserIconProps {
   name: string;
@@ -9,8 +9,8 @@ interface BrowserIconProps {
 }
 
 export const BrowserIcon = React.memo<BrowserIconProps>(({ name, className = 'h-3.5 w-3.5' }) => {
-  const normalizedName = name.toLowerCase().replace(/\s+/g, '') as BrowserType;
-  const iconName = browserIconNames[normalizedName];
+  const normalizedKey = normalizeBrowserKey(name);
+  const iconName = normalizedKey ? browserIconNames[normalizedKey] : undefined;
 
   if (!iconName) {
     return <Globe className={className} />;

--- a/dashboard/src/constants/browserIcons.ts
+++ b/dashboard/src/constants/browserIcons.ts
@@ -21,3 +21,36 @@ export const browserLabels: Record<string, string> = {
   vivaldi: 'Vivaldi',
   arc: 'Arc',
 };
+
+// Map common alias keys to canonical browser keys for icon/label mapping.
+// Keys are lowercase and stripped of non-alphanumeric characters.
+const browserAliasToCanonical: Record<string, BrowserType> = {
+  // Chrome family
+  chromemobile: 'chrome',
+  chromeios: 'chrome',
+  crios: 'chrome',
+  chromium: 'chrome',
+
+  // Safari family
+  mobilesafari: 'safari',
+  safariios: 'safari',
+
+  // Firefox family
+  firefoxmobile: 'firefox',
+  fxios: 'firefox',
+
+  // Edge family
+  microsoftedge: 'edge',
+  edg: 'edge',
+
+  // Opera family
+  opr: 'opera',
+  operamobile: 'opera',
+  operagx: 'opera',
+};
+
+export const normalizeBrowserKey = (name: string): BrowserType | undefined => {
+  const compact = name.toLowerCase().replace(/\s+/g, '');
+  const canonical = (browserAliasToCanonical[compact] ?? compact) as string;
+  return canonical in browserIconNames ? (canonical as BrowserType) : undefined;
+};


### PR DESCRIPTION
Canonalized entries like these:

<img width="331" height="199" alt="{123F0309-4013-4FB8-8F3F-20528627385F}" src="https://github.com/user-attachments/assets/745b2264-ecf8-40df-ab7d-bc903df3c30f" />
