### PR TITLE
Added applied filter count to filter selector trigger

### DIFF
--- a/dashboard/src/components/filters/QueryFiltersSelector.tsx
+++ b/dashboard/src/components/filters/QueryFiltersSelector.tsx
@@ -79,6 +79,8 @@ export default function QueryFiltersSelector() {
 
   const { data: isSavedFiltersLimitReached } = useSavedFiltersLimitReached();
 
+  const activeFilterCount = filterEmptyQueryFilters(contextQueryFilters).length;
+
   const content = (
     <>
       {queryFilters.length > 0 || isFiltersModified ? (
@@ -216,7 +218,10 @@ export default function QueryFiltersSelector() {
           >
             <div className='flex items-center gap-2'>
               <FilterIcon className='h-4 w-4' />
-              <span>{t('selector.triggerLabel')}</span>
+              <span>
+                {t('selector.triggerLabel')}
+                {activeFilterCount > 0 && ` (${activeFilterCount})`}
+              </span>
             </div>
             <ChevronDownIcon className={`ml-2 h-4 w-4 shrink-0 opacity-50`} />
           </Button>
@@ -243,7 +248,10 @@ export default function QueryFiltersSelector() {
         >
           <div className='flex items-center gap-2'>
             <FilterIcon className='h-4 w-4' />
-            <span>{t('selector.triggerLabel')}</span>
+            <span>
+              {t('selector.triggerLabel')}
+              {activeFilterCount > 0 && ` (${activeFilterCount})`}
+            </span>
           </div>
           <ChevronDownIcon className={`ml-2 h-4 w-4 shrink-0 opacity-50`} />
         </Button>


### PR DESCRIPTION
An user did not initially notice that he had accidentally applied filters (by clicking on table entries) and he couldn't figure out why data was not showing.

This PR adds an "applied filter count" to the filter selector trigger in an attempt to make it slightly more visible that filters are selected.