### PR TITLE
Added range override for filter values query for funnel creation

### DIFF
--- a/dashboard/src/app/(protected)/dashboard/[dashboardId]/funnels/FunnelStepFilter.tsx
+++ b/dashboard/src/app/(protected)/dashboard/[dashboardId]/funnels/FunnelStepFilter.tsx
@@ -107,6 +107,7 @@ export function FunnelStepFilter({
         key={filter.column}
         className='grow'
         triggerClassName={cn(showValueEmptyError && 'border-destructive')}
+        useExtendedRange
       />
       <Button variant='ghost' className='cursor-pointer' onClick={requestRemoval} disabled={disableDeletion}>
         <Trash2 />

--- a/dashboard/src/components/filters/FilterValueSearch.tsx
+++ b/dashboard/src/components/filters/FilterValueSearch.tsx
@@ -9,6 +9,7 @@ type FilterValueSearchProps<TEntity> = {
   onFilterUpdate: Dispatch<QueryFilter & TEntity>;
   className?: string;
   triggerClassName?: string;
+  useExtendedRange?: boolean;
 };
 
 export function FilterValueSearch<TEntity>({
@@ -16,10 +17,11 @@ export function FilterValueSearch<TEntity>({
   onFilterUpdate,
   className,
   triggerClassName,
+  useExtendedRange,
 }: FilterValueSearchProps<TEntity>) {
   const t = useTranslations('components.filters.selector');
 
-  const { options, isLoading, setSearch, search, isDirty } = useQueryFilterSearch(filter);
+  const { options, isLoading, setSearch, search, isDirty } = useQueryFilterSearch(filter, { useExtendedRange });
 
   return (
     <Combobox


### PR DESCRIPTION
Adds overridable option for filter ranges used primarily for funnel creation to ensure that filter value suggestions includes at least 30 days of values.

Closes #586 