### PR TITLE
790 infinite post request loop to dynamic routes with unresolved locale placeholders

### DIFF
--- a/dashboard/src/middleware.ts
+++ b/dashboard/src/middleware.ts
@@ -1,7 +1,17 @@
 import createMiddleware from 'next-intl/middleware';
 import { routing } from '@/i18n/routing';
+import type { NextRequest } from 'next/server';
 
-export default createMiddleware(routing);
+const intlMiddleware = createMiddleware(routing);
+
+export function middleware(request: NextRequest) {
+  if (request.method === 'POST' && request.url.includes('[locale]')) {
+    console.error('[next-intl loop detected]', request.url);
+    return new Response('Bad request', { status: 400 });
+  }
+
+  return intlMiddleware(request);
+}
 
 export const config = {
   matcher: ['/((?!api|_next|.*\\..*|dashboard|dashboards|billing).*)'],


### PR DESCRIPTION
Adds a middleware guard to break an infinite POST request loop that causes out-of-memory crashes in production. It intercepts POST requests containing the literal string `[locale]` in the URL (which should never occur in legitimate traffic) and returns a 400 before the loop can spiral. Logs occurrences for monitoring.

The middleware matcher excludes `/dashboard`, `/dashboards`, and `/billing` routes, so this guard only covers public-facing routes (e.g. `[locale]/` `[locale]/share/` and `[locale]/onboarding/`). We've only observed the loop on `/[locale]/share/` and `/[locale]/onboarding/` routes so far. If it occurs on excluded routes, the matcher will need to be expanded with the next-intl middleware conditionally applied.

Closes #790