### PR TITLE
Adjust weakly heatmap's tooltip to not block underlying selection

### DIFF
--- a/dashboard/src/app/(protected)/dashboard/[dashboardId]/(dashboard)/WeeklyHeatmapSection.tsx
+++ b/dashboard/src/app/(protected)/dashboard/[dashboardId]/(dashboard)/WeeklyHeatmapSection.tsx
@@ -161,7 +161,7 @@ function HeatmapGrid({ data, maxValue, metricLabel, metric }: HeatmapGridProps) 
           {Array.from({ length: 7 }).map((_, dayIndex) => {
             const value = data[dayIndex]?.hours[hourIndex] ?? 0;
             return (
-              <Tooltip key={`${hourIndex}-${dayIndex}`}>
+              <Tooltip key={`${hourIndex}-${dayIndex}`} delayDuration={0} disableHoverableContent>
                 <TooltipTrigger asChild>
                   <div
                     className={cn(
@@ -174,7 +174,7 @@ function HeatmapGrid({ data, maxValue, metricLabel, metric }: HeatmapGridProps) 
                 </TooltipTrigger>
                 <TooltipContent
                   side='top'
-                  className='border-border bg-popover/95 text-popover-foreground rounded-lg border p-2.5 shadow-xl backdrop-blur-sm'
+                  className='border-border bg-popover/95 text-popover-foreground pointer-events-none rounded-lg border p-2.5 shadow-xl backdrop-blur-sm'
                 >
                   <div>
                     <div className='text-popover-foreground font-medium'>


### PR DESCRIPTION
Adjust the heatmap tooltip to not block underlying hover actions. This is important when the user moves the mouse upwards. The tooltip's open state currently blocks the underlying map.

### Before
![msedge_hlFH7ItWOE](https://github.com/user-attachments/assets/683aa123-565e-4c91-8590-277f30395728)

### After
![msedge_nO4VGh2nuY](https://github.com/user-attachments/assets/12c9e6e2-eeb9-4823-9bdd-3a3811abe3af)
