### PR TITLE
fix: resolve #842 — Add Japanese as a supported language

### DIFF
--- a/frontend/src/components/LanguageSwitcher.tsx
+++ b/frontend/src/components/LanguageSwitcher.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+const LanguageSwitcher: React.FC = () => {
+  const { i18n } = useTranslation();
+
+  const changeLanguage = (lng: string) => {
+    i18n.changeLanguage(lng);
+  };
+
+  return (
+    <div className="language-switcher">
+      <button onClick={() => changeLanguage('en')}>English</button>
+      <button onClick={() => changeLanguage('ar')}>العربية</button>
+      <button onClick={() => changeLanguage('ja')}>日本語</button>
+    </div>
+  );
+};
+
+export default LanguageSwitcher;

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,0 +1,34 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  block-size: 100%;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  min-block-size: 100%;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif;
+  line-height: 1.5;
+  text-align: start;
+}
+
+img,
+picture,
+video,
+canvas,
+svg {
+  display: block;
+  max-inline-size: 100%;
+}
+
+input,
+button,
+textarea,
+select {
+  font: inherit;
+}


### PR DESCRIPTION
## Summary

fix: resolve #842 — Add Japanese as a supported language

## Problem

**Severity**: `Low` | **File**: `frontend/src/components/LanguageSwitcher.tsx`

Add Japanese as an option in the language selection dropdown. Ensure that the switcher respects the new RTL behaviour and that the UI updates correctly when Japanese is chosen.

## Solution

Locate the existing language selector component. Add a new button or option with label "日本語" and value "ja". Ensure the onClick handler calls `i18n.changeLanguage('ja')`. The `useDirection` hook will automatically handle the dir change. Test that the switcher works correctly in both LTR and RTL modes.

## Changes

- `frontend/src/components/LanguageSwitcher.tsx` (new)
- `frontend/src/styles/global.css` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced"