### PR TITLE
Fixed compare range labels showing wrong date range

### DIFF
--- a/dashboard/src/components/TimeRange/CompareRangePicker.tsx
+++ b/dashboard/src/components/TimeRange/CompareRangePicker.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState } from 'react';
 import { ChevronDownIcon, ScaleIcon } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
@@ -15,7 +15,6 @@ import { DateRangeSection } from '@/components/TimeRange/DateRangeSection';
 import { Switch } from '@/components/ui/switch';
 import { Separator } from '@/components/ui/separator';
 import { DisabledDemoTooltip } from '@/components/tooltip/DisabledDemoTooltip';
-import { getResolvedRanges } from '@/lib/ba-timerange';
 
 export function CompareRangePicker({ className = '' }: { className?: string }) {
   const [open, setOpen] = useState(false);
@@ -24,24 +23,7 @@ export function CompareRangePicker({ className = '' }: { className?: string }) {
   const ctx = useTimeRangeContext();
   const actions = useImmediateTimeRange();
 
-  const resolvedCompareDates = useMemo(() => {
-    if (ctx.compareMode === 'off') return undefined;
-
-    const resolved = getResolvedRanges(
-      ctx.interval,
-      ctx.compareMode,
-      ctx.timeZone,
-      ctx.startDate,
-      ctx.endDate,
-      ctx.granularity,
-      ctx.compareStartDate,
-      ctx.compareEndDate,
-      ctx.offset,
-      ctx.compareAlignWeekdays,
-    );
-
-    return resolved.compare;
-  }, [ctx]);
+  const resolvedCompareDates = ctx.compareMode === 'off' ? undefined : ctx.resolvedCompareRange;
 
   const label = () => {
     if (ctx.compareMode === 'off' || !resolvedCompareDates) return t('disabled');

--- a/dashboard/src/components/map/tooltip/MapPopupContent.tsx
+++ b/dashboard/src/components/map/tooltip/MapPopupContent.tsx
@@ -34,6 +34,9 @@ function MapPopupContentComponent({
 }: MapPopupContentProps) {
   if (!geoVisitor) return null;
 
+  const resolvedMain = timeRangeCtx.resolvedMainRange;
+  const resolvedCompare = timeRangeCtx.resolvedCompareRange;
+
   const percentageChange =
     geoVisitor.compareVisitors !== undefined
       ? geoVisitor.compareVisitors === 0 && geoVisitor.visitors > 0
@@ -101,19 +104,19 @@ function MapPopupContentComponent({
                 : formatPrimaryRangeLabel({
                     interval: timeRangeCtx.interval,
                     offset: timeRangeCtx.offset,
-                    startDate: timeRangeCtx.startDate,
-                    endDate: timeRangeCtx.endDate,
+                    startDate: resolvedMain.start,
+                    endDate: resolvedMain.end,
                     locale,
                   })
             }
-            tooltip={`${timeRangeCtx.startDate.toLocaleString()} - ${timeRangeCtx.endDate.toLocaleString()}`}
+            tooltip={`${resolvedMain.start.toLocaleString()} - ${resolvedMain.end.toLocaleString()}`}
             value={formatNumber(geoVisitor.visitors)}
           />
-          {timeRangeCtx.compareStartDate && timeRangeCtx.compareEndDate && (
+          {resolvedCompare && (
             <Row
               color='bg-chart-comparison'
               label={t('timeRange.previousPeriod')}
-              tooltip={`${timeRangeCtx.compareStartDate.toLocaleString()} - ${timeRangeCtx.compareEndDate.toLocaleString()}`}
+              tooltip={`${resolvedCompare.start.toLocaleString()} - ${resolvedCompare.end.toLocaleString()}`}
               value={formatNumber(geoVisitor.compareVisitors ?? 0)}
               muted
             />

--- a/dashboard/src/contexts/TimeRangeContextProvider.tsx
+++ b/dashboard/src/contexts/TimeRangeContextProvider.tsx
@@ -1,8 +1,9 @@
-import React, { Dispatch, SetStateAction, useCallback, useMemo, useEffect } from 'react';
+import React, { Dispatch, SetStateAction, useCallback, useMemo } from 'react';
 import { GranularityRangeValues } from '@/utils/granularityRanges';
 import { TimeRangeValue } from '@/utils/timeRanges';
 import { CompareMode } from '@/utils/compareRanges';
 import { BAFilterSearchParams } from '@/utils/filterSearchParams';
+import { getResolvedRanges, type TimeRangeResult } from '@/lib/ba-timerange';
 
 export type TimeRangeContextProps = {
   startDate: Date;
@@ -22,6 +23,10 @@ export type TimeRangeContextProps = {
   compareAlignWeekdays: boolean;
   setCompareAlignWeekdays: Dispatch<SetStateAction<boolean>>;
   timeZone: string;
+  resolvedRanges: TimeRangeResult;
+  resolvedMainRange: TimeRangeResult['main'];
+  resolvedCompareRange?: TimeRangeResult['compare'];
+  resolvedGranularity: TimeRangeResult['granularity'];
 };
 
 const TimeRangeContext = React.createContext<TimeRangeContextProps>({} as TimeRangeContextProps);
@@ -47,6 +52,34 @@ export function TimeRangeContextProvider({ children }: TimeRangeContextProviderP
   const [compareAlignWeekdays, setCompareAlignWeekdays] = React.useState<boolean>(false);
 
   const timeZone = React.useMemo(() => Intl.DateTimeFormat().resolvedOptions().timeZone, []);
+
+  const resolvedRanges = useMemo(
+    () =>
+      getResolvedRanges(
+        interval,
+        compareMode,
+        timeZone,
+        startDate,
+        endDate,
+        granularity,
+        compareStartDate,
+        compareEndDate,
+        offset,
+        compareAlignWeekdays,
+      ),
+    [
+      interval,
+      compareMode,
+      timeZone,
+      startDate,
+      endDate,
+      granularity,
+      compareStartDate,
+      compareEndDate,
+      offset,
+      compareAlignWeekdays,
+    ],
+  );
 
   const setPeriod = useCallback((newStartDate: Date, newEndDate: Date) => {
     setStartDate(newStartDate);
@@ -79,6 +112,10 @@ export function TimeRangeContextProvider({ children }: TimeRangeContextProviderP
         compareAlignWeekdays,
         setCompareAlignWeekdays,
         timeZone,
+        resolvedRanges,
+        resolvedMainRange: resolvedRanges.main,
+        resolvedCompareRange: resolvedRanges.compare,
+        resolvedGranularity: resolvedRanges.granularity,
       }}
     >
       {children}

--- a/dashboard/src/lib/ba-timerange.ts
+++ b/dashboard/src/lib/ba-timerange.ts
@@ -291,7 +291,7 @@ function getCompareRange(
   }
 }
 
-interface TimeRangeResult {
+export interface TimeRangeResult {
   main: {
     start: Date;
     end: Date;


### PR DESCRIPTION
The label for the compareRangePicker now shows the correct range. 

Closes #570 