### PR TITLE
Added missing translations to event page

### DIFF
--- a/dashboard/messages/da.json
+++ b/dashboard/messages/da.json
@@ -1159,6 +1159,11 @@
         "eventDetails": "Hændelsesdetaljer",
         "uniqueEvent": "Unik hændelse",
         "uniqueEvents": "Unikke hændelser"
+      },
+      "expandedEventContent": {
+        "loading": "Indlæser egenskaber...",
+        "noProperties": "Ingen egenskaber",
+        "noPropertiesDesc": "Denne hændelse har ingen brugerdefinerede egenskaber."
       }
     },
     "tabbedTable": {

--- a/dashboard/messages/en.json
+++ b/dashboard/messages/en.json
@@ -1155,6 +1155,11 @@
         "eventDetails": "Event Details",
         "uniqueEvent": "Unique Event",
         "uniqueEvents": "Unique Events"
+      },
+      "expandedEventContent": {
+        "loading": "Loading properties...",
+        "noProperties": "No Properties",
+        "noPropertiesDesc": "This event has no custom properties."
       }
     },
     "tabbedTable": {

--- a/dashboard/messages/it.json
+++ b/dashboard/messages/it.json
@@ -1161,6 +1161,11 @@
         "eventDetails": "Dettagli evento",
         "uniqueEvent": "Evento unico",
         "uniqueEvents": "Eventi unici"
+      },
+      "expandedEventContent": {
+        "loading": "Caricamento proprietà...",
+        "noProperties": "Nessuna proprietà",
+        "noPropertiesDesc": "Questo evento non ha proprietà personalizzate."
       }
     },
     "tabbedTable": {

--- a/dashboard/src/app/(protected)/dashboard/[dashboardId]/events/EventsTable.tsx
+++ b/dashboard/src/app/(protected)/dashboard/[dashboardId]/events/EventsTable.tsx
@@ -10,7 +10,6 @@ import {
   getSortedRowModel,
   flexRender,
 } from '@tanstack/react-table';
-import { EventTypeRow } from '@/entities/events';
 import { useTimeRangeContext } from '@/contexts/TimeRangeContextProvider';
 import { useQueryFiltersContext } from '@/contexts/QueryFiltersContextProvider';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -18,7 +17,7 @@ import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@
 import { Badge } from '@/components/ui/badge';
 import { ExpandedEventContent } from './ExpandedEventContent';
 import { calculatePercentage } from '@/utils/mathUtils';
-import { formatTimeAgo } from '@/utils/dateFormatters';
+import { formatRelativeTimeFromNow } from '@/utils/dateFormatters';
 import { formatPercentage } from '@/utils/formatters';
 import { cn } from '@/lib/utils';
 import type { fetchCustomEventsOverviewAction } from '@/app/actions/events';
@@ -143,7 +142,7 @@ export function EventsTable({ data }: EventsTableProps) {
         accessorKey: 'last_seen',
         header: t('lastSeen'),
         cell: ({ row }) => {
-          const timeAgo = formatTimeAgo(row.original.current.last_seen);
+          const timeAgo = formatRelativeTimeFromNow(row.original.current.last_seen);
 
           return (
             <div className='flex items-center text-right text-sm'>

--- a/dashboard/src/app/(protected)/dashboard/[dashboardId]/events/ExpandedEventContent.tsx
+++ b/dashboard/src/app/(protected)/dashboard/[dashboardId]/events/ExpandedEventContent.tsx
@@ -4,6 +4,7 @@ import { useDashboardId } from '@/hooks/use-dashboard-id';
 import { useEventProperties } from '@/hooks/use-event-properties';
 import { QueryFilter } from '@/entities/filter';
 import { Spinner } from '@/components/ui/spinner';
+import { useTranslations } from 'next-intl';
 
 interface ExpandedEventContentProps {
   event: EventTypeRow;
@@ -22,6 +23,7 @@ export function ExpandedEventContent({
   endDate,
   queryFilters,
 }: ExpandedEventContentProps) {
+  const t = useTranslations('components.events.expandedEventContent');
   const dashboardId = useDashboardId();
   const { data: propertiesData, isLoading: propertiesLoading } = useEventProperties(
     dashboardId,
@@ -38,7 +40,7 @@ export function ExpandedEventContent({
           <div className='relative'>
             <Spinner size='sm' />
           </div>
-          <p className='text-muted-foreground text-sm'>Loading properties...</p>
+          <p className='text-muted-foreground text-sm'>{t('loading')}</p>
         </div>
       ) : propertiesData?.properties.length ? (
         <div className='py-4 pr-6 pl-8'>
@@ -55,8 +57,8 @@ export function ExpandedEventContent({
         </div>
       ) : (
         <div className='py-12 pl-8 text-center'>
-          <h4 className='text-foreground mb-1 text-sm font-medium'>No Properties</h4>
-          <p className='text-muted-foreground text-xs'>This event has no custom properties.</p>
+          <h4 className='text-foreground mb-1 text-sm font-medium'>{t('noProperties')}</h4>
+          <p className='text-muted-foreground text-xs'>{t('noPropertiesDesc')}</p>
         </div>
       )}
     </div>

--- a/dashboard/src/components/events/EventLogItem.tsx
+++ b/dashboard/src/components/events/EventLogItem.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { User, ExternalLink, Activity } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { EventLogEntry } from '@/entities/events';
-import { formatTimeAgo } from '@/utils/dateFormatters';
+import { formatRelativeTimeFromNow } from '@/utils/dateFormatters';
 import { DeviceIcon, BrowserIcon, FlagIcon, FlagIconProps } from '@/components/icons';
 import { useLocale } from 'next-intl';
 import { getCountryName } from '@/utils/countryCodes';
@@ -83,7 +83,7 @@ export const EventLogItem = React.memo(function EventLogItem({ event, isNearEnd,
               <h3 className='text-foreground text-sm leading-tight font-semibold'>{event.event_name}</h3>
               <div className='bg-muted-foreground/40 h-1 w-1 rounded-full' />
               <Badge variant='secondary' className='border-border border text-xs font-medium shadow-xs'>
-                {formatTimeAgo(new Date(event.timestamp))}
+                {formatRelativeTimeFromNow(event.timestamp)}
               </Badge>
             </div>
           </div>


### PR DESCRIPTION
Adjusted the events page to use the new relative time formatter that takes translations into consideration. Also added missing translations for event table