### PR TITLE
Introduces request boundary cache for auth authentication

### DIFF
--- a/dashboard/src/auth/auth-actions.ts
+++ b/dashboard/src/auth/auth-actions.ts
@@ -13,6 +13,7 @@ import { unstable_cache } from 'next/cache';
 import { DashboardFindByUserSchema } from '@/entities/dashboard';
 import { stableStringify } from '@/utils/stableStringify';
 import { trace, SpanStatusCode } from '@opentelemetry/api';
+import { cache } from 'react';
 
 // Stable per-action signature to avoid cache key collisions (alternatively we provide each function an explicit name)
 type AnyFn = (...args: unknown[]) => unknown;
@@ -40,6 +41,16 @@ function getActionSignature(fn: AnyFn): string {
 
 const tracer = trace.getTracer('dashboard');
 
+const getCachedSession = cache(async () => {
+  return await getServerSession(authOptions);
+});
+
+const getCachedAuthorizedContext = cache(
+  async (userId: string, dashboardId: string): Promise<AuthContext | null> => {
+    return await getAuthorizedDashboardContextOrNull(DashboardFindByUserSchema.parse({ userId, dashboardId }));
+  },
+);
+
 async function withActionSpan<T>(
   name: string,
   attrs: Record<string, string | number | boolean>,
@@ -66,7 +77,7 @@ async function withActionSpan<T>(
 }
 
 export async function getAuthSession(): Promise<Session | null> {
-  const session = await getServerSession(authOptions);
+  const session = await getCachedSession();
   return session;
 }
 
@@ -83,7 +94,7 @@ export async function requireAuth(): Promise<Session> {
 type ActionRequiringAuthContext<Args extends Array<unknown>, Ret> = (context: AuthContext, ...args: Args) => Ret;
 
 async function tryGetAuthorizedContext(userId: string, dashboardId: string): Promise<AuthContext | null> {
-  return await getAuthorizedDashboardContextOrNull(DashboardFindByUserSchema.parse({ userId, dashboardId }));
+  return await getCachedAuthorizedContext(userId, dashboardId);
 }
 
 async function createDemoContext(dashboardId: string): Promise<AuthContext> {
@@ -98,7 +109,7 @@ async function createDemoContext(dashboardId: string): Promise<AuthContext> {
 }
 
 async function resolveDemoDashboardContext(dashboardId: string): Promise<AuthContext> {
-  const session = await getServerSession(authOptions);
+  const session = await getCachedSession();
   if (session?.user) {
     const authorizedCtx = await tryGetAuthorizedContext(session.user.id, dashboardId);
     if (authorizedCtx) return authorizedCtx;
@@ -107,7 +118,7 @@ async function resolveDemoDashboardContext(dashboardId: string): Promise<AuthCon
 }
 
 async function resolvePrivateDashboardContext(dashboardId: string): Promise<AuthContext> {
-  const session = await getServerSession(authOptions);
+  const session = await getCachedSession();
   if (session?.user) {
     const authorizedCtx = await tryGetAuthorizedContext(session.user.id, dashboardId);
     if (authorizedCtx) return authorizedCtx;
@@ -124,9 +135,7 @@ async function resolveDashboardContext(dashboardId: string): Promise<AuthContext
 
 async function requireDashboardAuth(dashboardId: string): Promise<AuthContext> {
   const session = await requireAuth();
-  const ctx = await getAuthorizedDashboardContextOrNull(
-    DashboardFindByUserSchema.parse({ userId: session.user.id, dashboardId }),
-  );
+  const ctx = await getCachedAuthorizedContext(session.user.id, dashboardId);
   if (!ctx) throw new Error('Unauthorized');
   return ctx;
 }


### PR DESCRIPTION
This PR introduces request boundary cache for our server-action auth wrappers.

Switched all session/auth lookups to use these caches:
- `getAuthSession` now calls `getCachedSession()` instead of `getServerSession(authOptions)`.
- `tryGetAuthorizedContext` uses `getCachedAuthorizedContext(...)`.
- `resolveDemoDashboardContext` and `resolvePrivateDashboardContext` use `getCachedSession()` and `tryGetAuthorizedContext`.
- `requireDashboardAuth` now uses `getCachedAuthorizedContext(session.user.id, dashboardId)`.

This means, that all parallel calls to our wrapped actions share the same getServerSession and getAuthorizedDashboardContextOrNull results. This reduces the number of repeated auth hits per request with no real downside. For instance, the overview page does 10+ server actions in parallel during one RSC render - this currently results in 10+ distinct dashboard authentication queries. With these changes, a single query covers all actions in the RSC render.

This is a prerequisite for swapping our auth to a DB session strategy, to prevent additional repeated session queries when triggering actions in parallel.

Nothing is shared across requests. Ecah request still does its own fresh auth, so there's no staleness or cross-user leakage.