### PR TITLE
Fixed active variant not displaying on initial render

### DIFF
--- a/dashboard/src/components/integration/VariantTabs.tsx
+++ b/dashboard/src/components/integration/VariantTabs.tsx
@@ -1,11 +1,20 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { UnderlineTabs, UnderlineTabsList, UnderlineTabsTrigger } from '../ui/UnderlineTabs';
 import type { FrameworkVariant } from './frameworkCodes';
 
 export function useVariantTabs(variants: FrameworkVariant[], defaultVariant?: string) {
   const [activeVariantId, setActiveVariantId] = useState(defaultVariant || variants[0]?.id);
+
+  useEffect(() => {
+    if (variants.length > 0) {
+      const activeVariantExists = variants.some((v) => v.id === activeVariantId);
+      if (!activeVariantExists) {
+        setActiveVariantId(defaultVariant || variants[0]?.id);
+      }
+    }
+  }, [variants, activeVariantId, defaultVariant]);
 
   const activeVariant = variants.find((v) => v.id === activeVariantId) || variants[0];
 


### PR DESCRIPTION
Fixed an issue, where the first variant instruction in the onboarding framework integration did not appear as selected, even though it is

<img width="368" height="69" alt="{3EBF7718-8887-4954-A57F-BE8C7DBA711F}" src="https://github.com/user-attachments/assets/5388ff96-3ef4-4e35-a44e-8e11a12257fa" />
