### PR TITLE
Make postgres host port configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,9 @@ CLICKHOUSE_DASHBOARD_USER=dashboard
 CLICKHOUSE_DASHBOARD_PASSWORD=password
 
 # Postgres database
+# Set POSTGRES_HOST_PORT if the default 5432 conflicts with a local Postgres instance.
+# If changed, also update the port in POSTGRES_URL, SITE_CONFIG_DATABASE_URL, and MONITORING_DATABASE_URL below.
+# POSTGRES_HOST_PORT=5433
 POSTGRES_URL="postgresql://user:password@localhost:5432/dashboard?schema=public"
 POSTGRES_DB=dashboard
 POSTGRES_USER=user

--- a/.env.production.example
+++ b/.env.production.example
@@ -16,6 +16,9 @@ CLICKHOUSE_DASHBOARD_USER=dashboard
 CLICKHOUSE_DASHBOARD_PASSWORD=password
 
 # Postgres database
+# Set POSTGRES_HOST_PORT if the default 5432 conflicts with a local Postgres instance.
+# If changed, also update the port in POSTGRES_URL, SITE_CONFIG_DATABASE_URL, and MONITORING_DATABASE_URL below.
+# POSTGRES_HOST_PORT=5433
 POSTGRES_URL="postgresql://user:password@localhost:5432/dashboard?schema=public"
 POSTGRES_DB=dashboard
 POSTGRES_USER=user

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
     container_name: postgres
     hostname: postgres
     ports:
-      - 5432:5432
+      - ${POSTGRES_HOST_PORT:-5432}:5432
     env_file:
       - .env
     volumes:


### PR DESCRIPTION
Allow the postgres host port to be overridable through .env. This is useful for running parallel betterlytics instances, or if there is a conflicting port running on 5432.