### PR TITLE
Only show Antarctica on world-map, if there are visitors from Antarctica

### DIFF
--- a/dashboard/src/components/map/LeafletMap.tsx
+++ b/dashboard/src/components/map/LeafletMap.tsx
@@ -72,8 +72,12 @@ export default function LeafletMap({
 
   const worldBounds = useMemo(() => {
     if (!mapComponents?.L) return null;
-    return mapComponents.L.latLngBounds(mapComponents.L.latLng(-100, -220), mapComponents.L.latLng(100, 220));
-  }, [mapComponents]);
+    const hasAntarctica = visitorData.some((d) => d.country_code === 'AQ' && d.visitors);
+    return mapComponents.L.latLngBounds(
+      mapComponents.L.latLng(hasAntarctica ? -100 : -60, -220),
+      mapComponents.L.latLng(100, 220),
+    );
+  }, [mapComponents, visitorData]);
 
   if (isPending || !mapComponents || !worldGeoJson) {
     return (

--- a/dashboard/src/components/map/MapCountryGeoJSON.tsx
+++ b/dashboard/src/components/map/MapCountryGeoJSON.tsx
@@ -46,6 +46,10 @@ export default function MapCountryGeoJSON({
       if (!country_code) return;
 
       let geoVisitor = visitorData.find((d) => d.country_code === country_code);
+      if (!geoVisitor?.visitors && country_code === 'AQ') {
+        layer.setStyle({ opacity: 0, fillOpacity: 0 });
+        return;
+      }
       if (!geoVisitor) {
         geoVisitor = { country_code, visitors: 0 };
       }


### PR DESCRIPTION
Antarctica takes up a large portion of the world-map. It improves the user-experience to conditionally render it, as traffic from Antarctica is still extremely rare. 

I have ensured to still show it, if it has an active visitor count.

WDYT is this something we want?

### Demo wout Antarctica
![msedge_eGPKAtL3YZ](https://github.com/user-attachments/assets/ecb72049-a118-4ffe-a4e3-6c58f076cbba)
