### PR TITLE
Removes deprecated queryfilters column from funnels table

### DIFF
--- a/dashboard/prisma/migrations/20251205124018_removes_deprecated_funnel_queryfilters_column/migration.sql
+++ b/dashboard/prisma/migrations/20251205124018_removes_deprecated_funnel_queryfilters_column/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `queryFilters` on the `Funnel` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Funnel" DROP COLUMN "queryFilters";

--- a/dashboard/prisma/schema.prisma
+++ b/dashboard/prisma/schema.prisma
@@ -170,7 +170,6 @@ model Funnel {
 
   name     String
   isStrict Boolean @default(true)
-  queryFilters Json? // Optional, will be removed in the future
 
   funnelSteps FunnelStep[]
 


### PR DESCRIPTION
This PR removes the queryFilters column from the Funnels table that were deprecated in #565 

Closes #580 