### PR TITLE
Adjusted link curvature, node width and colors

### DIFF
--- a/dashboard/src/app/(protected)/dashboard/[dashboardId]/user-journey/components/SankeyLink.tsx
+++ b/dashboard/src/app/(protected)/dashboard/[dashboardId]/user-journey/components/SankeyLink.tsx
@@ -18,7 +18,7 @@ export function SankeyLink({ link, isHighlighted, isMuted, onHover }: SankeyLink
   const y1 = link.targetY;
 
   // Curvature
-  const curvature = 0.5;
+  const curvature = 0.4;
   const cx0 = x0 + (x1 - x0) * curvature;
   const cx1 = x1 - (x1 - x0) * curvature;
 

--- a/dashboard/src/app/(protected)/dashboard/[dashboardId]/user-journey/constants.ts
+++ b/dashboard/src/app/(protected)/dashboard/[dashboardId]/user-journey/constants.ts
@@ -10,20 +10,14 @@ export const COLORS = {
     mutedStroke: 'var(--sankey-node-stroke-muted)',
   },
   link: {
-    stroke: '#6fa8ff88', // blue-ish
-    strokeMiddle: '#6fa8ff55', // gray-blue-ish
+    stroke: 'var(--sankey-link-stroke)',
+    strokeMiddle: 'var(--sankey-link-stroke-middle)',
 
-    highlightStroke: '#3f8cff',
-    highlightStrokeMiddle: '#3f8cffaa',
+    highlightStroke: 'var(--sankey-link-highlight)',
+    highlightStrokeMiddle: 'var(--sankey-link-highlight-middle)',
 
-    mutedStroke: '#6fa8ff66',
-    mutedStrokeMiddle: '#6fa8ff44',
-  },
-  label: {
-    text: '#334155', // Slate-700
-    subtext: '#64748b', // Slate-500
-    mutedText: '#94a3b8', // Slate-400
-    mutedSubtext: '#cbd5e1', // Slate-300
+    mutedStroke: 'var(--sankey-link-muted)',
+    mutedStrokeMiddle: 'var(--sankey-link-muted-middle)',
   },
   card: {
     bg: 'var(--sankey-card-bg)',
@@ -42,7 +36,7 @@ export const COLORS = {
 // ============================================
 export const LAYOUT = {
   padding: { top: 20, right: 20, bottom: 24, left: 20 },
-  nodeWidth: 16,
+  nodeWidth: 14,
   nodeRadius: 2,
   minNodeHeight: 6,
   compressionThreshold: 60,

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -64,6 +64,14 @@
   --sankey-node-fill-muted: rgba(107, 142, 245, 0.2);
   --sankey-node-stroke-muted: rgba(59, 130, 246, 0.2);
 
+  /* Sankey link colors */
+  --sankey-link-stroke: rgba(100, 116, 139, 0.45);
+  --sankey-link-stroke-middle: rgba(100, 116, 139, 0.32);
+  --sankey-link-highlight: rgba(59, 130, 246, 0.85);
+  --sankey-link-highlight-middle: rgba(59, 130, 246, 0.6);
+  --sankey-link-muted: rgba(100, 116, 139, 0.2);
+  --sankey-link-muted-middle: rgba(100, 116, 139, 0.12);
+
   /* Sankey node cards */
   --sankey-card-bg: rgba(255, 255, 255, 0.92);
   --sankey-card-bg-muted: rgba(241, 245, 249, 0.4);
@@ -154,6 +162,14 @@
   --sankey-node-stroke: #1d4ed8;
   --sankey-node-fill-muted: rgba(71, 102, 229, 0.2);
   --sankey-node-stroke-muted: rgba(29, 78, 216, 0.2);
+
+  /* Sankey link colors */
+  --sankey-link-stroke: rgba(148, 163, 184, 0.38);
+  --sankey-link-stroke-middle: rgba(148, 163, 184, 0.27);
+  --sankey-link-highlight: rgba(96, 165, 250, 0.87);
+  --sankey-link-highlight-middle: rgba(96, 165, 250, 0.67);
+  --sankey-link-muted: rgba(148, 163, 184, 0.19);
+  --sankey-link-muted-middle: rgba(148, 163, 184, 0.12);
 
   /* Sankey node cards */
   --sankey-card-bg: rgba(30, 41, 59, 0.85);


### PR DESCRIPTION
Minor adjustments to sankey diagram. The adjustments aims to reduce the chaos of the sankey diagram.

Before:
<img width="1353" height="1216" alt="{CC46EB6E-B640-41ED-9464-FA7695D76B8F}" src="https://github.com/user-attachments/assets/750ae8e3-4dcf-4b4f-b125-05343a22743e" />

After:
<img width="1437" height="1211" alt="{8BE56D07-04CB-4ABC-982F-AE402E5EAD95}" src="https://github.com/user-attachments/assets/6c081ca1-c8de-4da6-9311-b04c06e19ebe" />
