### PR TITLE
Update analytics.js to handle non-standard schemas (capacitor, tauri e.g.)

### DIFF
--- a/static/analytics.js
+++ b/static/analytics.js
@@ -20,7 +20,7 @@
     script
       .getAttribute("data-dynamic-urls")
       ?.split(",")
-      .filter(function (s) { return s.trim(); })
+      .filter(Boolean)
       .map(function (p) {
         p = p.trim();
         return {


### PR DESCRIPTION
Currently, our `analytics.js` script wont work for non-standard-schemes (such as `capacitor://`, which is the iOS path for capacitor iOS webpgaes). This is important, as it prevents any events from being received from many platform's native apps. 

The bug is quite deep but let me try to explain whats actually going on..

1. @betterlytics/tracker init() always sets "data-dynamic-urls" attributes, even when empty 
```
  i.setAttribute("data-dynamic-urls", t.dynamicUrls.join(","));
```

2. In js then `"".split(",")  => [""]`, NOT an empty array

3. This causes the Regex to match ANY url pathname: 
``` 
[""].map(function(p) {
    p = p.trim();
    return {
      original: "",
      regex: new RegExp("^" + "") // catch all /^/
    };
  })
```

4. `normalize()` constructs URL from `urlObj.origin`, which is `null` for non-standard schemas (capacitor://, flubber:// e.g.) 
```
  new URL("https://example.com/path").origin     // "https://example.com"
  new URL("https://localhost/path").origin            // "https://localhost"
  new URL("capacitor://localhost/path").origin     // "null"
```

5. Backend rejects since scheme is null
```
Url::parse("null/conversation") => Rejected event
```

**IMPORTANT NOTES:** 
* It will obviously still be required to turn off domain-validation before non-standard schemas work. I have been considering updating our docs and landing page about support for native devices, as this is a very common use-case and something most of the other analytics platforms doesnt support out of the box.
* I noticed this bug initially, since we use selfhosted betterlytics on a work capacitor webapp project built for both iOS and Android. I have since confirmed that this exact change resolved the issue for us in capacitor, but the fix  should resolve it for all platforms (tauri e.g.).