### PR TITLE
Introduces negative cache for favicon fetching to reduce repeated fet…

### DIFF
--- a/dashboard/src/app/api/favicons/route.ts
+++ b/dashboard/src/app/api/favicons/route.ts
@@ -10,6 +10,7 @@ const FAVICON_PATHS: string[] = ['/favicon.ico', '/favicon.png', '/favicon.jpg',
 const CONFIG = {
   timeoutMs: 2_000,
   cacheSeconds: 60 * 60 * 24 * 3,
+  negativeCacheSeconds: 60 * 60 * 6,
   maxBytes: 100 * 1024,
   maxRedirects: 5,
 };
@@ -26,7 +27,19 @@ export async function GET(request: NextRequest) {
   }
 
   const response = await proxyFavicon(parsed.data);
-  return response ?? new NextResponse(null, { status: 404 });
+  if (response) {
+    return response;
+  }
+
+  // Negative cache: if we fail to resolve a favicon for this domain, return a 404
+  // with the same caching semantics as a successful favicon. This prevents repeated
+  // lookups for obviously bad or misconfigured domains.
+  return new NextResponse(null, {
+    status: 404,
+    headers: {
+      'Cache-Control': `public, max-age=${CONFIG.negativeCacheSeconds}`,
+    },
+  });
 }
 
 async function proxyFavicon(domain: string): Promise<NextResponse | null> {
@@ -95,9 +108,8 @@ async function fetchFavicon(url: string): Promise<NextResponse | null> {
       },
     });
   } catch (error) {
-    if ((error as Error).name !== 'AbortError') {
-      console.warn('[favicon-proxy] Failed to fetch favicon from', url, error);
-    }
+    // Network/TLS issues for arbitrary user domains are expected.
+    // We don't want to log these in production to avoid log spam.
     return null;
   } finally {
     clearTimeout(timeoutId);


### PR DESCRIPTION
…ching + disables log spam for failing favicon requests

In production, we see a lot of redundant error logs appearing for favicon fetch requests with network/TLS issues for dashboards with arbitrary invalid domains. This PR disables logs entirely for favicon, and also introduces a negative cache to prevent repeated favicon fetch requests when the favicon fails to fetch.