### PR TITLE
Sanitize incoming events for global properties

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -16,6 +16,7 @@ pub mod outbound_link;
 pub mod postgres;
 pub mod processing;
 pub mod referrer;
+pub mod sanitize;
 pub mod session;
 pub mod site_config;
 pub mod ua_parser;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -28,6 +28,7 @@ mod outbound_link;
 mod postgres;
 mod processing;
 mod referrer;
+mod sanitize;
 mod session;
 mod ip_parser;
 mod session_replay;
@@ -263,15 +264,16 @@ async fn track_event(
     )>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
-    Json(raw_event): Json<RawTrackingEvent>,
+    Json(mut raw_event): Json<RawTrackingEvent>,
 ) -> Result<StatusCode, (StatusCode, String)> {
     let start_time = std::time::Instant::now();
 
     let ip_address = ip_parser::parse_ip(&headers).unwrap_or(addr.ip()).to_string();
 
+    sanitize::sanitize_event(&mut raw_event, &sanitize::SanitizeConfig::default());
+
     let validation_start = std::time::Instant::now();
 
-    // Validate and sanitize event
     let validated_event = match validator
         .validate_event(raw_event, ip_address.clone())
         .await

--- a/backend/src/sanitize/mod.rs
+++ b/backend/src/sanitize/mod.rs
@@ -1,0 +1,281 @@
+use serde_json::Value;
+use tracing::warn;
+
+use crate::analytics::RawTrackingEvent;
+
+#[derive(Debug, Clone)]
+pub struct SanitizeConfig {
+    pub max_global_properties_keys: usize,
+    pub max_global_property_key_length: usize,
+    pub max_global_property_value_length: usize,
+}
+
+impl Default for SanitizeConfig {
+    fn default() -> Self {
+        Self {
+            max_global_properties_keys: 30,
+            max_global_property_key_length: 64,
+            max_global_property_value_length: 128,
+        }
+    }
+}
+
+/// Strip/truncate anything in the event that would otherwise cause validation to drop it.
+/// Never errors - a malformed `global_properties` becomes `None` and the event survives.
+pub fn sanitize_event(event: &mut RawTrackingEvent, cfg: &SanitizeConfig) {
+    let Some(gp) = event.global_properties.take() else {
+        return;
+    };
+
+    let (cleaned, was_sanitized) = sanitize_global_properties(gp, cfg);
+    event.global_properties = cleaned;
+
+    if was_sanitized {
+        warn!(
+            rejection_reason = "global_properties_sanitized",
+            site_id = %event.site_id,
+            event_name = %event.event_name,
+            "Event accepted with global_properties sanitization"
+        );
+    }
+}
+
+fn sanitize_global_properties(value: Value, cfg: &SanitizeConfig) -> (Option<Value>, bool) {
+    let obj = match value {
+        Value::Object(o) => o,
+        _ => return (None, true),
+    };
+
+    let mut sanitized = serde_json::Map::new();
+    let mut was_sanitized = false;
+
+    for (key, val) in obj.into_iter() {
+        if sanitized.len() >= cfg.max_global_properties_keys {
+            was_sanitized = true;
+            break;
+        }
+
+        if key.len() > cfg.max_global_property_key_length {
+            was_sanitized = true;
+            continue;
+        }
+        if contains_control_characters(&key) {
+            was_sanitized = true;
+            continue;
+        }
+
+        match val {
+            Value::String(s) => {
+                if s.is_empty() {
+                    was_sanitized = true;
+                    continue;
+                }
+                if contains_dangerous_control_characters(&s) {
+                    was_sanitized = true;
+                    continue;
+                }
+                let truncated = if s.chars().count() > cfg.max_global_property_value_length {
+                    was_sanitized = true;
+                    s.chars()
+                        .take(cfg.max_global_property_value_length)
+                        .collect::<String>()
+                } else {
+                    s
+                };
+                sanitized.insert(key, Value::String(truncated));
+            }
+            Value::Number(n) => {
+                const MAX_SAFE: f64 = (1u64 << 53) as f64 - 1.0;
+                match n.as_f64() {
+                    Some(f) if f.is_finite() && f <= MAX_SAFE && f >= -MAX_SAFE => {
+                        sanitized.insert(key, Value::Number(n));
+                    }
+                    _ => {
+                        was_sanitized = true;
+                    }
+                }
+            }
+            Value::Bool(b) => {
+                sanitized.insert(key, Value::Bool(b));
+            }
+            _ => {
+                was_sanitized = true;
+            }
+        }
+    }
+
+    if sanitized.is_empty() {
+        (None, was_sanitized)
+    } else {
+        (Some(Value::Object(sanitized)), was_sanitized)
+    }
+}
+
+fn contains_control_characters(input: &str) -> bool {
+    input.chars().any(|c| c.is_control())
+}
+
+fn contains_dangerous_control_characters(input: &str) -> bool {
+    input.chars().any(|c| c.is_control() && c != '\n' && c != '\t')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn cfg() -> SanitizeConfig {
+        SanitizeConfig::default()
+    }
+
+    #[test]
+    fn valid_mixed_types_unchanged() {
+        let input = json!({
+            "plan": "pro",
+            "count": 42,
+            "active": true,
+            "ratio": 0.5,
+        });
+        let (out, was) = sanitize_global_properties(input, &cfg());
+        assert!(!was);
+        let out = out.expect("expected Some value");
+        let out_obj = out.as_object().unwrap();
+        assert_eq!(out_obj.len(), 4);
+        assert_eq!(out_obj.get("plan").unwrap(), &json!("pro"));
+        assert_eq!(out_obj.get("count").unwrap(), &json!(42));
+        assert_eq!(out_obj.get("active").unwrap(), &json!(true));
+        assert_eq!(out_obj.get("ratio").unwrap(), &json!(0.5));
+    }
+
+    #[test]
+    fn oversized_key_dropped() {
+        let long_key = "k".repeat(65);
+        let mut input = serde_json::Map::new();
+        input.insert(long_key.clone(), json!("val"));
+        input.insert("ok".to_string(), json!("ok_val"));
+        let (out, was) = sanitize_global_properties(Value::Object(input), &cfg());
+        assert!(was);
+        let out_obj = out.unwrap();
+        let out_obj = out_obj.as_object().unwrap();
+        assert!(!out_obj.contains_key(&long_key));
+        assert_eq!(out_obj.get("ok").unwrap(), &json!("ok_val"));
+    }
+
+    #[test]
+    fn oversized_string_value_truncated() {
+        let long_val: String = "a".repeat(200);
+        let input = json!({ "big": long_val });
+        let (out, was) = sanitize_global_properties(input, &cfg());
+        assert!(was);
+        let out_obj = out.unwrap();
+        let got = out_obj.as_object().unwrap().get("big").unwrap();
+        let got_str = got.as_str().unwrap();
+        assert_eq!(got_str.chars().count(), 128);
+        assert!(got_str.chars().all(|c| c == 'a'));
+    }
+
+    #[test]
+    fn non_finite_number_dropped() {
+        let mut m = serde_json::Map::new();
+        m.insert(
+            "k".to_string(),
+            Value::Number(serde_json::Number::from_f64(1e20).unwrap()),
+        );
+        m.insert("ok".to_string(), json!(1));
+        let (out, was) = sanitize_global_properties(Value::Object(m), &cfg());
+        assert!(was);
+        let out_obj = out.unwrap();
+        let out_obj = out_obj.as_object().unwrap();
+        assert!(!out_obj.contains_key("k"));
+        assert_eq!(out_obj.get("ok").unwrap(), &json!(1));
+    }
+
+    #[test]
+    fn array_value_dropped() {
+        let input = json!({ "a": [1, 2, 3], "b": "str" });
+        let (out, was) = sanitize_global_properties(input, &cfg());
+        assert!(was);
+        let out_obj = out.unwrap();
+        let out_obj = out_obj.as_object().unwrap();
+        assert!(!out_obj.contains_key("a"));
+        assert_eq!(out_obj.get("b").unwrap(), &json!("str"));
+    }
+
+    #[test]
+    fn null_value_dropped() {
+        let input = json!({ "a": null, "b": 1 });
+        let (out, was) = sanitize_global_properties(input, &cfg());
+        assert!(was);
+        let out_obj = out.unwrap();
+        let out_obj = out_obj.as_object().unwrap();
+        assert!(!out_obj.contains_key("a"));
+        assert_eq!(out_obj.get("b").unwrap(), &json!(1));
+    }
+
+    #[test]
+    fn empty_string_value_dropped() {
+        let input = json!({ "empty": "", "ok": "v" });
+        let (out, was) = sanitize_global_properties(input, &cfg());
+        assert!(was);
+        let out_obj = out.unwrap();
+        let out_obj = out_obj.as_object().unwrap();
+        assert!(!out_obj.contains_key("empty"));
+        assert_eq!(out_obj.get("ok").unwrap(), &json!("v"));
+    }
+
+    #[test]
+    fn too_many_keys_first_n_kept() {
+        let mut m = serde_json::Map::new();
+        for i in 0..40 {
+            m.insert(format!("k{:02}", i), json!(i));
+        }
+        let (out, was) = sanitize_global_properties(Value::Object(m), &cfg());
+        assert!(was);
+        let out_obj = out.unwrap();
+        let out_obj = out_obj.as_object().unwrap();
+        assert_eq!(out_obj.len(), 30);
+    }
+
+    #[test]
+    fn non_object_input_returns_none_sanitized() {
+        let (out, was) = sanitize_global_properties(json!([1, 2, 3]), &cfg());
+        assert!(was);
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn all_keys_sanitized_returns_none() {
+        let input = json!({
+            "a": null,
+            "b": [1, 2],
+            "c": "",
+        });
+        let (out, was) = sanitize_global_properties(input, &cfg());
+        assert!(was);
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn control_char_key_dropped() {
+        let mut m = serde_json::Map::new();
+        m.insert("bad\x00key".to_string(), json!("v"));
+        m.insert("ok".to_string(), json!("v"));
+        let (out, was) = sanitize_global_properties(Value::Object(m), &cfg());
+        assert!(was);
+        let out_obj = out.unwrap();
+        let out_obj = out_obj.as_object().unwrap();
+        assert_eq!(out_obj.len(), 1);
+        assert!(out_obj.contains_key("ok"));
+    }
+
+    #[test]
+    fn bool_preserved() {
+        let input = json!({ "a": true, "b": false });
+        let (out, was) = sanitize_global_properties(input, &cfg());
+        assert!(!was);
+        let out_obj = out.unwrap();
+        let out_obj = out_obj.as_object().unwrap();
+        assert_eq!(out_obj.get("a").unwrap(), &json!(true));
+        assert_eq!(out_obj.get("b").unwrap(), &json!(false));
+    }
+}

--- a/backend/src/sanitize/mod.rs
+++ b/backend/src/sanitize/mod.rs
@@ -59,6 +59,10 @@ fn sanitize_global_properties(value: Value, cfg: &SanitizeConfig) -> (Option<Val
             was_sanitized = true;
             continue;
         }
+        if key.is_empty() {
+            was_sanitized = true;
+            continue;
+        }
         if contains_control_characters(&key) {
             was_sanitized = true;
             continue;
@@ -253,6 +257,20 @@ mod tests {
         let (out, was) = sanitize_global_properties(input, &cfg());
         assert!(was);
         assert!(out.is_none());
+    }
+
+    #[test]
+    fn empty_key_dropped() {
+        let mut m = serde_json::Map::new();
+        m.insert("".to_string(), json!("v"));
+        m.insert("ok".to_string(), json!("v"));
+        let (out, was) = sanitize_global_properties(Value::Object(m), &cfg());
+        assert!(was);
+        let out_obj = out.unwrap();
+        let out_obj = out_obj.as_object().unwrap();
+        assert_eq!(out_obj.len(), 1);
+        assert!(out_obj.contains_key("ok"));
+        assert!(!out_obj.contains_key(""));
     }
 
     #[test]

--- a/backend/src/validation/mod.rs
+++ b/backend/src/validation/mod.rs
@@ -17,9 +17,6 @@ pub struct ValidationConfig {
     pub max_site_id_length: usize,
     pub max_user_agent_length: usize,
     pub max_error_exceptions_size: usize,
-    pub max_global_properties_keys: usize,
-    pub max_global_property_key_length: usize,
-    pub max_global_property_value_length: usize,
     pub max_timestamp_drift_seconds: i64,
     pub enforce_timestamp_validation: bool,
 }
@@ -33,9 +30,6 @@ impl Default for ValidationConfig {
             max_site_id_length: 100,                  // Site ID is usually short, but we should keep leeway for extra long domain names
             max_user_agent_length: 8 * 1024,          // 8192 bytes - same limit that apache uses (https://httpd.apache.org/docs/2.2/mod/core.html#limitrequestfieldsize)
             max_error_exceptions_size: 16 * 1024,     // 16KB - client caps stack at 10KB + type/value/mechanism overhead
-            max_global_properties_keys: 30,
-            max_global_property_key_length: 64,
-            max_global_property_value_length: 128,
             max_timestamp_drift_seconds: 300,         // 5 minutes - we should allow for some clock drift to account for packet latency
             enforce_timestamp_validation: true,       // Enforce timestamp validation
         }
@@ -68,8 +62,6 @@ pub enum ValidationError {
     DomainNotAllowed(String),
     #[error("Invalid scroll depth: {0}")]
     InvalidScrollDepth(String),
-    #[error("Invalid global properties: {0}")]
-    InvalidGlobalProperties(String),
 }
 
 #[derive(Debug, Clone)]
@@ -93,12 +85,11 @@ impl EventValidator {
         ip_address: String,
     ) -> Result<ValidatedTrackingEvent, ValidationError> {
         let result = self.validate_event_internal(&raw_event, &ip_address);
-        
-        // Log sanitized rejection details if validation fails
+
         if let Err(ref error) = result {
             self.log_sanitized_rejection(error, &raw_event, &ip_address);
         }
-        
+
         result
     }
 
@@ -130,10 +121,6 @@ impl EventValidator {
         // only present for custom events
         if !raw_event.properties.is_empty() {
             self.validate_properties_json(&raw_event.properties)?;
-        }
-
-        if let Some(ref gp) = raw_event.global_properties {
-            self.validate_global_properties(gp)?;
         }
 
         Ok(ValidatedTrackingEvent {
@@ -334,68 +321,6 @@ impl EventValidator {
         }
     }
 
-    fn validate_global_properties(&self, value: &serde_json::Value) -> Result<(), ValidationError> {
-        let obj = value.as_object().ok_or_else(|| {
-            ValidationError::InvalidGlobalProperties("Must be a JSON object".to_string())
-        })?;
-
-        if obj.len() > self.config.max_global_properties_keys {
-            return Err(ValidationError::InvalidGlobalProperties(
-                format!("Too many keys (max {})", self.config.max_global_properties_keys),
-            ));
-        }
-
-        for (key, val) in obj {
-            if key.len() > self.config.max_global_property_key_length {
-                return Err(ValidationError::InvalidGlobalProperties(
-                    format!("Key '{}' too long (max {} chars)", key, self.config.max_global_property_key_length),
-                ));
-            }
-            if contains_control_characters(key) {
-                return Err(ValidationError::InvalidGlobalProperties(
-                    format!("Key '{}' contains control characters", key),
-                ));
-            }
-            match val {
-                serde_json::Value::String(s) => {
-                    if s.is_empty() {
-                        return Err(ValidationError::InvalidGlobalProperties(
-                            format!("Value for '{}' must not be empty", key),
-                        ));
-                    }
-                    if s.len() > self.config.max_global_property_value_length {
-                        return Err(ValidationError::InvalidGlobalProperties(
-                            format!("Value for '{}' too long (max {} chars)", key, self.config.max_global_property_value_length),
-                        ));
-                    }
-                    if contains_dangerous_control_characters(s) {
-                        return Err(ValidationError::InvalidGlobalProperties(
-                            format!("Value for '{}' contains control characters", key),
-                        ));
-                    }
-                }
-                serde_json::Value::Number(n) => {
-                    const MAX_SAFE: f64 = (1u64 << 53) as f64 - 1.0;
-                    if let Some(f) = n.as_f64() {
-                        if !f.is_finite() || f > MAX_SAFE || f < -MAX_SAFE {
-                            return Err(ValidationError::InvalidGlobalProperties(
-                                format!("Value for '{}' is out of range", key),
-                            ));
-                        }
-                    }
-                }
-                serde_json::Value::Bool(_) => {}
-                _ => {
-                    return Err(ValidationError::InvalidGlobalProperties(
-                        format!("Value for '{}' must be a string, number, or boolean", key),
-                    ));
-                }
-            }
-        }
-
-        Ok(())
-    }
-
     /// Log sanitized rejection details for debugging
     fn log_sanitized_rejection(
         &self,
@@ -433,7 +358,6 @@ impl EventValidator {
             ValidationError::BlacklistedIp(_) => "blacklisted_ip",
             ValidationError::DomainNotAllowed(_) => "domain_not_allowed",
             ValidationError::InvalidScrollDepth(_) => "invalid_scroll_depth",
-            ValidationError::InvalidGlobalProperties(_) => "invalid_global_properties",
         }
     }
 

--- a/docs/src/content/integration/global-properties.mdx
+++ b/docs/src/content/integration/global-properties.mdx
@@ -44,7 +44,7 @@ betterlytics.setGlobalProperties({
 });
 ```
 
-The following values are rejected by the client with a console warning:
+The following values are silently dropped on the server:
 
 ```javascript
 betterlytics.setGlobalProperties({
@@ -59,12 +59,14 @@ betterlytics.setGlobalProperties({
 
 ## Limits
 
-| Limit | Value |
-|-------|-------|
-| Maximum keys per event | 30 |
-| Maximum key length | 64 characters |
-| Maximum string value length | 128 characters |
-| Numeric range | ±2^53 − 1 ([`Number.MAX_SAFE_INTEGER`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER)) |
+| Limit | Value | Behavior when exceeded |
+|-------|-------|------------------------|
+| Maximum keys per event | 30 | extra keys dropped |
+| Maximum key length | 64 characters | key dropped |
+| Maximum string value length | 128 characters | value truncated |
+| Numeric range | ±2^53 − 1 ([`Number.MAX_SAFE_INTEGER`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER)) | value dropped |
+
+Values outside these bounds are sanitized server-side without rejecting the event — the rest of the properties still go through. The event itself is never dropped because of a bad global property.
 
 ## Filtering in the Dashboard
 

--- a/docs/src/content/integration/global-properties.mdx
+++ b/docs/src/content/integration/global-properties.mdx
@@ -58,7 +58,7 @@ betterlytics.setGlobalProperties({
 });
 ```
 
-The following values are silently dropped on the server:
+Global properties with the following values are ignored and not included in events:
 
 ```javascript
 betterlytics.setGlobalProperties({

--- a/static/analytics.js
+++ b/static/analytics.js
@@ -131,19 +131,7 @@
       if (props == null || typeof props !== "object" || Array.isArray(props)) {
         return console.error("Betterlytics: setGlobalProperties requires a flat object");
       }
-      var keys = Object.keys(props);
-      for (var i = 0; i < keys.length; i++) {
-        var val = props[keys[i]];
-        if (val == null) {
-          console.warn("Betterlytics: skipping global property '" + keys[i] + "' — value must be a string, number, or boolean");
-        } else if (typeof val === "number" && !isFinite(val)) {
-          console.warn("Betterlytics: skipping global property '" + keys[i] + "' — number must be finite");
-        } else if (["string", "number", "boolean"].includes(typeof val)) {
-          globalProperties[keys[i]] = val;
-        } else {
-          console.warn("Betterlytics: skipping global property '" + keys[i] + "' — value must be a string, number, or boolean");
-        }
-      }
+      Object.assign(globalProperties, props);
     },
     clearGlobalProperties: function () {
       globalProperties = {};


### PR DESCRIPTION
Added backend sanitization module instead of dropping all events in invalid global properties