### PR TITLE
Fixed OG API endpoint path

### DIFF
--- a/docs/src/app/[[...mdxPath]]/page.tsx
+++ b/docs/src/app/[[...mdxPath]]/page.tsx
@@ -1,5 +1,6 @@
 import { generateStaticParamsFor, importPage } from "nextra/pages";
 import { useMDXComponents as getMDXComponents } from "@/mdx-components";
+import { getAssetPath } from "@/lib/constants";
 
 export const generateStaticParams = generateStaticParamsFor("mdxPath");
 
@@ -11,8 +12,8 @@ export async function generateMetadata(props: {
 
   const canonicalPath =
     Array.isArray(params.mdxPath) && params.mdxPath.length > 0
-      ? `/docs/${params.mdxPath.join("/")}`
-      : "/docs";
+      ? getAssetPath(`/${params.mdxPath.join("/")}`)
+      : getAssetPath("/");
 
   const category =
     Array.isArray(params.mdxPath) && params.mdxPath.length > 0
@@ -33,7 +34,7 @@ export async function generateMetadata(props: {
     ogImageParams.set("description", metadata.description);
   }
 
-  const ogImageUrl = `/docs/api/og?${ogImageParams.toString()}`;
+  const ogImageUrl = getAssetPath(`/api/og?${ogImageParams.toString()}`);
 
   return {
     ...metadata,


### PR DESCRIPTION
Open-graph images were served at /api instead of /docs/api