### PR TITLE
Adds locale cookie to reduce number of database queries for resolving…

### DIFF
--- a/dashboard/src/app/actions/userSettings.ts
+++ b/dashboard/src/app/actions/userSettings.ts
@@ -6,6 +6,7 @@ import { ChangePasswordRequest, ChangePasswordRequestSchema } from '@/entities/p
 import { withUserAuth } from '@/auth/auth-actions';
 import * as UserSettingsService from '@/services/userSettings';
 import { User } from 'next-auth';
+import { setLocaleCookie } from '@/constants/cookies';
 
 export const getUserSettingsAction = withUserAuth(async (user: User): Promise<UserSettings> => {
   return UserSettingsService.getUserSettings(user.id);
@@ -13,7 +14,13 @@ export const getUserSettingsAction = withUserAuth(async (user: User): Promise<Us
 
 export const updateUserSettingsAction = withUserAuth(
   async (user: User, updates: UserSettingsUpdate): Promise<UserSettings> => {
-    return UserSettingsService.updateUserSettings(user.id, updates);
+    const result = await UserSettingsService.updateUserSettings(user.id, updates);
+
+    if (updates.language) {
+      await setLocaleCookie(updates.language);
+    }
+
+    return result;
   },
 );
 

--- a/dashboard/src/constants/cookies.ts
+++ b/dashboard/src/constants/cookies.ts
@@ -1,0 +1,20 @@
+import { cookies } from 'next/headers';
+
+export const LOCALE_COOKIE_NAME = 'NEXT_LOCALE';
+
+const LOCALE_COOKIE_OPTIONS = {
+  httpOnly: false,
+  secure: process.env.NODE_ENV === 'production',
+  sameSite: 'lax' as const,
+  maxAge: 60 * 60 * 24 * 365, // 1 year
+  path: '/',
+};
+
+export async function setLocaleCookie(language: string): Promise<void> {
+  try {
+    const cookieStore = await cookies();
+    cookieStore.set(LOCALE_COOKIE_NAME, language, LOCALE_COOKIE_OPTIONS);
+  } catch {
+    // Cookies may not be available in all contexts
+  }
+}

--- a/dashboard/src/i18n/request.ts
+++ b/dashboard/src/i18n/request.ts
@@ -1,23 +1,21 @@
 import { SUPPORTED_LANGUAGES, SupportedLanguages } from '@/constants/i18n';
-import { authOptions } from '@/lib/auth';
-import { getServerSession } from 'next-auth/next';
 import { getRequestConfig } from 'next-intl/server';
+import { LOCALE_COOKIE_NAME } from '@/constants/cookies';
+import { cookies } from 'next/headers';
 
 export default getRequestConfig(async ({ requestLocale }) => {
   let locale = await requestLocale;
+
   if (!locale) {
     try {
-      const session = await getServerSession(authOptions);
-
-      if (session?.user.settings?.language) {
-        locale = session.user.settings.language;
-      }
-    } catch (error) {
-      console.error('Error fetching user settings from session:', error);
+      const cookieStore = await cookies();
+      locale = cookieStore.get(LOCALE_COOKIE_NAME)?.value;
+    } catch {
+      // Cookies may not be available in all contexts (e.g., during build)
     }
   }
 
-  if (SUPPORTED_LANGUAGES.includes(locale as SupportedLanguages) === false) {
+  if (!SUPPORTED_LANGUAGES.includes(locale as SupportedLanguages)) {
     locale = process.env.NEXT_PUBLIC_DEFAULT_LANGUAGE ?? 'en';
   }
 

--- a/dashboard/src/lib/auth.ts
+++ b/dashboard/src/lib/auth.ts
@@ -12,6 +12,7 @@ import { env } from '@/lib/env';
 import prisma from '@/lib/postgres';
 import { createDefaultUserSettings, getUserSettings } from '@/services/userSettings';
 import { createStarterSubscriptionForUser } from '@/services/subscription.service';
+import { setLocaleCookie } from '@/constants/cookies';
 
 export const authOptions: NextAuthOptions = {
   adapter: PrismaAdapter(prisma),
@@ -188,6 +189,10 @@ export const authOptions: NextAuthOptions = {
         session.user.termsAcceptedAt = token.termsAcceptedAt;
         session.user.termsAcceptedVersion = token.termsAcceptedVersion;
         session.user.changelogVersionSeen = token.changelogVersionSeen ?? 'v0';
+
+        if (session.user.settings?.language) {
+          await setLocaleCookie(session.user.settings.language);
+        }
       }
       return session;
     },


### PR DESCRIPTION
… locale

The PR introduces a locale cookie to get rid of getServerSession when resolving the locale request. This in preparation for DB strategy authentication, where getServerSession causes multiple queries to be executed in order to retrieve the session.

The cookie completely eliminates these queries while continously ensuring that users' preferred locale is respected on public pages.

Closes #498 