### PR TITLE
Move topbar loader to top of page

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -305,12 +305,6 @@
   }
 }
 
-@media (min-width: 768px) {
-  #nprogress .bar {
-    top: var(--topbar-height) !important;
-  }
-}
-
 [data-slot='sheet-content'] > button.absolute.top-4.right-4 {
   cursor: pointer;
 }


### PR DESCRIPTION
Our new integrated sign-up / login / boarding pages causes issues with the TopBarLoader placement below the topbar, as the topbar isnt visible on those pages.

To resolve this, I have standardized the topbar to be above the topbar on all pages. 

## See bug
![msedge_895wez08Gl](https://github.com/user-attachments/assets/86ea9187-ce2d-4f8a-94c6-e37aec4a71c7)