### PR TITLE
Added fallback for null & removed 0% fallback for comparison when val…

### DIFF
--- a/dashboard/src/components/TableTrendIndicator.tsx
+++ b/dashboard/src/components/TableTrendIndicator.tsx
@@ -37,8 +37,6 @@ export function TableTrendIndicator({
     return (
       <div className='flex items-center gap-1 text-xs opacity-85'>
         <span className='text-muted-foreground'>vs {formatter(comparedData)}</span>
-        <Minus className='h-3 w-3' />
-        <span>0%</span>
       </div>
     );
   }

--- a/dashboard/src/presenters/toDataTable.ts
+++ b/dashboard/src/presenters/toDataTable.ts
@@ -19,7 +19,16 @@ function rowChange<D extends Record<string, unknown>>({ row, compareRow, enabled
       };
     }
 
-    const compareValue = (compareRow?.[key] as number | undefined) || 0;
+    const rawCompareValue = compareRow?.[key];
+
+    if (compareRow && rawCompareValue === null) {
+      return {
+        ...acc,
+        [key]: undefined,
+      };
+    }
+
+    const compareValue = (rawCompareValue as number | undefined) ?? 0;
     const difference = value - compareValue;
 
     return {


### PR DESCRIPTION
…ues are equal

This PR should fix the following cases:

1) Scroll depth always shows 0% for comparison ranges where scroll depth data does not exist:
<img width="197" height="799" alt="{BEE8F467-53DE-4D5E-A202-59E9754A6391}" src="https://github.com/user-attachments/assets/955adc6a-ee28-42e2-a9d8-c7d119da6662" />

2) The comparison indicator weirdly shows "- 0%" when values are equal

<img width="138" height="49" alt="{3B32AAAC-0B7D-4992-8A44-3DD049C44B78}" src="https://github.com/user-attachments/assets/52cf72f1-e6b0-4de4-a6e2-ffde0c53b4fa" />
