### PR TITLE
Security: Metrics endpoint exposes internal application metrics without authentication

### DIFF
--- a/dashboard/src/app/api/metrics/route.ts
+++ b/dashboard/src/app/api/metrics/route.ts
@@ -17,6 +17,14 @@ export async function GET(req: NextRequest) {
     });
   }
 
+  const metricsApiKey = process.env.METRICS_API_KEY;
+  if (metricsApiKey) {
+    const authHeader = req.headers.get('authorization');
+    if (!authHeader || !authHeader.startsWith('Bearer ') || authHeader.slice(7) !== metricsApiKey) {
+      return new Response('Unauthorized', { status: 401 });
+    }
+  }
+
   const contentType = register.contentType;
   const metrics = await register.metrics();
 


### PR DESCRIPTION
## Summary

Security: Metrics endpoint exposes internal application metrics without authentication

## Problem

**Severity**: `Medium` | **File**: `dashboard/src/app/api/metrics/route.ts:L1`

The endpoint `/api/metrics` exposes Prometheus metrics data, including request counts, error rates, and system performance metrics. There is no authentication or authorization check, allowing any external visitor to access potentially sensitive operational data. This could aid attackers in identifying system behavior, load patterns, or vulnerabilities.

## Solution

Restrict access to the metrics endpoint by implementing authentication (e.g., API key, basic auth) or network-level controls such as IP whitelisting. Alternatively, disable external exposure by moving the endpoint to an internal-only route or using middleware to block unauthorized requests.

## Changes

- `dashboard/src/app/api/metrics/route.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced"