### PR TITLE
Enabled server-side source map for production builds

### DIFF
--- a/dashboard/next.config.ts
+++ b/dashboard/next.config.ts
@@ -22,6 +22,13 @@ const nextConfig: NextConfig = {
       },
     ];
   },
+  webpack: (config, { isServer }) => {
+    if (isServer) {
+      config.devtool = 'source-map';
+    }
+    return config;
+  },
+  productionBrowserSourceMaps: false,
 };
 
 export default createNextIntlPlugin()(nextConfig);


### PR DESCRIPTION
This enables server-side source map for the production build to make debugging easier.