### PR TITLE
Add accessibility to active query filter close icon

### DIFF
--- a/dashboard/messages/da.json
+++ b/dashboard/messages/da.json
@@ -2408,7 +2408,8 @@
         "toastUndo": "Fortryd",
         "savedFiltersLimitReached": "Maksimalt antal gemte filtre nået"
       },
-      "filterBy": "Filtrer efter {label}"
+      "filterBy": "Filtrer efter {label}",
+      "removeFilter": "Fjern forespørgselsfilter"
     },
     "funnels": {
       "skeleton": {

--- a/dashboard/messages/da.json
+++ b/dashboard/messages/da.json
@@ -2409,7 +2409,7 @@
         "savedFiltersLimitReached": "Maksimalt antal gemte filtre nået"
       },
       "filterBy": "Filtrer efter {label}",
-      "removeFilter": "Fjern forespørgselsfilter"
+      "removeFilter": "Fjern filter"
     },
     "funnels": {
       "skeleton": {

--- a/dashboard/messages/en.json
+++ b/dashboard/messages/en.json
@@ -2405,7 +2405,8 @@
         "toastUndo": "Undo",
         "savedFiltersLimitReached": "Maximum saved filters reached"
       },
-      "filterBy": "Filter by {label}"
+      "filterBy": "Filter by {label}",
+      "removeFilter": "Remove query filter"
     },
     "funnels": {
       "skeleton": {

--- a/dashboard/messages/en.json
+++ b/dashboard/messages/en.json
@@ -2406,7 +2406,7 @@
         "savedFiltersLimitReached": "Maximum saved filters reached"
       },
       "filterBy": "Filter by {label}",
-      "removeFilter": "Remove query filter"
+      "removeFilter": "Remove filter"
     },
     "funnels": {
       "skeleton": {

--- a/dashboard/messages/it.json
+++ b/dashboard/messages/it.json
@@ -2417,7 +2417,7 @@
         "savedFiltersLimitReached": "Numero massimo di filtri salvati raggiunto"
       },
       "filterBy": "Filtra per {label}",
-      "removeFilter": "Rimuovi filtro query"
+      "removeFilter": "Rimuovi filtro"
     },
     "funnels": {
       "skeleton": {

--- a/dashboard/messages/it.json
+++ b/dashboard/messages/it.json
@@ -2416,7 +2416,8 @@
         "toastUndo": "Annulla",
         "savedFiltersLimitReached": "Numero massimo di filtri salvati raggiunto"
       },
-      "filterBy": "Filtra per {label}"
+      "filterBy": "Filtra per {label}",
+      "removeFilter": "Rimuovi filtro query"
     },
     "funnels": {
       "skeleton": {

--- a/dashboard/messages/nb.json
+++ b/dashboard/messages/nb.json
@@ -2416,7 +2416,8 @@
         "toastUndo": "Angre",
         "savedFiltersLimitReached": "Maksimalt antall lagrede filtre nådd"
       },
-      "filterBy": "Filtrer etter {label}"
+      "filterBy": "Filtrer etter {label}",
+      "removeFilter": "Fjern spørringsfilter"
     },
     "funnels": {
       "skeleton": {

--- a/dashboard/messages/nb.json
+++ b/dashboard/messages/nb.json
@@ -2417,7 +2417,7 @@
         "savedFiltersLimitReached": "Maksimalt antall lagrede filtre nådd"
       },
       "filterBy": "Filtrer etter {label}",
-      "removeFilter": "Fjern spørringsfilter"
+      "removeFilter": "Fjern filter"
     },
     "funnels": {
       "skeleton": {

--- a/dashboard/src/components/filters/ActiveQueryFilters.tsx
+++ b/dashboard/src/components/filters/ActiveQueryFilters.tsx
@@ -1,11 +1,15 @@
 'use client';
 import { useQueryFiltersContext } from '@/contexts/QueryFiltersContextProvider';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui-extended/tooltip';
 import { XIcon } from 'lucide-react';
+import { useTranslations } from 'next-intl';
 import { FilterDescription } from '@/components/filters/FilterDescription';
 
 export function ActiveQueryFilters() {
   const { queryFilters, removeQueryFilter } = useQueryFiltersContext();
+  const t = useTranslations('components.filters');
 
   if (queryFilters.length === 0) {
     return null;
@@ -16,15 +20,23 @@ export function ActiveQueryFilters() {
         <Badge
           key={filter.id}
           variant='outline'
-          className='border-input bg-muted/50 hover:bg-muted/70 dark:bg-secondary dark:hover:bg-secondary/90 px-2 py-1'
+          className='gap-1.5 border-input bg-muted/50 hover:bg-muted/70 dark:bg-secondary dark:hover:bg-secondary/90 p-1 px-1.5'
         >
           <FilterDescription filter={filter} />
-          <div
-            className='text-muted-foreground mt-0.5 size-3.5 cursor-pointer opacity-80 hover:opacity-100'
-            onClick={() => removeQueryFilter(filter.id)}
-          >
-            <XIcon className='size-full' />
-          </div>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant='ghost'
+                size='icon'
+                aria-label={t('removeFilter')}
+                className='text-muted-foreground/80 size-3.5 cursor-pointer hover:text-foreground focus-visible:text-foreground focus-visible:ring self-end -ml-0.5'
+                onClick={() => removeQueryFilter(filter.id)}
+              >
+                <XIcon className='size-full' />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{t('removeFilter')}</TooltipContent>
+          </Tooltip>
         </Badge>
       ))}
     </div>

--- a/dashboard/src/components/filters/ActiveQueryFilters.tsx
+++ b/dashboard/src/components/filters/ActiveQueryFilters.tsx
@@ -27,12 +27,11 @@ export function ActiveQueryFilters() {
             <TooltipTrigger asChild>
               <Button
                 variant='ghost'
-                size='icon'
                 aria-label={t('removeFilter')}
-                className='text-muted-foreground/80 size-3.5 cursor-pointer hover:text-foreground focus-visible:text-foreground focus-visible:ring self-end -ml-0.5'
+                className='text-muted-foreground/80 size-6 cursor-pointer hover:text-foreground focus-visible:text-foreground -mx-0.5'
                 onClick={() => removeQueryFilter(filter.id)}
               >
-                <XIcon className='size-full' />
+                <XIcon className='size-3.5' />
               </Button>
             </TooltipTrigger>
             <TooltipContent>{t('removeFilter')}</TooltipContent>


### PR DESCRIPTION
Replaces the close icon with a proper Button so it's keyboard-focusable and screen-reader labelled, and bumps its target to 24×24 px (WCAG AA min). I have also added a new `removeFilter` translation key across our localized languages.

## Demo
<img width="565" height="237" alt="image" src="https://github.com/user-attachments/assets/f06d9085-9381-4c55-8709-a3f39625293e" />
