### PR TITLE
Add dot-grid animation to landing page's framework compatibility carousel

### DIFF
--- a/dashboard/src/app/[locale]/(public)/(landing)/components/FrameworkCard.tsx
+++ b/dashboard/src/app/[locale]/(public)/(landing)/components/FrameworkCard.tsx
@@ -2,22 +2,21 @@
 
 import { useState } from 'react';
 import Image from 'next/image';
-import { useTheme } from 'next-themes';
 import { DotGrid } from '@/components/animations/DotGrid';
 
-type Framework = {
+type FrameworkCardProps = {
   name: string;
   logo: string;
-  brandColor: string | { light: string; dark: string };
+  color: string;
 };
 
-export function FrameworkCard({ framework }: { framework: Framework }) {
+export function FrameworkCard({ name, logo, color }: FrameworkCardProps) {
   const [isActive, setIsActive] = useState(false);
-  const { resolvedTheme } = useTheme();
 
   return (
     <div
       tabIndex={0}
+      aria-label={name}
       className="group relative flex min-w-[120px] flex-shrink-0 flex-col items-center justify-center rounded-lg border border-transparent p-6 transition-[border-color,background-color] duration-300 hover:border-border hover:bg-card focus-within:border-border focus-within:bg-card"
       onMouseEnter={() => setIsActive(true)}
       onMouseLeave={() => setIsActive(false)}
@@ -25,13 +24,7 @@ export function FrameworkCard({ framework }: { framework: Framework }) {
       onBlur={() => setIsActive(false)}
     >
       <DotGrid
-        color={
-          typeof framework.brandColor === 'string'
-            ? framework.brandColor
-            : resolvedTheme === 'dark'
-              ? framework.brandColor.dark
-              : framework.brandColor.light
-        }
+        color={color}
         active={isActive}
         gap={12}
         dotRadius={1}
@@ -46,8 +39,8 @@ export function FrameworkCard({ framework }: { framework: Framework }) {
           style={{ transform: isActive ? 'translateY(0px)' : 'translateY(8px)' }}
         >
           <Image
-            src={framework.logo}
-            alt={`${framework.name} logo`}
+            src={logo}
+            alt={`${name} logo`}
             width={32}
             height={32}
             className="h-8 w-8"
@@ -61,7 +54,7 @@ export function FrameworkCard({ framework }: { framework: Framework }) {
             transitionDelay: isActive ? '75ms' : '0ms',
           }}
         >
-          {framework.name}
+          {name}
         </span>
       </div>
     </div>

--- a/dashboard/src/app/[locale]/(public)/(landing)/components/FrameworkCard.tsx
+++ b/dashboard/src/app/[locale]/(public)/(landing)/components/FrameworkCard.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useState } from 'react';
+import Image from 'next/image';
+import { useTheme } from 'next-themes';
+import { DotGrid } from '@/components/animations/DotGrid';
+
+type Framework = {
+  name: string;
+  logo: string;
+  brandColor: string | { light: string; dark: string };
+};
+
+export function FrameworkCard({ framework }: { framework: Framework }) {
+  const [isActive, setIsActive] = useState(false);
+  const { resolvedTheme } = useTheme();
+  const dotColor =
+    typeof framework.brandColor === 'string'
+      ? framework.brandColor
+      : resolvedTheme === 'dark'
+        ? framework.brandColor.dark
+        : framework.brandColor.light;
+
+  return (
+    <div
+      className="group relative flex min-w-[120px] flex-shrink-0 flex-col items-center justify-center rounded-lg border border-transparent p-6 transition-[border-color,background-color] duration-300 hover:border-border hover:bg-card focus-within:border-border focus-within:bg-card"
+      onMouseEnter={() => setIsActive(true)}
+      onMouseLeave={() => setIsActive(false)}
+      onFocus={() => setIsActive(true)}
+      onBlur={() => setIsActive(false)}
+    >
+      {/* Layer 1: Dot grid canvas */}
+      <DotGrid
+        color={dotColor}
+        active={isActive}
+        gap={12}
+        dotRadius={1}
+        className="absolute inset-0 overflow-hidden rounded-lg"
+      />
+
+      {/* Layer 2: Gradient overlay to keep logo readable */}
+      <div
+        className="pointer-events-none absolute inset-0 rounded-lg bg-gradient-to-t to-transparent to-[70%] opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+        style={{ '--tw-gradient-from': 'var(--dot-grid-overlay)' } as React.CSSProperties}
+      />
+
+      {/* Layer 3: Logo + label */}
+      <div className="relative flex flex-col items-center">
+        <div
+          className="transition-transform duration-300 ease-out"
+          style={{ transform: isActive ? 'translateY(0px)' : 'translateY(8px)' }}
+        >
+          <Image
+            src={framework.logo}
+            alt={`${framework.name} logo`}
+            width={32}
+            height={32}
+            className="h-8 w-8"
+          />
+        </div>
+
+        <span
+          className="mt-2 text-center text-sm font-medium transition-opacity duration-300"
+          style={{
+            opacity: isActive ? 1 : 0,
+            transitionDelay: isActive ? '75ms' : '0ms',
+          }}
+        >
+          {framework.name}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/app/[locale]/(public)/(landing)/components/FrameworkCard.tsx
+++ b/dashboard/src/app/[locale]/(public)/(landing)/components/FrameworkCard.tsx
@@ -14,37 +14,32 @@ type Framework = {
 export function FrameworkCard({ framework }: { framework: Framework }) {
   const [isActive, setIsActive] = useState(false);
   const { resolvedTheme } = useTheme();
-  const dotColor =
-    typeof framework.brandColor === 'string'
-      ? framework.brandColor
-      : resolvedTheme === 'dark'
-        ? framework.brandColor.dark
-        : framework.brandColor.light;
 
   return (
     <div
+      tabIndex={0}
       className="group relative flex min-w-[120px] flex-shrink-0 flex-col items-center justify-center rounded-lg border border-transparent p-6 transition-[border-color,background-color] duration-300 hover:border-border hover:bg-card focus-within:border-border focus-within:bg-card"
       onMouseEnter={() => setIsActive(true)}
       onMouseLeave={() => setIsActive(false)}
       onFocus={() => setIsActive(true)}
       onBlur={() => setIsActive(false)}
     >
-      {/* Layer 1: Dot grid canvas */}
       <DotGrid
-        color={dotColor}
+        color={
+          typeof framework.brandColor === 'string'
+            ? framework.brandColor
+            : resolvedTheme === 'dark'
+              ? framework.brandColor.dark
+              : framework.brandColor.light
+        }
         active={isActive}
         gap={12}
         dotRadius={1}
         className="absolute inset-0 overflow-hidden rounded-lg"
       />
 
-      {/* Layer 2: Gradient overlay to keep logo readable */}
-      <div
-        className="pointer-events-none absolute inset-0 rounded-lg bg-gradient-to-t to-transparent to-[70%] opacity-0 transition-opacity duration-300 group-hover:opacity-100"
-        style={{ '--tw-gradient-from': 'var(--dot-grid-overlay)' } as React.CSSProperties}
-      />
+      <div className="pointer-events-none absolute inset-0 rounded-lg bg-gradient-to-t from-[--dot-grid-overlay] to-transparent to-[70%] opacity-0 transition-opacity duration-300 group-hover:opacity-100 group-focus-within:opacity-100" />
 
-      {/* Layer 3: Logo + label */}
       <div className="relative flex flex-col items-center">
         <div
           className="transition-transform duration-300 ease-out"

--- a/dashboard/src/app/[locale]/(public)/(landing)/components/FrameworkCarousel.tsx
+++ b/dashboard/src/app/[locale]/(public)/(landing)/components/FrameworkCarousel.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useTheme } from 'next-themes';
+import { FrameworkCard } from './FrameworkCard';
+
+type Framework = {
+  name: string;
+  logo: string;
+  brandColor: string | { light: string; dark: string };
+};
+
+const frameworks: Framework[] = [
+  { name: 'Next.js', logo: '/framework-logos/nextjs-icon.svg', brandColor: { light: '#4a4a4a', dark: '#ffffff' } },
+  { name: 'Svelte', logo: '/framework-logos/svelte-icon.svg', brandColor: '#FF3E00' },
+  { name: 'Vue.js', logo: '/framework-logos/vue-icon.svg', brandColor: '#4FC08D' },
+  { name: 'GTM', logo: '/framework-logos/gtm-icon.svg', brandColor: '#4285F4' },
+  { name: 'Laravel', logo: '/framework-logos/laravel-icon.svg', brandColor: '#FF2D20' },
+  { name: 'Shopify', logo: '/framework-logos/shopify-icon.svg', brandColor: '#96BF48' },
+  { name: 'Webflow', logo: '/framework-logos/webflow-icon.svg', brandColor: '#4353FF' },
+  { name: 'Wix', logo: '/framework-logos/wix-icon.svg', brandColor: '#FAAD4D' },
+  { name: 'Nuxt.js', logo: '/framework-logos/nuxtjs-icon.svg', brandColor: '#00DC82' },
+  { name: 'Angular', logo: '/framework-logos/angular-icon.svg', brandColor: '#DD0031' },
+  { name: 'Solid.js', logo: '/framework-logos/solidjs-icon.svg', brandColor: '#4F88C6' },
+  { name: 'Gatsby', logo: '/framework-logos/gatsby-icon.svg', brandColor: '#663399' },
+  { name: 'React', logo: '/framework-logos/react-icon.svg', brandColor: '#61DAFB' },
+  { name: 'Astro', logo: '/framework-logos/astro-icon.svg', brandColor: '#FF5D01' },
+  { name: 'WordPress', logo: '/framework-logos/wordpress-icon.svg', brandColor: '#21759B' },
+  {
+    name: 'Squarespace',
+    logo: '/framework-logos/squarespace-icon.svg',
+    brandColor: { light: '#4a4a4a', dark: '#ffffff' },
+  },
+  { name: 'Remix', logo: '/framework-logos/remix-icon.svg', brandColor: '#3992FF' },
+];
+
+function FrameworkList({ resolvedTheme }: { resolvedTheme: string | undefined }) {
+  return frameworks.map((fw) => (
+    <FrameworkCard
+      key={fw.name}
+      name={fw.name}
+      logo={fw.logo}
+      color={
+        typeof fw.brandColor === 'string'
+          ? fw.brandColor
+          : resolvedTheme === 'dark'
+            ? fw.brandColor.dark
+            : fw.brandColor.light
+      }
+    />
+  ));
+}
+
+export function FrameworkCarousel() {
+  const { resolvedTheme } = useTheme();
+
+  return (
+    <div className='flex w-max animate-[scroll_20s_linear_infinite] gap-3 will-change-transform focus-within:[animation-play-state:paused] hover:[animation-play-state:paused] sm:gap-6 lg:animate-[scroll_40s_linear_infinite] lg:gap-8'>
+      <FrameworkList resolvedTheme={resolvedTheme} />
+      <FrameworkList resolvedTheme={resolvedTheme} />
+    </div>
+  );
+}

--- a/dashboard/src/app/[locale]/(public)/(landing)/components/FrameworkCarousel.tsx
+++ b/dashboard/src/app/[locale]/(public)/(landing)/components/FrameworkCarousel.tsx
@@ -54,9 +54,13 @@ export function FrameworkCarousel() {
   const { resolvedTheme } = useTheme();
 
   return (
-    <div className='flex w-max animate-[scroll_20s_linear_infinite] gap-3 will-change-transform focus-within:[animation-play-state:paused] hover:[animation-play-state:paused] sm:gap-6 lg:animate-[scroll_40s_linear_infinite] lg:gap-8'>
-      <FrameworkList resolvedTheme={resolvedTheme} />
-      <FrameworkList resolvedTheme={resolvedTheme} />
+    <div className='relative overflow-hidden'>
+      <div className='flex w-max animate-[scroll_20s_linear_infinite] gap-3 will-change-transform focus-within:[animation-play-state:paused] hover:[animation-play-state:paused] sm:gap-6 lg:animate-[scroll_40s_linear_infinite] lg:gap-8'>
+        <FrameworkList resolvedTheme={resolvedTheme} />
+        <FrameworkList resolvedTheme={resolvedTheme} />
+      </div>
+      <div className='from-background pointer-events-none absolute top-0 left-0 z-10 h-full w-32 bg-gradient-to-r to-transparent' />
+      <div className='from-background pointer-events-none absolute top-0 right-0 z-10 h-full w-32 bg-gradient-to-l to-transparent' />
     </div>
   );
 }

--- a/dashboard/src/app/[locale]/(public)/(landing)/components/frameworkCompatibility.tsx
+++ b/dashboard/src/app/[locale]/(public)/(landing)/components/frameworkCompatibility.tsx
@@ -1,7 +1,6 @@
 import { getTranslations } from 'next-intl/server';
 import { FrameworkCard } from './FrameworkCard';
 
-// Ordered to spread brand colors evenly — no two similar hues adjacent
 const frameworks = [
   { name: 'Next.js', logo: '/framework-logos/nextjs-icon.svg', brandColor: { light: '#4a4a4a', dark: '#ffffff' } },
   { name: 'Svelte', logo: '/framework-logos/svelte-icon.svg', brandColor: '#FF3E00' },
@@ -33,7 +32,7 @@ export async function FrameworkCompatibility() {
         </div>
 
         <div className='relative overflow-hidden'>
-          <div className='flex w-max animate-[scroll_20s_linear_infinite] gap-3 will-change-transform hover:[animation-play-state:paused] sm:gap-6 lg:animate-[scroll_40s_linear_infinite] lg:gap-8'>
+          <div className='flex w-max animate-[scroll_20s_linear_infinite] gap-3 will-change-transform hover:[animation-play-state:paused] focus-within:[animation-play-state:paused] sm:gap-6 lg:animate-[scroll_40s_linear_infinite] lg:gap-8'>
             {frameworks.map((framework) => (
               <FrameworkCard key={`first-${framework.name}`} framework={framework} />
             ))}

--- a/dashboard/src/app/[locale]/(public)/(landing)/components/frameworkCompatibility.tsx
+++ b/dashboard/src/app/[locale]/(public)/(landing)/components/frameworkCompatibility.tsx
@@ -10,14 +10,7 @@ export async function FrameworkCompatibility() {
           <h2 className='mb-4 text-2xl font-bold'>{t('title')}</h2>
           <p className='text-muted-foreground'>{t('subtitle')}</p>
         </div>
-
-        <div className='relative overflow-hidden'>
-          <FrameworkCarousel />
-
-          <div className='from-background pointer-events-none absolute top-0 left-0 z-10 h-full w-32 bg-gradient-to-r to-transparent' />
-          <div className='from-background pointer-events-none absolute top-0 right-0 z-10 h-full w-32 bg-gradient-to-l to-transparent' />
-        </div>
-
+        <FrameworkCarousel />
         <div className='mt-8 text-center'>
           <p className='text-muted-foreground text-sm'>{t('footer')}</p>
         </div>

--- a/dashboard/src/app/[locale]/(public)/(landing)/components/frameworkCompatibility.tsx
+++ b/dashboard/src/app/[locale]/(public)/(landing)/components/frameworkCompatibility.tsx
@@ -1,24 +1,25 @@
-import Image from 'next/image';
 import { getTranslations } from 'next-intl/server';
+import { FrameworkCard } from './FrameworkCard';
 
+// Ordered to spread brand colors evenly — no two similar hues adjacent
 const frameworks = [
-  { name: 'Next.js', logo: '/framework-logos/nextjs-icon.svg' },
-  { name: 'React', logo: '/framework-logos/react-icon.svg' },
-  { name: 'Vue.js', logo: '/framework-logos/vue-icon.svg' },
-  { name: 'Angular', logo: '/framework-logos/angular-icon.svg' },
-  { name: 'Svelte', logo: '/framework-logos/svelte-icon.svg' },
-  { name: 'Nuxt.js', logo: '/framework-logos/nuxtjs-icon.svg' },
-  { name: 'Gatsby', logo: '/framework-logos/gatsby-icon.svg' },
-  { name: 'Laravel', logo: '/framework-logos/laravel-icon.svg' },
-  { name: 'WordPress', logo: '/framework-logos/wordpress-icon.svg' },
-  { name: 'Shopify', logo: '/framework-logos/shopify-icon.svg' },
-  { name: 'GTM', logo: '/framework-logos/gtm-icon.svg' },
-  { name: 'Webflow', logo: '/framework-logos/webflow-icon.svg' },
-  { name: 'Remix', logo: '/framework-logos/remix-icon.svg' },
-  { name: 'Solid.js', logo: '/framework-logos/solidjs-icon.svg' },
-  { name: 'Astro', logo: '/framework-logos/astro-icon.svg' },
-  { name: 'Wix', logo: '/framework-logos/wix-icon.svg' },
-  { name: 'Squarespace', logo: '/framework-logos/squarespace-icon.svg' },
+  { name: 'Next.js', logo: '/framework-logos/nextjs-icon.svg', brandColor: { light: '#4a4a4a', dark: '#ffffff' } },
+  { name: 'Svelte', logo: '/framework-logos/svelte-icon.svg', brandColor: '#FF3E00' },
+  { name: 'Vue.js', logo: '/framework-logos/vue-icon.svg', brandColor: '#4FC08D' },
+  { name: 'GTM', logo: '/framework-logos/gtm-icon.svg', brandColor: '#4285F4' },
+  { name: 'Laravel', logo: '/framework-logos/laravel-icon.svg', brandColor: '#FF2D20' },
+  { name: 'Shopify', logo: '/framework-logos/shopify-icon.svg', brandColor: '#96BF48' },
+  { name: 'Webflow', logo: '/framework-logos/webflow-icon.svg', brandColor: '#4353FF' },
+  { name: 'Wix', logo: '/framework-logos/wix-icon.svg', brandColor: '#FAAD4D' },
+  { name: 'Nuxt.js', logo: '/framework-logos/nuxtjs-icon.svg', brandColor: '#00DC82' },
+  { name: 'Angular', logo: '/framework-logos/angular-icon.svg', brandColor: '#DD0031' },
+  { name: 'Solid.js', logo: '/framework-logos/solidjs-icon.svg', brandColor: '#4F88C6' },
+  { name: 'Gatsby', logo: '/framework-logos/gatsby-icon.svg', brandColor: '#663399' },
+  { name: 'React', logo: '/framework-logos/react-icon.svg', brandColor: '#61DAFB' },
+  { name: 'Astro', logo: '/framework-logos/astro-icon.svg', brandColor: '#FF5D01' },
+  { name: 'WordPress', logo: '/framework-logos/wordpress-icon.svg', brandColor: '#21759B' },
+  { name: 'Squarespace', logo: '/framework-logos/squarespace-icon.svg', brandColor: { light: '#4a4a4a', dark: '#ffffff' } },
+  { name: 'Remix', logo: '/framework-logos/remix-icon.svg', brandColor: '#3992FF' },
 ];
 
 export async function FrameworkCompatibility() {
@@ -32,50 +33,22 @@ export async function FrameworkCompatibility() {
         </div>
 
         <div className='relative overflow-hidden'>
-          <div className='flex w-max animate-[scroll_20s_linear_infinite] space-x-3 will-change-transform hover:[animation-play-state:paused] sm:space-x-6 lg:animate-[scroll_40s_linear_infinite] lg:space-x-8'>
+          <div className='flex w-max animate-[scroll_20s_linear_infinite] gap-3 will-change-transform hover:[animation-play-state:paused] sm:gap-6 lg:animate-[scroll_40s_linear_infinite] lg:gap-8'>
             {frameworks.map((framework) => (
-              <div
-                key={`first-${framework.name}`}
-                className='hover:bg-card flex min-w-[120px] flex-shrink-0 flex-col items-center space-y-2 rounded-lg p-4 transition-colors'
-              >
-                <div className='flex h-8 w-8 items-center justify-center'>
-                  <Image
-                    src={framework.logo}
-                    alt={`${framework.name} logo`}
-                    width={32}
-                    height={32}
-                    className='h-8 w-8'
-                  />
-                </div>
-                <span className='text-center text-sm font-medium'>{framework.name}</span>
-              </div>
+              <FrameworkCard key={`first-${framework.name}`} framework={framework} />
             ))}
 
-            {/* Duplicate set of frameworks to reduce the flickering when the loop reaches the end */}
+            {/* Duplicate set for seamless loop */}
             {frameworks.map((framework) => (
-              <div
-                key={`second-${framework.name}`}
-                className='hover:bg-card flex min-w-[120px] flex-shrink-0 flex-col items-center space-y-2 rounded-lg p-4 transition-colors'
-              >
-                <div className='flex h-8 w-8 items-center justify-center'>
-                  <Image
-                    src={framework.logo}
-                    alt={`${framework.name} logo`}
-                    width={32}
-                    height={32}
-                    className='h-8 w-8'
-                  />
-                </div>
-                <span className='text-center text-sm font-medium'>{framework.name}</span>
-              </div>
+              <FrameworkCard key={`second-${framework.name}`} framework={framework} />
             ))}
           </div>
 
           {/* Left fade gradient */}
-          <div className='from-background pointer-events-none absolute top-0 left-0 z-10 h-full w-32 bg-gradient-to-r to-transparent'></div>
+          <div className='from-background pointer-events-none absolute top-0 left-0 z-10 h-full w-32 bg-gradient-to-r to-transparent' />
 
           {/* Right fade gradient */}
-          <div className='from-background pointer-events-none absolute top-0 right-0 z-10 h-full w-32 bg-gradient-to-l to-transparent'></div>
+          <div className='from-background pointer-events-none absolute top-0 right-0 z-10 h-full w-32 bg-gradient-to-l to-transparent' />
         </div>
 
         <div className='mt-8 text-center'>

--- a/dashboard/src/app/[locale]/(public)/(landing)/components/frameworkCompatibility.tsx
+++ b/dashboard/src/app/[locale]/(public)/(landing)/components/frameworkCompatibility.tsx
@@ -1,25 +1,5 @@
 import { getTranslations } from 'next-intl/server';
-import { FrameworkCard } from './FrameworkCard';
-
-const frameworks = [
-  { name: 'Next.js', logo: '/framework-logos/nextjs-icon.svg', brandColor: { light: '#4a4a4a', dark: '#ffffff' } },
-  { name: 'Svelte', logo: '/framework-logos/svelte-icon.svg', brandColor: '#FF3E00' },
-  { name: 'Vue.js', logo: '/framework-logos/vue-icon.svg', brandColor: '#4FC08D' },
-  { name: 'GTM', logo: '/framework-logos/gtm-icon.svg', brandColor: '#4285F4' },
-  { name: 'Laravel', logo: '/framework-logos/laravel-icon.svg', brandColor: '#FF2D20' },
-  { name: 'Shopify', logo: '/framework-logos/shopify-icon.svg', brandColor: '#96BF48' },
-  { name: 'Webflow', logo: '/framework-logos/webflow-icon.svg', brandColor: '#4353FF' },
-  { name: 'Wix', logo: '/framework-logos/wix-icon.svg', brandColor: '#FAAD4D' },
-  { name: 'Nuxt.js', logo: '/framework-logos/nuxtjs-icon.svg', brandColor: '#00DC82' },
-  { name: 'Angular', logo: '/framework-logos/angular-icon.svg', brandColor: '#DD0031' },
-  { name: 'Solid.js', logo: '/framework-logos/solidjs-icon.svg', brandColor: '#4F88C6' },
-  { name: 'Gatsby', logo: '/framework-logos/gatsby-icon.svg', brandColor: '#663399' },
-  { name: 'React', logo: '/framework-logos/react-icon.svg', brandColor: '#61DAFB' },
-  { name: 'Astro', logo: '/framework-logos/astro-icon.svg', brandColor: '#FF5D01' },
-  { name: 'WordPress', logo: '/framework-logos/wordpress-icon.svg', brandColor: '#21759B' },
-  { name: 'Squarespace', logo: '/framework-logos/squarespace-icon.svg', brandColor: { light: '#4a4a4a', dark: '#ffffff' } },
-  { name: 'Remix', logo: '/framework-logos/remix-icon.svg', brandColor: '#3992FF' },
-];
+import { FrameworkCarousel } from './FrameworkCarousel';
 
 export async function FrameworkCompatibility() {
   const t = await getTranslations('public.landing.framework');
@@ -32,21 +12,9 @@ export async function FrameworkCompatibility() {
         </div>
 
         <div className='relative overflow-hidden'>
-          <div className='flex w-max animate-[scroll_20s_linear_infinite] gap-3 will-change-transform hover:[animation-play-state:paused] focus-within:[animation-play-state:paused] sm:gap-6 lg:animate-[scroll_40s_linear_infinite] lg:gap-8'>
-            {frameworks.map((framework) => (
-              <FrameworkCard key={`first-${framework.name}`} framework={framework} />
-            ))}
+          <FrameworkCarousel />
 
-            {/* Duplicate set for seamless loop */}
-            {frameworks.map((framework) => (
-              <FrameworkCard key={`second-${framework.name}`} framework={framework} />
-            ))}
-          </div>
-
-          {/* Left fade gradient */}
           <div className='from-background pointer-events-none absolute top-0 left-0 z-10 h-full w-32 bg-gradient-to-r to-transparent' />
-
-          {/* Right fade gradient */}
           <div className='from-background pointer-events-none absolute top-0 right-0 z-10 h-full w-32 bg-gradient-to-l to-transparent' />
         </div>
 

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -141,6 +141,8 @@
   --map-feature-border-clicked: #08e966;
   --map-feature-border-none: #9ca3af;
 
+  --dot-grid-overlay: rgba(255, 255, 255, 0.9);
+
   --trend-up: rgb(14, 148, 70);
   --trend-down: rgb(207, 51, 23);
 
@@ -243,6 +245,8 @@
   --map-feature-border-hovered: #00ffe1;
   --map-feature-border-clicked: #2ecc2e;
   --map-feature-border-none: #888888;
+
+  --dot-grid-overlay: rgba(10, 10, 14, 0.9);
 
   --trend-up: rgb(88, 207, 146);
   --trend-down: rgb(212, 89, 81);

--- a/dashboard/src/components/animations/DotGrid.tsx
+++ b/dashboard/src/components/animations/DotGrid.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import { useRef, useEffect, useCallback } from 'react';
+
+type Dot = {
+  x: number;
+  y: number;
+  baseOpacity: number;
+  activeOpacity: number;
+  delay: number;
+};
+
+type DotGridProps = {
+  color: string;
+  active: boolean;
+  gap?: number;
+  dotRadius?: number;
+  className?: string;
+};
+
+function easeOut(t: number): number {
+  return 1 - (1 - t) * (1 - t);
+}
+
+export function DotGrid({
+  color,
+  active,
+  gap = 12,
+  dotRadius = 1,
+  className,
+}: DotGridProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const dotsRef = useRef<Dot[]>([]);
+  const progressRef = useRef(0);
+  const sizeRef = useRef({ width: 0, height: 0 });
+  const rafRef = useRef<number>(0);
+
+  const buildDots = useCallback(
+    (width: number, height: number): Dot[] => {
+      const dots: Dot[] = [];
+      const cols = Math.floor(width / gap);
+      const rows = Math.floor(height / gap);
+      const offsetX = (width - cols * gap) / 2 + gap / 2;
+      const offsetY = (height - rows * gap) / 2 + gap / 2;
+
+      for (let r = 0; r < rows; r++) {
+        for (let c = 0; c < cols; c++) {
+          dots.push({
+            x: offsetX + c * gap,
+            y: offsetY + r * gap,
+            baseOpacity: 0,
+            activeOpacity: 0.3 + Math.random() * 0.7,
+            delay: Math.random(),
+          });
+        }
+      }
+      return dots;
+    },
+    [gap]
+  );
+
+  const drawFrame = useCallback(
+    (progress: number) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
+
+      const { width, height } = sizeRef.current;
+      ctx.clearRect(0, 0, width, height);
+
+      for (const dot of dotsRef.current) {
+        const staggered = Math.max(
+          0,
+          Math.min(1, (progress - dot.delay * 0.3) / (1 - dot.delay * 0.3))
+        );
+        const opacity =
+          dot.baseOpacity + (dot.activeOpacity - dot.baseOpacity) * staggered;
+
+        ctx.beginPath();
+        ctx.arc(dot.x, dot.y, dotRadius, 0, Math.PI * 2);
+        ctx.fillStyle = color;
+        ctx.globalAlpha = opacity;
+        ctx.fill();
+      }
+
+      ctx.globalAlpha = 1;
+    },
+    [color, dotRadius]
+  );
+
+  // Resize handling
+  useEffect(() => {
+    const container = containerRef.current;
+    const canvas = canvasRef.current;
+    if (!container || !canvas) return;
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      const { width, height } = entry.contentRect;
+      const dpr = window.devicePixelRatio || 1;
+
+      canvas.width = width * dpr;
+      canvas.height = height * dpr;
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+
+      const ctx = canvas.getContext('2d');
+      if (ctx) ctx.scale(dpr, dpr);
+
+      sizeRef.current = { width, height };
+      dotsRef.current = buildDots(width, height);
+      drawFrame(progressRef.current);
+    });
+
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [buildDots, drawFrame]);
+
+  // Activation animation via requestAnimationFrame
+  useEffect(() => {
+    const target = active ? 1 : 0;
+    const start = progressRef.current;
+    const duration = active ? 600 : 800;
+    const startTime = performance.now();
+
+    function tick(now: number) {
+      const elapsed = now - startTime;
+      const t = Math.min(elapsed / duration, 1);
+      progressRef.current = start + (target - start) * easeOut(t);
+      drawFrame(progressRef.current);
+      if (t < 1) {
+        rafRef.current = requestAnimationFrame(tick);
+      }
+    }
+
+    rafRef.current = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [active, drawFrame]);
+
+  return (
+    <div ref={containerRef} className={className}>
+      <canvas ref={canvasRef} className="h-full w-full" />
+    </div>
+  );
+}

--- a/dashboard/src/components/animations/DotGrid.tsx
+++ b/dashboard/src/components/animations/DotGrid.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useEffect, useCallback } from 'react';
+import { useRef, useState, useEffect, useCallback } from 'react';
 
 type Dot = {
   x: number;
@@ -17,24 +17,23 @@ type DotGridProps = {
   className?: string;
 };
 
+const MIN_DOT_OPACITY = 0.3;
+const STAGGER_SPREAD = 0.3;
+const ACTIVATE_MS = 600;
+const DEACTIVATE_MS = 800;
+
 function easeOut(t: number): number {
   return 1 - (1 - t) * (1 - t);
 }
 
-export function DotGrid({
-  color,
-  active,
-  gap = 12,
-  dotRadius = 1,
-  className,
-}: DotGridProps) {
+export function DotGrid({ color, active, gap = 12, dotRadius = 1, className }: DotGridProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const dotsRef = useRef<Dot[]>([]);
   const progressRef = useRef(0);
   const sizeRef = useRef({ width: 0, height: 0 });
   const rafRef = useRef<number>(0);
-  const hasActivatedRef = useRef(false);
+  const [initialized, setInitialized] = useState(false);
   const colorRef = useRef(color);
   colorRef.current = color;
 
@@ -51,14 +50,14 @@ export function DotGrid({
           dots.push({
             x: offsetX + c * gap,
             y: offsetY + r * gap,
-            activeOpacity: 0.3 + Math.random() * 0.7,
+            activeOpacity: MIN_DOT_OPACITY + Math.random() * (1 - MIN_DOT_OPACITY),
             delay: Math.random(),
           });
         }
       }
       return dots;
     },
-    [gap]
+    [gap],
   );
 
   const drawFrame = useCallback(
@@ -72,10 +71,7 @@ export function DotGrid({
       ctx.clearRect(0, 0, width, height);
 
       for (const dot of dotsRef.current) {
-        const staggered = Math.max(
-          0,
-          Math.min(1, (progress - dot.delay * 0.3) / (1 - dot.delay * 0.3))
-        );
+        const staggered = Math.max(0, Math.min(1, (progress - dot.delay * STAGGER_SPREAD) / (1 - dot.delay * STAGGER_SPREAD)));
 
         ctx.beginPath();
         ctx.arc(dot.x, dot.y, dotRadius, 0, Math.PI * 2);
@@ -86,12 +82,15 @@ export function DotGrid({
 
       ctx.globalAlpha = 1;
     },
-    [dotRadius]
+    [dotRadius],
   );
 
   useEffect(() => {
-    if (active) hasActivatedRef.current = true;
-    if (!hasActivatedRef.current) return;
+    if (active && !initialized) setInitialized(true);
+  }, [active, initialized]);
+
+  useEffect(() => {
+    if (!initialized) return;
 
     const container = containerRef.current;
     const canvas = canvasRef.current;
@@ -119,10 +118,10 @@ export function DotGrid({
 
     observer.observe(container);
     return () => observer.disconnect();
-  }, [active, buildDots, drawFrame]);
+  }, [initialized, buildDots, drawFrame]);
 
   useEffect(() => {
-    if (!hasActivatedRef.current) return;
+    if (!initialized) return;
 
     const target = active ? 1 : 0;
     const start = progressRef.current;
@@ -131,7 +130,7 @@ export function DotGrid({
       return;
     }
 
-    const duration = active ? 600 : 800;
+    const duration = active ? ACTIVATE_MS : DEACTIVATE_MS;
     const startTime = performance.now();
 
     function tick(now: number) {
@@ -145,11 +144,11 @@ export function DotGrid({
 
     rafRef.current = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(rafRef.current);
-  }, [active, drawFrame]);
+  }, [active, initialized, drawFrame]);
 
   return (
     <div ref={containerRef} className={className}>
-      <canvas ref={canvasRef} className="h-full w-full" aria-hidden="true" />
+      <canvas ref={canvasRef} className='h-full w-full' aria-hidden='true' />
     </div>
   );
 }

--- a/dashboard/src/components/animations/DotGrid.tsx
+++ b/dashboard/src/components/animations/DotGrid.tsx
@@ -5,7 +5,6 @@ import { useRef, useEffect, useCallback } from 'react';
 type Dot = {
   x: number;
   y: number;
-  baseOpacity: number;
   activeOpacity: number;
   delay: number;
 };
@@ -35,6 +34,9 @@ export function DotGrid({
   const progressRef = useRef(0);
   const sizeRef = useRef({ width: 0, height: 0 });
   const rafRef = useRef<number>(0);
+  const hasActivatedRef = useRef(false);
+  const colorRef = useRef(color);
+  colorRef.current = color;
 
   const buildDots = useCallback(
     (width: number, height: number): Dot[] => {
@@ -49,7 +51,6 @@ export function DotGrid({
           dots.push({
             x: offsetX + c * gap,
             y: offsetY + r * gap,
-            baseOpacity: 0,
             activeOpacity: 0.3 + Math.random() * 0.7,
             delay: Math.random(),
           });
@@ -75,31 +76,29 @@ export function DotGrid({
           0,
           Math.min(1, (progress - dot.delay * 0.3) / (1 - dot.delay * 0.3))
         );
-        const opacity =
-          dot.baseOpacity + (dot.activeOpacity - dot.baseOpacity) * staggered;
 
         ctx.beginPath();
         ctx.arc(dot.x, dot.y, dotRadius, 0, Math.PI * 2);
-        ctx.fillStyle = color;
-        ctx.globalAlpha = opacity;
+        ctx.fillStyle = colorRef.current;
+        ctx.globalAlpha = dot.activeOpacity * staggered;
         ctx.fill();
       }
 
       ctx.globalAlpha = 1;
     },
-    [color, dotRadius]
+    [dotRadius]
   );
 
-  // Resize handling
   useEffect(() => {
+    if (active) hasActivatedRef.current = true;
+    if (!hasActivatedRef.current) return;
+
     const container = containerRef.current;
     const canvas = canvasRef.current;
     if (!container || !canvas) return;
 
     const observer = new ResizeObserver((entries) => {
-      const entry = entries[0];
-      if (!entry) return;
-      const { width, height } = entry.contentRect;
+      const { width, height } = entries[0].contentRect;
       const dpr = window.devicePixelRatio || 1;
 
       canvas.width = width * dpr;
@@ -108,7 +107,10 @@ export function DotGrid({
       canvas.style.height = `${height}px`;
 
       const ctx = canvas.getContext('2d');
-      if (ctx) ctx.scale(dpr, dpr);
+      if (ctx) {
+        ctx.setTransform(1, 0, 0, 1, 0, 0);
+        ctx.scale(dpr, dpr);
+      }
 
       sizeRef.current = { width, height };
       dotsRef.current = buildDots(width, height);
@@ -117,18 +119,23 @@ export function DotGrid({
 
     observer.observe(container);
     return () => observer.disconnect();
-  }, [buildDots, drawFrame]);
+  }, [active, buildDots, drawFrame]);
 
-  // Activation animation via requestAnimationFrame
   useEffect(() => {
+    if (!hasActivatedRef.current) return;
+
     const target = active ? 1 : 0;
     const start = progressRef.current;
+    if (start === target) {
+      drawFrame(target);
+      return;
+    }
+
     const duration = active ? 600 : 800;
     const startTime = performance.now();
 
     function tick(now: number) {
-      const elapsed = now - startTime;
-      const t = Math.min(elapsed / duration, 1);
+      const t = Math.min((now - startTime) / duration, 1);
       progressRef.current = start + (target - start) * easeOut(t);
       drawFrame(progressRef.current);
       if (t < 1) {
@@ -142,7 +149,7 @@ export function DotGrid({
 
   return (
     <div ref={containerRef} className={className}>
-      <canvas ref={canvasRef} className="h-full w-full" />
+      <canvas ref={canvasRef} className="h-full w-full" aria-hidden="true" />
     </div>
   );
 }


### PR DESCRIPTION
Add Canvas dot-grid animation to the landing page's framework compatibility carousel.

**Notes:** 
* I can't use tailwindcss variables directly for the grid colors, as they don't work in the canvas. I could call `getComputedStyle` within the canvas, and resolve them before applying. But I think its fragile, and only two of the frameworks need the theme color, so I instead implemented it with hardcoded colors per theme, and the `useTheme` hook. 
* Could simplify the code substantially if I used framer.motion for the animations. Worth looking into in the future if we pull framer.motion in on the landing page.

## Demo
![msedge_sqeXNA969A](https://github.com/user-attachments/assets/46ebac2e-a3d9-46bf-813d-8c7376e643cd)
![msedge_ndVnhla62k](https://github.com/user-attachments/assets/25373ce8-f32e-409e-b216-c673f81181a5)