### PR TITLE
Adjusts monitoring limit

### DIFF
--- a/dashboard/messages/da.json
+++ b/dashboard/messages/da.json
@@ -1476,7 +1476,7 @@
       "uptimeMonitoring": {
         "name": "Oppetidsovervågning",
         "values": {
-          "5": "5 overvågninger",
+          "1": "1 overvågning",
           "50": "50 overvågninger",
           "unlimited": "Ubegrænset overvågning"
         }

--- a/dashboard/messages/en.json
+++ b/dashboard/messages/en.json
@@ -1473,7 +1473,7 @@
       "uptimeMonitoring": {
         "name": "Uptime monitoring",
         "values": {
-          "5": "5 monitors",
+          "1": "1 monitor",
           "50": "50 monitors",
           "unlimited": "Unlimited monitors"
         }

--- a/dashboard/messages/it.json
+++ b/dashboard/messages/it.json
@@ -1484,7 +1484,7 @@
       "uptimeMonitoring": {
         "name": "Monitoraggio uptime",
         "values": {
-          "5": "5 monitor",
+          "1": "1 monitor",
           "50": "50 monitor",
           "unlimited": "Monitor illimitati"
         }

--- a/dashboard/src/app/[locale]/(public)/pricing/FeatureComparisonSection.tsx
+++ b/dashboard/src/app/[locale]/(public)/pricing/FeatureComparisonSection.tsx
@@ -43,7 +43,7 @@ const FEATURE_CATEGORIES: FeatureCategory[] = [
   {
     key: 'observability',
     features: [
-      { key: 'uptimeMonitoring', growth: '5', professional: '50', enterprise: 'unlimited' },
+      { key: 'uptimeMonitoring', growth: '1', professional: '50', enterprise: 'unlimited' },
       { key: 'checkInterval', growth: '5min', professional: '1min', enterprise: '1min' },
       { key: 'sslMonitoring', growth: true, professional: true, enterprise: true },
       { key: 'customHttpMethods', growth: false, professional: true, enterprise: true },

--- a/dashboard/src/lib/billing/capabilities.ts
+++ b/dashboard/src/lib/billing/capabilities.ts
@@ -21,7 +21,7 @@ export const PLAN_CAPABILITIES: Record<TierName, PlanCapabilities> = {
   growth: {
     dashboards: { maxDashboards: 2 },
     monitoring: {
-      maxMonitors: 5,
+      maxMonitors: 1,
       minIntervalSeconds: 300,
       httpMethodConfigurable: false,
       customStatusCodes: false,


### PR DESCRIPTION
Adjusts monitoring limit from 5 to 1 for growth plan. This allows users to create 1 monitor per dashboard 😄 