### PR TITLE
Unknown locale safeguards

### DIFF
--- a/dashboard/src/app/[locale]/layout.tsx
+++ b/dashboard/src/app/[locale]/layout.tsx
@@ -1,0 +1,17 @@
+import { hasLocale } from 'next-intl';
+import { notFound } from 'next/navigation';
+import { routing } from '@/i18n/routing';
+
+type Props = {
+  children: React.ReactNode;
+  params: Promise<{ locale: string }>;
+};
+
+export default async function LocaleLayout({ children, params }: Props) {
+  const { locale } = await params;
+  if (!hasLocale(routing.locales, locale)) {
+    notFound();
+  }
+
+  return children;
+}

--- a/dashboard/src/i18n/request.ts
+++ b/dashboard/src/i18n/request.ts
@@ -1,23 +1,23 @@
-import { SUPPORTED_LANGUAGES, SupportedLanguages } from '@/constants/i18n';
+import { SupportedLanguages } from '@/constants/i18n';
 import { getRequestConfig } from 'next-intl/server';
+import { hasLocale } from 'next-intl';
 import { LOCALE_COOKIE_NAME } from '@/constants/cookies';
 import { cookies } from 'next/headers';
+import { routing } from '@/i18n/routing';
 
 export default getRequestConfig(async ({ requestLocale }) => {
-  let locale = await requestLocale;
+  let requested = await requestLocale;
 
-  if (!locale) {
+  if (!requested) {
     try {
       const cookieStore = await cookies();
-      locale = cookieStore.get(LOCALE_COOKIE_NAME)?.value;
+      requested = cookieStore.get(LOCALE_COOKIE_NAME)?.value;
     } catch {
       // Cookies may not be available in all contexts (e.g., during build)
     }
   }
 
-  if (!SUPPORTED_LANGUAGES.includes(locale as SupportedLanguages)) {
-    locale = process.env.NEXT_PUBLIC_DEFAULT_LANGUAGE ?? 'en';
-  }
+  const locale = hasLocale(routing.locales, requested) ? requested : routing.defaultLocale;
 
   return {
     locale: locale as SupportedLanguages,

--- a/dashboard/src/lib/seo.ts
+++ b/dashboard/src/lib/seo.ts
@@ -54,7 +54,9 @@ export function generateSEO(
     },
     openGraph: {
       type: 'website',
-      locale: LANGUAGE_METADATA[currentLocale as SupportedLanguages].ogLocale,
+      locale:
+        LANGUAGE_METADATA[currentLocale as SupportedLanguages]?.ogLocale ??
+        LANGUAGE_METADATA[defaultLocale].ogLocale,
       url: fullUrl,
       title: title,
       description,


### PR DESCRIPTION
This PR addresses the “unknown ogLocale” issue observed in the logs. It leverages the native hasLocale utility from next-intl to validate locales and adds a locale check in the root locale layout, in line with the approach recommended in the next-intl documentation.