### PR TITLE
Unify funnel CRUD behavior

### DIFF
--- a/dashboard/src/app/actions/analytics/funnels.actions.ts
+++ b/dashboard/src/app/actions/analytics/funnels.actions.ts
@@ -38,7 +38,7 @@ export const deleteFunnelAction = withDashboardMutationAuthContext(
 export const updateFunnelAction = withDashboardMutationAuthContext(
   async (ctx: AuthContext, data: UpdateFunnel): Promise<void> => {
     const validatedData = UpdateFunnelSchema.parse(data);
-    await updateFunnelForDashboard(validatedData);
+    await updateFunnelForDashboard(ctx.dashboardId, validatedData);
     revalidatePath(`/dashboard/${ctx.dashboardId}/funnels`);
   },
 );

--- a/dashboard/src/repositories/postgres/funnels.repository.ts
+++ b/dashboard/src/repositories/postgres/funnels.repository.ts
@@ -21,9 +21,9 @@ export async function getFunnelsByDashboardId(dashboardCUID: string): Promise<Fu
   return funnels.map((funnel) => FunnelSchema.parse(funnel));
 }
 
-export async function getFunnelById(id: string): Promise<Funnel | null> {
-  const funnel = await prisma.funnel.findUnique({
-    where: { id, deletedAt: null },
+export async function getFunnelById(dashboardId: string, id: string): Promise<Funnel | null> {
+  const funnel = await prisma.funnel.findFirst({
+    where: { id, dashboardId, deletedAt: null },
     include: {
       funnelSteps: true,
     },
@@ -56,9 +56,9 @@ export async function deleteFunnelById(dashboardId: string, funnelId: string): P
   });
 }
 
-export async function updateFunnel(funnel: UpdateFunnel): Promise<void> {
+export async function updateFunnel(dashboardId: string, funnel: UpdateFunnel): Promise<void> {
   await prisma.funnel.update({
-    where: { id: funnel.id },
+    where: { id: funnel.id, dashboardId },
     data: {
       ...funnel,
       funnelSteps: {

--- a/dashboard/src/services/analytics/funnels.service.ts
+++ b/dashboard/src/services/analytics/funnels.service.ts
@@ -44,12 +44,13 @@ export async function getFunnelsByDashboardId(
 }
 
 export async function getFunnelDetailsById(
+  dashboardId: string,
   siteId: string,
   funnelId: string,
   startDate: Date,
   endDate: Date,
 ): Promise<FunnelDetails | null> {
-  const funnel = await PostgresFunnelRepository.getFunnelById(funnelId);
+  const funnel = await PostgresFunnelRepository.getFunnelById(dashboardId, funnelId);
 
   if (funnel === null) {
     return null;
@@ -106,7 +107,7 @@ export async function deleteFunnelFromDashboard(dashboardId: string, funnelId: s
   return PostgresFunnelRepository.deleteFunnelById(dashboardId, funnelId);
 }
 
-export async function updateFunnelForDashboard(funnel: UpdateFunnel): Promise<void> {
+export async function updateFunnelForDashboard(dashboardId: string, funnel: UpdateFunnel): Promise<void> {
   const validatedFunnel = UpdateFunnelSchema.parse(funnel);
-  return PostgresFunnelRepository.updateFunnel(validatedFunnel);
+  return PostgresFunnelRepository.updateFunnel(dashboardId, validatedFunnel);
 }

--- a/dashboard/src/trpc/routers/funnels.ts
+++ b/dashboard/src/trpc/routers/funnels.ts
@@ -16,7 +16,13 @@ export const funnelsRouter = createRouter({
     .input(z.object({ funnelId: z.string() }))
     .query(async ({ ctx, input }) => {
       const { main } = ctx;
-      const funnel = await getFunnelDetailsById(ctx.authContext.siteId, input.funnelId, main.startDate, main.endDate);
+      const funnel = await getFunnelDetailsById(
+        ctx.authContext.dashboardId,
+        ctx.authContext.siteId,
+        input.funnelId,
+        main.startDate,
+        main.endDate,
+      );
       if (!funnel) throw new TRPCError({ code: 'NOT_FOUND' });
       return toFunnel(funnel);
     }),


### PR DESCRIPTION
Thread dashboardId through getFunnelById and updateFunnel to match the existing deleteFunnelById signature, so all three CRUD operations scope by dashboard consistently.