### PR TITLE
Removed plan-details from pricing documentation

### DIFF
--- a/docs/src/content/pricing/index.mdx
+++ b/docs/src/content/pricing/index.mdx
@@ -62,7 +62,7 @@ Read our [Installation Guide](/installation) to get started, or check out our [U
 
 ### Ready to Upgrade?
 
-- **[View Pricing](https://betterlytics.io/#pricing)** - See exact costs for your traffic
+- **[View Pricing](https://betterlytics.io/pricing)** - See exact costs for your traffic
 - **[Upgrade Guide](/pricing/upgrading)** - Step-by-step upgrade process
 - **[Managing Subscriptions](/pricing/managing-subscription)** - Learn how to manage your plan, view your invoices and more
 

--- a/docs/src/content/pricing/upgrading.mdx
+++ b/docs/src/content/pricing/upgrading.mdx
@@ -22,34 +22,6 @@ Before selecting a plan, review your current event usage:
   stats](/images/billing/subscription-overview.png)
 </div>
 
-### Choose the Right Plan
-
-<div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '2rem', marginBottom: '2rem', marginTop: '2rem' }}>
-
-<div>
-
-**Growth Plan** - Perfect if you need:
-
-- More than 10,000 events per month
-- Basic analytics features
-- 1 website dashboard
-- Standard support
-
-</div>
-
-<div>
-
-**Professional Plan** - Choose this if you need:
-
-- Everything in the Growth plan
-- Multiple website dashboards (up to 50)
-- Extended data retention (3+ years)
-- Priority support
-
-</div>
-
-</div>
-
 ## Step-by-Step Upgrade Process
 
 ### Step 1: Access the Billing Page
@@ -71,7 +43,7 @@ Before selecting a plan, review your current event usage:
 
 The pricing updates automatically as you adjust the slider.
 
-See our [Plan Overview](/pricing#plans-overview) page for the differences between the plans or our [Pricing](https://betterlytics.io/#pricing) page for the exact pricing.
+See our [pricing](https://betterlytics.io/pricing) page for exact pricing and the differences between the plans.
 
 ### Step 3: Complete Payment Setup
 


### PR DESCRIPTION
With the introduction of the dedicated pricing page with a plan-feature comparison table, we should no longer have plan details in the pricing docs. 

This PR simplifies the plan overview documentation to a more high-level perspective and corrects links.