### PR TITLE
fix: resolve #834 — Sort dashboard cards by creation date on overview page

### DIFF
--- a/backend/src/site_config/repository.rs
+++ b/backend/src/site_config/repository.rs
@@ -17,7 +17,7 @@ FROM "SiteConfig" sc
 INNER JOIN "Dashboard" d ON d."id" = sc."dashboardId"
 "#;
 
-const ORDER_BY_UPDATED_AT: &str = r#" ORDER BY sc."updatedAt" ASC"#;
+const ORDER_BY_UPDATED_AT: &str = r#" ORDER BY d."createdAt" ASC"#;
 
 #[derive(Clone, Debug)]
 pub struct SiteConfigRecord {


### PR DESCRIPTION
## Summary

fix: resolve #834 — Sort dashboard cards by creation date on overview page

## Problem

**Severity**: `Low` | **File**: `backend/src/site_config/repository.rs`

The dashboards overview page currently displays dashboard cards in an unspecified order. To improve user experience and consistency, cards should be sorted chronologically by creation date, with the oldest dashboard appearing first and newer ones following. This change modifies the backend database query that fetches the list of dashboards for the overview, adding an `ORDER BY created_at ASC` clause. The frontend then receives already-sorted data and renders cards without additional client-side sorting.

## Solution

Locate the function that retrieves all dashboards for a user or site (e.g., `list_dashboards`, `get_dashboards`, or similar) inside `repository.rs`. Assuming the dashboard model has a `created_at` field (timestamp), modify the SQL query (or ORM method) to include `ORDER BY created_at ASC`. If using Diesel (Rust ORM), change `.load::<Dashboard>(conn)` to `.order(dashboards::created_at.asc()).load::<Dashboard>(conn)`. Ensure the field exists in the schema and model. If no explicit ordering exists, add it. Also verify that the frontend does not re-sort the list after receiving it; if it does, remove that client-side sorting to respect the backend order.

## Changes

- `backend/src/site_config/repository.rs` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced"