### PR TITLE
Fixed overlapping backoff level interval display

### DIFF
--- a/dashboard/src/app/(protected)/dashboard/[dashboardId]/(dashboard)/monitoring/MonitorList.tsx
+++ b/dashboard/src/app/(protected)/dashboard/[dashboardId]/(dashboard)/monitoring/MonitorList.tsx
@@ -96,6 +96,7 @@ export function MonitorList({ monitors }: MonitorListProps) {
                     {getStatusDurationText({
                       currentStateSince: monitor.currentStateSince,
                       isUp: statusPresentation.label === 'Up',
+                      t,
                     }) || (!hasData ? t('list.noData') : '')}
                   </span>
                 </div>
@@ -125,6 +126,7 @@ export function MonitorList({ monitors }: MonitorListProps) {
                           {getStatusDurationText({
                             currentStateSince: monitor.currentStateSince,
                             isUp: statusPresentation.label === 'Up',
+                            t,
                           })}
                         </span>
                       )}
@@ -244,10 +246,10 @@ function IntervalDisplay({
 type StatusDurationTextParams = {
   currentStateSince: string | null | undefined;
   isUp: boolean;
+  t: ReturnType<typeof useTranslations<'monitoringPage'>>;
 };
 
-function getStatusDurationText({ currentStateSince, isUp }: StatusDurationTextParams): string {
-  const t = useTranslations('monitoringPage');
+function getStatusDurationText({ currentStateSince, isUp, t }: StatusDurationTextParams): string {
   if (!currentStateSince) return '';
   const prefix = isUp ? t('list.upPrefix') : t('list.downPrefix');
   return `${prefix} ${formatElapsedTime(new Date(currentStateSince))}`;


### PR DESCRIPTION
The backoff warning badge is now consolidated with the interval display label, where the interval display label turns into a backoff warning when backoff applies:

<img width="400" height="267" alt="{AA1D6E42-9FD8-4E48-BABB-EF7FCED8E9DB}" src="https://github.com/user-attachments/assets/94845518-4835-48a9-a584-348fc2a8eb0c" />

This fixes the overlapping issues we had 😄 

Closes #703 