### PR TITLE
fix: resolve #36 — GA4 Import for easy migration

### DIFF
--- a/backend/src/import/ga4/importer.rs
+++ b/backend/src/import/ga4/importer.rs
@@ -1,0 +1,56 @@
+use chrono::{DateTime, Utc};
+use clickhouse::Row;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ga4Event {
+    pub name: String,
+    pub timestamp: DateTime<Utc>,
+    pub user_id: Option<String>,
+    pub session_id: Option<String>,
+    pub params: Option<serde_json::Value>,
+    pub idempotency_key: Option<String>,
+}
+
+#[derive(Row, Serialize, Deserialize, Debug)]
+pub struct InternalEvent {
+    site_id: i64,
+    event_name: String,
+    event_timestamp: i64,
+    user_id: Option<String>,
+    session_id: Option<String>,
+    properties: serde_json::Value,
+    idempotency_key: Option<String>,
+}
+
+pub async fn import_ga4_events(
+    site_id: i64,
+    events: Vec<Ga4Event>,
+    client: &clickhouse::Client,
+) -> Result<(), Box<dyn std::error::Error>> {
+    const CHUNK_SIZE: usize = 10000;
+    for chunk in events.chunks(CHUNK_SIZE) {
+        let mut internal_events = Vec::with_capacity(chunk.len());
+        for event in chunk {
+            internal_events.push(convert_to_internal(site_id, event));
+        }
+        let mut insert = client.insert("events")?;
+        for event in internal_events {
+            insert.write(&event).await?;
+        }
+        insert.end().await?;
+    }
+    Ok(())
+}
+
+fn convert_to_internal(site_id: i64, event: &Ga4Event) -> InternalEvent {
+    InternalEvent {
+        site_id,
+        event_name: event.name.clone(),
+        event_timestamp: event.timestamp.timestamp_millis(),
+        user_id: event.user_id.clone(),
+        session_id: event.session_id.clone(),
+        properties: event.params.clone().unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new())),
+        idempotency_key: event.idempotency_key.clone(),
+    }
+}

--- a/backend/src/import/mod.rs
+++ b/backend/src/import/mod.rs
@@ -1,0 +1,3 @@
+pub mod ga4;
+
+pub use ga4::{Ga4ImportConfig, Ga4ImportResult, import_ga4_data};

--- a/backend/src/routes/import.rs
+++ b/backend/src/routes/import.rs
@@ -1,0 +1,7 @@
+use axum::{Router, routing::post};
+
+pub fn import_routes() -> Router {
+    Router::new()
+        .route("/ga4/import", post(crate::handlers::ga4::start_import))
+        .route("/ga4/import/:job_id", post(crate::handlers::ga4::get_import_status))
+}


### PR DESCRIPTION
## Summary

fix: resolve #36 — GA4 Import for easy migration

## Problem

**Severity**: `High` | **File**: `backend/src/import/ga4/importer.rs`

Provides function `import_ga4_events(site_id, events, clickhouse_pool)` that converts a batch of GA4 events into internal format and writes them to the events table using ClickHouse’s native insert. Implements chunking (e.g., 10k rows per insert) to avoid memory overload and handles duplicate detection via idempotency keys (optional).

## Solution



## Changes

- `backend/src/import/ga4/importer.rs` (new)
- `backend/src/routes/import.rs` (new)
- `backend/src/import/mod.rs` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced"