### PR TITLE
fix: resolve #885 — Active query filter pills overflow on mobile

### DIFF
--- a/frontend/src/lib/components/filters/ActiveFilterPills.svelte
+++ b/frontend/src/lib/components/filters/ActiveFilterPills.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  export let filters: Array<{ id: string; text: string; onRemove: () => void }> = [];
+</script>
+
+<div class="active-filter-pills">
+  {#each filters as filter (filter.id)}
+    <div class="pill" title={filter.text}>
+      <span class="pill-text">{filter.text}</span>
+      <button class="remove-btn" on:click={filter.onRemove}>×</button>
+    </div>
+  {/each}
+</div>
+
+<style>
+  .active-filter-pills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+  .pill {
+    display: inline-flex;
+    align-items: center;
+    background-color: #e2e8f0;
+    border-radius: 9999px;
+    padding: 0.25rem 0.75rem;
+    font-size: 0.875rem;
+    max-width: calc(100% - 1rem);
+  }
+  .pill-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .remove-btn {
+    margin-left: 0.5rem;
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 1rem;
+    line-height: 1;
+    padding: 0;
+  }
+  @media (max-width: 768px) {
+    .pill {
+      max-width: calc(100% - 1rem);
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary

fix: resolve #885 — Active query filter pills overflow on mobile

## Problem

**Severity**: `Medium` | **File**: `frontend/src/lib/components/filters/ActiveFilterPills.svelte`

The active filter pills currently overflow horizontally on mobile screens when a filter value is very long. This causes a poor user experience with horizontal scrolling and cut-off content. The solution applies responsive flex wrapping and text truncation to ensure pills wrap to multiple lines and long text is truncated with ellipsis.

## Solution

Locate the container element that holds the filter pill list. Modify its CSS to use `display: flex; flex-wrap: wrap; gap: 0.5rem;` and ensure the container has `overflow-x: auto` only if needed, but better to rely on wrapping. For each pill, set `max-width: calc(100% - 1rem);` (or a percentage like 90% on mobile) and apply `overflow: hidden; text-overflow: ellipsis; white-space: nowrap;` to truncate long text. Use a media query for mobile devices (max-width: 768px). Additionally, consider adding a `title` attribute to show full text on hover or long-press. Example implementation:

## Changes

- `frontend/src/lib/components/filters/ActiveFilterPills.svelte` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced"