### PR TITLE
Enrich /events page with global-property drilldown

### DIFF
--- a/dashboard/messages/da.json
+++ b/dashboard/messages/da.json
@@ -2418,8 +2418,16 @@
       },
       "expandedEventContent": {
         "loading": "Indlæser egenskaber...",
-        "noProperties": "Ingen egenskaber",
-        "noPropertiesDesc": "Denne hændelse har ingen brugerdefinerede egenskaber."
+        "noPropertiesTitle": "Ingen egenskaber",
+        "noPropertiesDesc": "Denne hændelse har ingen brugerdefinerede egenskaber.",
+        "eventProperties": "Hændelsesegenskaber",
+        "globalProperties": "Globale egenskaber",
+        "eventPropertiesInline": "hændelsesegenskaber",
+        "globalPropertiesInline": "globale egenskaber",
+        "noProperties": "Ingen {propertyName} på disse hændelser.",
+        "noEventOrGlobalProperties": "Ingen hændelses- eller globale egenskaber registreret for disse hændelser.",
+        "valueCount": "{count, plural, one {{count} værdi} other {{count} værdier}}",
+        "moreValues": "{count, plural, one {+{count} mere} other {+{count} mere}}"
       }
     },
     "tabbedTable": {

--- a/dashboard/messages/en.json
+++ b/dashboard/messages/en.json
@@ -2415,8 +2415,16 @@
       },
       "expandedEventContent": {
         "loading": "Loading properties...",
-        "noProperties": "No Properties",
-        "noPropertiesDesc": "This event has no custom properties."
+        "noPropertiesTitle": "No Properties",
+        "noPropertiesDesc": "This event has no custom properties.",
+        "eventProperties": "Event properties",
+        "globalProperties": "Global properties",
+        "eventPropertiesInline": "event properties",
+        "globalPropertiesInline": "global properties",
+        "noProperties": "No {propertyName} on these events.",
+        "noEventOrGlobalProperties": "No event or global properties recorded for these events.",
+        "valueCount": "{count, plural, one {{count} value} other {{count} values}}",
+        "moreValues": "{count, plural, one {+{count} more} other {+{count} more}}"
       }
     },
     "tabbedTable": {

--- a/dashboard/messages/it.json
+++ b/dashboard/messages/it.json
@@ -2426,8 +2426,16 @@
       },
       "expandedEventContent": {
         "loading": "Caricamento proprietà...",
-        "noProperties": "Nessuna proprietà",
-        "noPropertiesDesc": "Questo evento non ha proprietà personalizzate."
+        "noPropertiesTitle": "Nessuna proprietà",
+        "noPropertiesDesc": "Questo evento non ha proprietà personalizzate.",
+        "eventProperties": "Proprietà dell'evento",
+        "globalProperties": "Proprietà globali",
+        "eventPropertiesInline": "proprietà dell'evento",
+        "globalPropertiesInline": "proprietà globale",
+        "noProperties": "Nessuna {propertyName} per questi eventi.",
+        "noEventOrGlobalProperties": "Nessuna proprietà dell'evento o globale registrata per questi eventi.",
+        "valueCount": "{count, plural, one {{count} valore} other {{count} valori}}",
+        "moreValues": "{count, plural, one {+{count} altro} other {+{count} altri}}"
       }
     },
     "tabbedTable": {

--- a/dashboard/messages/nb.json
+++ b/dashboard/messages/nb.json
@@ -2426,8 +2426,16 @@
       },
       "expandedEventContent": {
         "loading": "Laster inn egenskaper...",
-        "noProperties": "Ingen egenskaper",
-        "noPropertiesDesc": "Denne hendelsen har ingen brukerdefinerte egenskaper."
+        "noPropertiesTitle": "Ingen egenskaper",
+        "noPropertiesDesc": "Denne hendelsen har ingen brukerdefinerte egenskaper.",
+        "eventProperties": "Hendelsesegenskaper",
+        "globalProperties": "Globale egenskaper",
+        "eventPropertiesInline": "hendelsesegenskaper",
+        "globalPropertiesInline": "globale egenskaper",
+        "noProperties": "Ingen {propertyName} for disse hendelsene.",
+        "noEventOrGlobalProperties": "Ingen hendelses- eller globale egenskaper registrert for disse hendelsene.",
+        "valueCount": "{count, plural, one {{count} verdi} other {{count} verdier}}",
+        "moreValues": "{count, plural, one {+{count} til} other {+{count} til}}"
       }
     },
     "tabbedTable": {

--- a/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/events/ExpandedEventContent.tsx
+++ b/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/events/ExpandedEventContent.tsx
@@ -1,4 +1,5 @@
-import { EventTypeRow } from '@/entities/analytics/events.entities';
+import { SunsetIcon, TagsIcon, type LucideIcon } from 'lucide-react';
+import { EventTypeRow, EventPropertyAnalytics } from '@/entities/analytics/events.entities';
 import { PropertyRow } from '@/components/events/PropertyRow';
 import { Spinner } from '@/components/ui/spinner';
 import { useTranslations } from 'next-intl';
@@ -14,7 +15,7 @@ interface ExpandedEventContentProps {
 export function ExpandedEventContent({ event, expandedProperties, onToggleProperty }: ExpandedEventContentProps) {
   const t = useTranslations('components.events.expandedEventContent');
   const { input, options } = useBAQueryParams();
-  const { data: propertiesData, isLoading: propertiesLoading } = trpc.events.eventPropertiesAnalytics.useQuery(
+  const { data, isLoading } = trpc.events.eventPropertiesAnalytics.useQuery(
     {
       ...input,
       eventName: event.event_name,
@@ -22,32 +23,99 @@ export function ExpandedEventContent({ event, expandedProperties, onToggleProper
     options,
   );
 
-  return (
-    <div className='bg-muted/20 border-primary/30 border-l-2'>
-      {propertiesLoading ? (
+  if (isLoading) {
+    return (
+      <div className='bg-muted/20 border-primary/30 border-l-2'>
         <div className='flex flex-col items-center gap-4 py-12'>
-          <div className='relative'>
-            <Spinner size='sm' />
-          </div>
+          <Spinner size='sm' />
           <p className='text-muted-foreground text-sm'>{t('loading')}</p>
         </div>
-      ) : propertiesData?.properties.length ? (
-        <div className='py-4 pr-6 pl-8'>
-          <div className='space-y-4'>
-            {propertiesData.properties.map((property) => (
-              <PropertyRow
-                key={property.propertyName}
-                property={property}
-                isExpanded={expandedProperties.has(property.propertyName)}
-                onToggle={() => onToggleProperty(property.propertyName)}
-              />
-            ))}
-          </div>
-        </div>
-      ) : (
+      </div>
+    );
+  }
+
+  const eventProperties = data?.properties ?? [];
+  const globalProperties = data?.globalProperties ?? [];
+  const hasEventProperties = eventProperties.length > 0;
+  const hasGlobalProperties = globalProperties.length > 0;
+
+  if (!hasEventProperties && !hasGlobalProperties) {
+    return (
+      <div className='bg-muted/20 border-primary/30 border-l-2'>
         <div className='py-12 pl-8 text-center'>
-          <h4 className='text-foreground mb-1 text-sm font-medium'>{t('noProperties')}</h4>
-          <p className='text-muted-foreground text-xs'>{t('noPropertiesDesc')}</p>
+          <h4 className='text-foreground mb-1 text-sm font-medium'>{t('noPropertiesTitle')}</h4>
+          <p className='text-muted-foreground text-xs'>{t('noEventOrGlobalProperties')}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className='bg-muted/20 border-primary/30 border-l-2 @container'>
+      <div className='grid grid-cols-1 gap-x-8 gap-y-6 py-4 pr-6 pl-8 @[720px]:grid-cols-2'>
+        <PropertyGroup
+          label={t('eventProperties')}
+          icon={SunsetIcon}
+          properties={eventProperties}
+          keyPrefix='event'
+          expandedProperties={expandedProperties}
+          onToggleProperty={onToggleProperty}
+          emptyMessage={t('noProperties', { propertyName: t('eventPropertiesInline') })}
+        />
+        <PropertyGroup
+          label={t('globalProperties')}
+          icon={TagsIcon}
+          properties={globalProperties}
+          keyPrefix='global'
+          expandedProperties={expandedProperties}
+          onToggleProperty={onToggleProperty}
+          emptyMessage={t('noProperties', { propertyName: t('globalPropertiesInline') })}
+        />
+      </div>
+    </div>
+  );
+}
+
+interface PropertyGroupProps {
+  label: string;
+  icon: LucideIcon;
+  properties: EventPropertyAnalytics[];
+  keyPrefix: 'event' | 'global';
+  expandedProperties: Set<string>;
+  onToggleProperty: (propertyName: string) => void;
+  emptyMessage: string;
+}
+
+function PropertyGroup({
+  label,
+  icon: Icon,
+  properties,
+  keyPrefix,
+  expandedProperties,
+  onToggleProperty,
+  emptyMessage,
+}: PropertyGroupProps) {
+  return (
+    <div>
+      <div className='text-muted-foreground mb-2 flex items-center gap-2 font-medium'>
+        <Icon className='size-4' aria-hidden='true' />
+        <span>{label}</span>
+      </div>
+      {properties.length === 0 ? (
+        <p className='text-muted-foreground py-2 text-xs'>{emptyMessage}</p>
+      ) : (
+        <div className='space-y-4'>
+          {properties.map((property) => {
+            const namespacedKey = `${keyPrefix}:${property.propertyName}`;
+            return (
+              <PropertyRow
+                key={namespacedKey}
+                property={property}
+                isExpanded={expandedProperties.has(namespacedKey)}
+                onToggle={() => onToggleProperty(namespacedKey)}
+              />
+            );
+          })}
         </div>
       )}
     </div>

--- a/dashboard/src/components/events/PropertyRow.tsx
+++ b/dashboard/src/components/events/PropertyRow.tsx
@@ -1,4 +1,7 @@
 import { ChevronDown, ChevronRight } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { Badge } from '@/components/ui/badge';
+import { ScrollArea } from '@/components/ui/scroll-area';
 import { EventPropertyAnalytics } from '@/entities/analytics/events.entities';
 import { PropertyValueBar } from '@/components/PropertyValueBar';
 import { cn } from '@/lib/utils';
@@ -10,10 +13,12 @@ interface PropertyRowProps {
 }
 
 export function PropertyRow({ property, isExpanded, onToggle }: PropertyRowProps) {
+  const t = useTranslations('components.events.expandedEventContent');
   const hasValues = property.topValues.length > 0;
+  const hiddenValueCount = property.uniqueValueCount - property.topValues.length;
 
   return (
-    <div className='relative space-y-3'>
+    <div className='relative space-y-2.5'>
       <div
         className={cn(
           'hover:ring-border/60 flex cursor-pointer items-center gap-3 rounded px-3 py-2 transition-colors hover:ring-1',
@@ -36,28 +41,28 @@ export function PropertyRow({ property, isExpanded, onToggle }: PropertyRowProps
           )}
         </div>
 
-        <div className='flex min-w-0 flex-1 items-center justify-between'>
+        <div className='flex min-w-0 flex-1 items-center justify-start gap-3'>
           <span className='text-foreground text-sm font-medium'>{property.propertyName}</span>
+          {property.uniqueValueCount > 0 && (
+            <Badge variant='outline'>{t('valueCount', { count: property.uniqueValueCount })}</Badge>
+          )}
         </div>
       </div>
 
       {isExpanded && hasValues && (
-        <>
-          {/* Connecting border */}
-          <div className='bg-border/80 absolute top-10 bottom-0 left-[1.15rem] w-px' />
-
-          <div className='ml-7 space-y-2'>
-            {property.topValues.map((value, index) => (
-              <PropertyValueBar key={index} value={value} />
-            ))}
-
-            {property.uniqueValueCount > property.topValues.length && (
-              <div className='text-muted-foreground flex items-center gap-2 px-3 py-1.5 text-xs'>
-                <span>+{property.uniqueValueCount - property.topValues.length} more</span>
+          <ScrollArea className='relative [&_[data-slot=scroll-area-viewport]]:max-h-48 [&_[data-slot=scroll-area-scrollbar]]:translate-x-1'>
+            <div className='bg-border/80 absolute top-0 bottom-0 left-[1.15rem] z-10 w-px' />
+            <div className='ml-7 space-y-2 pr-2'>
+              {property.topValues.map((value, index) => (
+                <PropertyValueBar key={index} value={value} />
+              ))}
+            </div>
+            {hiddenValueCount > 0 && (
+              <div className='text-muted-foreground ml-7 flex items-center gap-2 py-3 px-1.5 text-xs'>
+                <span>{t('moreValues', { count: hiddenValueCount })}</span>
               </div>
             )}
-          </div>
-        </>
+          </ScrollArea>
       )}
     </div>
   );

--- a/dashboard/src/entities/analytics/events.entities.ts
+++ b/dashboard/src/entities/analytics/events.entities.ts
@@ -32,6 +32,7 @@ export const EventPropertiesOverviewSchema = z.object({
   eventName: z.string(),
   totalEvents: z.number(),
   properties: z.array(EventPropertyAnalyticsSchema),
+  globalProperties: z.array(EventPropertyAnalyticsSchema),
 });
 
 export const EventLogEntrySchema = z.object({

--- a/dashboard/src/entities/analytics/globalProperties.entities.ts
+++ b/dashboard/src/entities/analytics/globalProperties.entities.ts
@@ -14,3 +14,19 @@ export const GlobalPropertyKeyValueRowSchema = z.object({
 });
 
 export type GlobalPropertyKeyValueRow = z.infer<typeof GlobalPropertyKeyValueRowSchema>;
+
+export const GlobalPropertyEventCountRowSchema = z.object({
+  property_key: z.string(),
+  event_count: z.coerce.number().int().nonnegative(),
+  unique_value_count: z.coerce.number().int().nonnegative(),
+});
+
+export type GlobalPropertyEventCountRow = z.infer<typeof GlobalPropertyEventCountRowSchema>;
+
+export const GlobalPropertyEventValueRowSchema = z.object({
+  property_key: z.string(),
+  value: z.string(),
+  event_count: z.coerce.number().int().nonnegative(),
+});
+
+export type GlobalPropertyEventValueRow = z.infer<typeof GlobalPropertyEventValueRowSchema>;

--- a/dashboard/src/presenters/toEventPropertyAnalyticsFromGlobalEvent.ts
+++ b/dashboard/src/presenters/toEventPropertyAnalyticsFromGlobalEvent.ts
@@ -1,0 +1,31 @@
+import { EventPropertyAnalytics } from '@/entities/analytics/events.entities';
+import { calculatePercentage } from '@/utils/mathUtils';
+
+export type GlobalPropertyForEventAggregate = {
+  property_key: string;
+  event_count: number;
+  unique_value_count: number;
+  values: { value: string; event_count: number }[];
+};
+
+export function toEventPropertyAnalyticsFromGlobalEvent(
+  aggregate: GlobalPropertyForEventAggregate[],
+): EventPropertyAnalytics[] {
+  return aggregate.map((entry) => {
+    const denominator = entry.event_count;
+    return {
+      propertyName: entry.property_key,
+      uniqueValueCount: entry.unique_value_count,
+      totalOccurrences: denominator,
+      topValues: entry.values.map((v) => {
+        const ratio = denominator > 0 ? calculatePercentage(v.event_count, denominator) : 0;
+        return {
+          value: v.value,
+          count: v.event_count,
+          percentage: ratio,
+          relativePercentage: ratio,
+        };
+      }),
+    };
+  });
+}

--- a/dashboard/src/repositories/clickhouse/globalProperties.repository.ts
+++ b/dashboard/src/repositories/clickhouse/globalProperties.repository.ts
@@ -7,6 +7,10 @@ import {
   GlobalPropertyKeyCountRowSchema,
   GlobalPropertyKeyValueRow,
   GlobalPropertyKeyValueRowSchema,
+  GlobalPropertyEventCountRow,
+  GlobalPropertyEventCountRowSchema,
+  GlobalPropertyEventValueRow,
+  GlobalPropertyEventValueRowSchema,
 } from '@/entities/analytics/globalProperties.entities';
 
 export async function getTopGlobalPropertyKeys(
@@ -92,4 +96,100 @@ export async function getTopGlobalPropertyValuesForKeys(
     .toPromise();
 
   return GlobalPropertyKeyValueRowSchema.array().parse(result);
+}
+
+export async function getTopGlobalPropertyKeysForEvent(
+  siteQuery: BASiteQuery,
+  eventName: string,
+  keyLimit: number,
+): Promise<GlobalPropertyEventCountRow[]> {
+  const { siteId, queryFilters, startDateTime, endDateTime } = siteQuery;
+  const filters = BAQuery.getFilterQuery(queryFilters);
+
+  const query = safeSql`
+    SELECT
+      property_key,
+      count() AS event_count,
+      uniqExact(value) AS unique_value_count
+    FROM analytics.events
+    ARRAY JOIN
+      global_properties_keys AS property_key,
+      global_properties_values AS value
+    WHERE site_id = {site_id:String}
+      AND event_type = 'custom'
+      AND custom_event_name = {event_name:String}
+      AND timestamp BETWEEN {start:DateTime} AND {end:DateTime}
+      AND length(global_properties_keys) > 0
+      AND value != ''
+      AND ${SQL.AND(filters)}
+    GROUP BY property_key
+    ORDER BY event_count DESC
+    LIMIT {key_limit:UInt32}
+  `;
+
+  const result = await clickhouse
+    .query(query.taggedSql, {
+      params: {
+        ...query.taggedParams,
+        site_id: siteId,
+        event_name: eventName,
+        start: startDateTime,
+        end: endDateTime,
+        key_limit: keyLimit,
+      },
+    })
+    .toPromise();
+
+  return GlobalPropertyEventCountRowSchema.array().parse(result);
+}
+
+export async function getTopGlobalPropertyValuesForEventKeys(
+  siteQuery: BASiteQuery,
+  eventName: string,
+  selectedKeys: string[],
+  valueLimit: number,
+): Promise<GlobalPropertyEventValueRow[]> {
+  if (selectedKeys.length === 0) {
+    return [];
+  }
+
+  const { siteId, queryFilters, startDateTime, endDateTime } = siteQuery;
+  const filters = BAQuery.getFilterQuery(queryFilters);
+
+  const query = safeSql`
+    SELECT
+      property_key,
+      value,
+      count() AS event_count
+    FROM analytics.events
+    ARRAY JOIN
+      global_properties_keys AS property_key,
+      global_properties_values AS value
+    WHERE site_id = {site_id:String}
+      AND event_type = 'custom'
+      AND custom_event_name = {event_name:String}
+      AND timestamp BETWEEN {start:DateTime} AND {end:DateTime}
+      AND value != ''
+      AND property_key IN {selected_keys:Array(String)}
+      AND ${SQL.AND(filters)}
+    GROUP BY property_key, value
+    ORDER BY event_count DESC
+    LIMIT {value_limit:UInt32} BY property_key
+  `;
+
+  const result = await clickhouse
+    .query(query.taggedSql, {
+      params: {
+        ...query.taggedParams,
+        site_id: siteId,
+        event_name: eventName,
+        start: startDateTime,
+        end: endDateTime,
+        selected_keys: selectedKeys,
+        value_limit: valueLimit,
+      },
+    })
+    .toPromise();
+
+  return GlobalPropertyEventValueRowSchema.array().parse(result);
 }

--- a/dashboard/src/services/analytics/events.service.ts
+++ b/dashboard/src/services/analytics/events.service.ts
@@ -13,6 +13,8 @@ import {
 } from '@/entities/analytics/events.entities';
 import { calculatePercentage } from '@/utils/mathUtils';
 import { BASiteQuery } from '@/entities/analytics/analyticsQuery.entities';
+import { getGlobalPropertiesForEvent } from '@/services/analytics/globalProperties.service';
+import { toEventPropertyAnalyticsFromGlobalEvent } from '@/presenters/toEventPropertyAnalyticsFromGlobalEvent';
 
 const MAX_TOP_VALUES = 10;
 
@@ -31,16 +33,23 @@ export async function getTotalEventCountForSite(siteQuery: BASiteQuery) {
 export async function getEventPropertiesAnalyticsForSite(
   siteQuery: BASiteQuery,
   eventName: string,
+  globalPropertiesKeyLimit: number,
+  globalPropertiesValueLimit: number,
 ): Promise<EventPropertiesOverview> {
-  const rawPropertyData = await getEventPropertyData(siteQuery, eventName);
+  const [rawPropertyData, globalAggregate] = await Promise.all([
+    getEventPropertyData(siteQuery, eventName),
+    getGlobalPropertiesForEvent(siteQuery, eventName, globalPropertiesKeyLimit, globalPropertiesValueLimit),
+  ]);
 
   const totalEvents = rawPropertyData.length;
   const properties = processPropertyData(rawPropertyData);
+  const globalProperties = toEventPropertyAnalyticsFromGlobalEvent(globalAggregate);
 
   return {
     eventName,
     totalEvents,
     properties,
+    globalProperties,
   };
 }
 

--- a/dashboard/src/services/analytics/globalProperties.service.ts
+++ b/dashboard/src/services/analytics/globalProperties.service.ts
@@ -3,8 +3,11 @@
 import {
   getTopGlobalPropertyKeys,
   getTopGlobalPropertyValuesForKeys,
+  getTopGlobalPropertyKeysForEvent,
+  getTopGlobalPropertyValuesForEventKeys,
 } from '@/repositories/clickhouse/globalProperties.repository';
 import { BASiteQuery } from '@/entities/analytics/analyticsQuery.entities';
+import { GlobalPropertyForEventAggregate } from '@/presenters/toEventPropertyAnalyticsFromGlobalEvent';
 
 export type GlobalPropertyAggregate = {
   property_key: string;
@@ -37,6 +40,39 @@ export async function getGlobalPropertiesOverview(
 
   return topKeys.map((topKey) => ({
     ...topKey,
+    values: valuesByKey.get(topKey.property_key) ?? [],
+  }));
+}
+
+export async function getGlobalPropertiesForEvent(
+  siteQuery: BASiteQuery,
+  eventName: string,
+  keyLimit: number,
+  valueLimit: number,
+): Promise<GlobalPropertyForEventAggregate[]> {
+  const topKeys = await getTopGlobalPropertyKeysForEvent(siteQuery, eventName, keyLimit);
+  if (topKeys.length === 0) {
+    return [];
+  }
+
+  const valueRows = await getTopGlobalPropertyValuesForEventKeys(
+    siteQuery,
+    eventName,
+    topKeys.map((k) => k.property_key),
+    valueLimit,
+  );
+
+  const valuesByKey = new Map<string, { value: string; event_count: number }[]>();
+  for (const row of valueRows) {
+    const list = valuesByKey.get(row.property_key) ?? [];
+    list.push({ value: row.value, event_count: row.event_count });
+    valuesByKey.set(row.property_key, list);
+  }
+
+  return topKeys.map((topKey) => ({
+    property_key: topKey.property_key,
+    event_count: topKey.event_count,
+    unique_value_count: topKey.unique_value_count,
     values: valuesByKey.get(topKey.property_key) ?? [],
   }));
 }

--- a/dashboard/src/trpc/routers/events.ts
+++ b/dashboard/src/trpc/routers/events.ts
@@ -42,7 +42,12 @@ export const eventsRouter = createRouter({
     .input(z.object({ eventName: z.string() }))
     .query(async ({ ctx, input }) => {
       const { main } = ctx;
-      return getEventPropertiesAnalyticsForSite(main, input.eventName);
+      return getEventPropertiesAnalyticsForSite(
+        main,
+        input.eventName,
+        GLOBAL_PROPERTIES_KEY_LIMIT,
+        GLOBAL_PROPERTIES_VALUE_LIMIT,
+      );
     }),
 
   recentEvents: analyticsProcedure


### PR DESCRIPTION
Add global properties to the 'event descriptions' section on the /events page.

## Demo
<img width="2552" height="1274" alt="msedge_HGLh7Yo3IQ" src="https://github.com/user-attachments/assets/f7d9b629-aa24-4d06-a67d-432884d44f95" />
