### PR TITLE
Fix form-dialog's close flickers

### DIFF
--- a/dashboard/src/app/(protected)/dashboard/[dashboardId]/(dashboard)/funnels/CreateFunnelDialog.tsx
+++ b/dashboard/src/app/(protected)/dashboard/[dashboardId]/(dashboard)/funnels/CreateFunnelDialog.tsx
@@ -14,6 +14,7 @@ import { useTranslations } from 'next-intl';
 import { ComponentProps, useCallback, useMemo, useState } from 'react';
 import { postFunnelAction } from '@/app/actions/index.actions';
 import { useDashboardId } from '@/hooks/use-dashboard-id';
+import { useOverlayReset } from '@/hooks/use-overlay-reset';
 import { toast } from 'sonner';
 import { trpc } from '@/trpc/client';
 import { useFunnelDialog } from '@/hooks/use-funnel-dialog';
@@ -69,6 +70,11 @@ export function CreateFunnelDialog({ triggerText, triggerVariant, disabled }: Cr
     [dashboardId, funnelSteps, metadata.isStrict, metadata.name],
   );
 
+  const { markPending, onAnimationEnd } = useOverlayReset(() => {
+    setHasAttemptedSubmit(false);
+    reset({ name: '', isStrict: false, steps: createDefaultSteps() });
+  });
+
   const handleCreateFunnel = useCallback(() => {
     setHasAttemptedSubmit(true);
     if (!isCreateValid) {
@@ -76,26 +82,23 @@ export function CreateFunnelDialog({ triggerText, triggerVariant, disabled }: Cr
     }
     postFunnelAction(dashboardId, metadata.name, funnelSteps, metadata.isStrict)
       .then(() => {
-        setHasAttemptedSubmit(false);
+        markPending();
         setIsOpen(false);
         toast.success(t('create.successMessage'));
         utils.funnels.list.invalidate({ dashboardId });
-        reset({ name: '', isStrict: false, steps: createDefaultSteps() });
       })
       .catch(() => {
         toast.error(t('create.errorMessage'));
       });
-  }, [dashboardId, funnelSteps, isCreateValid, metadata.isStrict, metadata.name, reset, t, utils]);
+  }, [dashboardId, funnelSteps, isCreateValid, markPending, metadata.isStrict, metadata.name, t, utils]);
 
-  const handleOpenChange = useCallback((open: boolean) => {
-    setIsOpen(open);
-    if (!open) {
-      setHasAttemptedSubmit(false);
-    }
-  }, []);
+  const handleCancel = useCallback(() => {
+    markPending();
+    setIsOpen(false);
+  }, [markPending]);
 
   return (
-    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <DialogTrigger asChild>
         <Button variant={triggerVariant || 'ghost'} className='cursor-pointer' disabled={disabled}>
           <PlusIcon className='h-4 w-4' />
@@ -105,6 +108,7 @@ export function CreateFunnelDialog({ triggerText, triggerVariant, disabled }: Cr
       <DialogContent
         aria-describedby={undefined}
         className='bg-background flex max-h-[90dvh] min-h-[70dvh] w-[70dvw] !max-w-[1000px] flex-col'
+        onAnimationEnd={onAnimationEnd}
       >
         <DialogHeader>
           <DialogTitle>{t('create.createFunnel')}</DialogTitle>
@@ -133,7 +137,7 @@ export function CreateFunnelDialog({ triggerText, triggerVariant, disabled }: Cr
           }}
         />
         <DialogFooter className='flex items-end justify-end gap-2'>
-          <Button variant='outline' className='w-30 cursor-pointer' onClick={() => setIsOpen(false)}>
+          <Button variant='outline' className='w-30 cursor-pointer' onClick={handleCancel}>
             {t('create.cancel')}
           </Button>
           <Button variant='default' className='w-30 cursor-pointer' onClick={handleCreateFunnel}>

--- a/dashboard/src/app/(protected)/dashboard/[dashboardId]/(dashboard)/monitoring/CreateMonitorDialog.tsx
+++ b/dashboard/src/app/(protected)/dashboard/[dashboardId]/(dashboard)/monitoring/CreateMonitorDialog.tsx
@@ -200,7 +200,10 @@ export function CreateMonitorDialog({
               type='button'
               variant='outline'
               className='cursor-pointer'
-              onClick={() => setOpen(false)}
+              onClick={() => {
+                resetForm();
+                setOpen(false);
+              }}
               disabled={isPending}
             >
               {t('actions.cancel')}

--- a/dashboard/src/app/(protected)/dashboard/[dashboardId]/(dashboard)/monitoring/CreateMonitorDialog.tsx
+++ b/dashboard/src/app/(protected)/dashboard/[dashboardId]/(dashboard)/monitoring/CreateMonitorDialog.tsx
@@ -80,6 +80,11 @@ export function CreateMonitorDialog({
     });
   };
 
+  const handleCancel = () => {
+    markPending();
+    setOpen(false);
+  };
+
   const nameAtLimit = (form.state.name?.length ?? 0) >= MONITOR_LIMITS.NAME_MAX;
   const urlAtLimit = url.length >= MONITOR_LIMITS.URL_MAX;
 
@@ -203,10 +208,7 @@ export function CreateMonitorDialog({
               type='button'
               variant='outline'
               className='cursor-pointer'
-              onClick={() => {
-                markPending();
-                setOpen(false);
-              }}
+              onClick={handleCancel}
               disabled={isPending}
             >
               {t('actions.cancel')}

--- a/dashboard/src/app/(protected)/dashboard/[dashboardId]/(dashboard)/monitoring/CreateMonitorDialog.tsx
+++ b/dashboard/src/app/(protected)/dashboard/[dashboardId]/(dashboard)/monitoring/CreateMonitorDialog.tsx
@@ -16,6 +16,7 @@ import { Loader2, CheckCircle2 } from 'lucide-react';
 import { MONITOR_LIMITS } from '@/entities/analytics/monitoring.entities';
 import { isUrlOnDomain } from '@/utils/domainValidation';
 import { useMonitorForm } from './shared/hooks/useMonitorForm';
+import { useOverlayReset } from '@/hooks/use-overlay-reset';
 import { TimingSection, AlertsSection, AdvancedSettingsSection } from './shared/components';
 import { normalizeUrl } from '@/utils/domainValidation';
 import { UpgradeButton } from '@/components/billing/UpgradeButton';
@@ -57,6 +58,8 @@ export function CreateMonitorDialog({
     form.reset();
   };
 
+  const { markPending, onAnimationEnd } = useOverlayReset(resetForm);
+
   const onSubmit = (evt: React.FormEvent<HTMLFormElement>) => {
     evt.preventDefault();
     startTransition(async () => {
@@ -67,7 +70,7 @@ export function CreateMonitorDialog({
           icon: <CheckCircle2 className='h-4 w-4 text-emerald-500' />,
           description: t('successDescription'),
         });
-        resetForm();
+        markPending();
         setOpen(false);
         router.refresh();
       } catch (error) {
@@ -118,7 +121,7 @@ export function CreateMonitorDialog({
           </span>
         </Button>
       </DialogTrigger>
-      <DialogContent className='max-h-[90vh] overflow-y-auto sm:max-w-2xl'>
+      <DialogContent className='max-h-[90vh] overflow-y-auto sm:max-w-2xl' onAnimationEnd={onAnimationEnd}>
         <DialogHeader>
           <DialogTitle>{t('title')}</DialogTitle>
         </DialogHeader>
@@ -201,7 +204,7 @@ export function CreateMonitorDialog({
               variant='outline'
               className='cursor-pointer'
               onClick={() => {
-                resetForm();
+                markPending();
                 setOpen(false);
               }}
               disabled={isPending}

--- a/dashboard/src/app/(protected)/dashboard/[dashboardId]/(dashboard)/monitoring/[monitorId]/EditMonitorSheet.tsx
+++ b/dashboard/src/app/(protected)/dashboard/[dashboardId]/(dashboard)/monitoring/[monitorId]/EditMonitorSheet.tsx
@@ -22,6 +22,7 @@ import { type MonitorCheck } from '@/entities/analytics/monitoring.entities';
 import { isHttpUrl } from '../utils';
 import { useMonitorForm } from '../shared/hooks/useMonitorForm';
 import { useMonitorMutations } from '../shared/hooks/useMonitorMutations';
+import { useOverlayReset } from '@/hooks/use-overlay-reset';
 import { TimingSection, AlertsSection, AdvancedSettingsSection } from '../shared/components';
 
 type EditMonitorSheetProps = {
@@ -54,6 +55,8 @@ export function EditMonitorSheet({
   const { deleteMutation } = useMonitorMutations(dashboardId, monitor.id);
   const form = useMonitorForm({ mode: 'edit', monitor });
 
+  const { markPending, onAnimationEnd } = useOverlayReset(() => form.reset());
+
   const handleOpenChange = useCallback(
     (newOpen: boolean) => {
       if (newOpen) {
@@ -71,10 +74,10 @@ export function EditMonitorSheet({
   );
 
   const handleConfirmDiscard = useCallback(() => {
-    form.reset();
+    markPending();
     setShowConfirmDialog(false);
     setOpen(false);
-  }, [form]);
+  }, [markPending]);
 
   const handleSave = useCallback(() => {
     startTransition(async () => {
@@ -108,7 +111,11 @@ export function EditMonitorSheet({
     <>
       <Sheet open={open} onOpenChange={handleOpenChange}>
         <SheetTrigger asChild>{trigger ?? <Button size='sm'>{t('trigger')}</Button>}</SheetTrigger>
-        <SheetContent side='right' className='w-full max-w-2xl overflow-y-auto p-0 sm:max-w-4xl'>
+        <SheetContent
+          side='right'
+          className='w-full max-w-2xl overflow-y-auto p-0 sm:max-w-4xl'
+          onAnimationEnd={onAnimationEnd}
+        >
           <div className='flex h-full flex-col'>
             <SheetHeader className='border-border space-y-0 border-b px-6 py-5'>
               <SheetTitle className='text-lg font-semibold'>{t('title')}</SheetTitle>

--- a/dashboard/src/app/(protected)/dashboards/CreateDashboardDialog.tsx
+++ b/dashboard/src/app/(protected)/dashboards/CreateDashboardDialog.tsx
@@ -67,9 +67,6 @@ export function CreateDashboardDialog({ dashboardStatsPromise, trigger }: Create
 
       toast.success(t('toast.createdInitializing'));
       setOpen(false);
-      setDomain('');
-      setValidationError('');
-
       router.push(`/dashboard/${newDashboard.data.id}?showIntegration=true`);
     });
   };
@@ -77,7 +74,7 @@ export function CreateDashboardDialog({ dashboardStatsPromise, trigger }: Create
   const handleOpenChange = (newOpen: boolean) => {
     if (!isPending) {
       setOpen(newOpen);
-      if (!newOpen) {
+      if (newOpen) {
         setDomain('');
         setValidationError('');
       }

--- a/dashboard/src/components/bugReport/BugReportDialog.tsx
+++ b/dashboard/src/components/bugReport/BugReportDialog.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/dialog';
 import { Textarea } from '@/components/ui/textarea';
 import { useDashboardId } from '@/hooks/use-dashboard-id';
+import { useOverlayReset } from '@/hooks/use-overlay-reset';
 import { submitBugReportAction } from '@/app/actions/system/bugReports.action';
 import { toast } from 'sonner';
 import { useTranslations } from 'next-intl';
@@ -29,6 +30,8 @@ export function BugReportDialog({ open, onOpenChange }: BugReportDialogProps) {
   const [message, setMessage] = useState('');
   const [isPending, startTransition] = useTransition();
 
+  const { markPending, onAnimationEnd } = useOverlayReset(() => setMessage(''));
+
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const trimmed = message.trim();
@@ -41,7 +44,7 @@ export function BugReportDialog({ open, onOpenChange }: BugReportDialogProps) {
       try {
         await submitBugReportAction(dashboardId, { message: trimmed });
         toast.success(t('toast.success'));
-        setMessage('');
+        markPending();
         onOpenChange(false);
       } catch (error) {
         console.error(error);
@@ -52,7 +55,7 @@ export function BugReportDialog({ open, onOpenChange }: BugReportDialogProps) {
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
+      <DialogContent onAnimationEnd={onAnimationEnd}>
         <DialogHeader>
           <DialogTitle>{t('title')}</DialogTitle>
           <DialogDescription>{t('description')}</DialogDescription>

--- a/dashboard/src/components/charts/AnnotationDialogs.tsx
+++ b/dashboard/src/components/charts/AnnotationDialogs.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Trash2 } from 'lucide-react';
 import { DateTimePicker24h } from '@/app/(protected)/dashboards/DateTimePicker';
+import { useOverlayReset } from '@/hooks/use-overlay-reset';
 import { Label } from '@/components/ui/label';
 import {
   AlertDialog,
@@ -113,6 +114,14 @@ const AnnotationDialogs = forwardRef<AnnotationDialogsRef, AnnotationDialogsProp
     const [editForm, setEditForm] = useState<AnnotationFormState>(emptyForm);
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
+    const { markPending: markCreatePending, onAnimationEnd: onCreateAnimationEnd } = useOverlayReset(() =>
+      setCreateForm(emptyForm),
+    );
+    const { markPending: markEditPending, onAnimationEnd: onEditAnimationEnd } = useOverlayReset(() => {
+      setEditForm(emptyForm);
+      setSelectedAnnotation(null);
+    });
+
     useImperativeHandle(ref, () => ({
       openCreateDialog: (date: number) => {
         setCreateForm({
@@ -149,8 +158,8 @@ const AnnotationDialogs = forwardRef<AnnotationDialogsRef, AnnotationDialogsProp
         colorToken: createForm.color,
       });
 
+      markCreatePending();
       setShowCreateDialog(false);
-      setCreateForm(emptyForm);
     };
 
     const handleUpdateAnnotation = () => {
@@ -163,9 +172,8 @@ const AnnotationDialogs = forwardRef<AnnotationDialogsRef, AnnotationDialogsProp
         date: (editForm.date ?? new Date(selectedAnnotation.date)).getTime(),
       });
 
+      markEditPending();
       setShowEditDialog(false);
-      setSelectedAnnotation(null);
-      setEditForm(emptyForm);
     };
 
     const handleDeleteAnnotation = () => {
@@ -173,16 +181,25 @@ const AnnotationDialogs = forwardRef<AnnotationDialogsRef, AnnotationDialogsProp
 
       onDeleteAnnotation(selectedAnnotation.id);
 
+      markEditPending();
       setShowDeleteConfirm(false);
       setShowEditDialog(false);
-      setSelectedAnnotation(null);
-      setEditForm(emptyForm);
+    };
+
+    const handleCreateCancel = () => {
+      markCreatePending();
+      setShowCreateDialog(false);
+    };
+
+    const handleEditCancel = () => {
+      markEditPending();
+      setShowEditDialog(false);
     };
 
     return (
       <>
         <Dialog open={showCreateDialog} onOpenChange={setShowCreateDialog}>
-          <DialogContent className='sm:max-w-md'>
+          <DialogContent className='sm:max-w-md' onAnimationEnd={onCreateAnimationEnd}>
             <DialogHeader>
               <DialogTitle>{t('addTitle')}</DialogTitle>
             </DialogHeader>
@@ -226,7 +243,7 @@ const AnnotationDialogs = forwardRef<AnnotationDialogsRef, AnnotationDialogsProp
               />
             </div>
             <DialogFooter>
-              <Button variant='outline' className='cursor-pointer' onClick={() => setShowCreateDialog(false)}>
+              <Button variant='outline' className='cursor-pointer' onClick={handleCreateCancel}>
                 {t('cancel')}
               </Button>
               <Button
@@ -249,7 +266,7 @@ const AnnotationDialogs = forwardRef<AnnotationDialogsRef, AnnotationDialogsProp
             }
           }}
         >
-          <DialogContent className='sm:max-w-md'>
+          <DialogContent className='sm:max-w-md' onAnimationEnd={onEditAnimationEnd}>
             <DialogHeader>
               <DialogTitle>{t('editTitle')}</DialogTitle>
             </DialogHeader>
@@ -326,7 +343,7 @@ const AnnotationDialogs = forwardRef<AnnotationDialogsRef, AnnotationDialogsProp
                 <Button
                   variant='outline'
                   className='min-w-[104px] cursor-pointer'
-                  onClick={() => setShowEditDialog(false)}
+                  onClick={handleEditCancel}
                 >
                   {t('cancel')}
                 </Button>

--- a/dashboard/src/components/filters/SaveQueryFilterDialog.tsx
+++ b/dashboard/src/components/filters/SaveQueryFilterDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { SaveIcon, Loader2Icon } from 'lucide-react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
@@ -38,7 +38,6 @@ export function SaveQueryFilterDialog({ open, onOpenChange, filters }: SaveQuery
         })),
       });
       toast.success(t('selector.toastFilterSavedSuccess'));
-      setFilterName('');
       onOpenChange(false);
     } catch {
       toast.error(t('selector.toastFilterSavedError'));
@@ -46,18 +45,14 @@ export function SaveQueryFilterDialog({ open, onOpenChange, filters }: SaveQuery
     baEvent('query-filter-saved');
   }, [filterName, filters, createSavedFilterMutation, onOpenChange, t]);
 
-  const handleOpenChange = useCallback(
-    (isOpen: boolean) => {
-      if (!isOpen) {
-        setFilterName('');
-      }
-      onOpenChange(isOpen);
-    },
-    [onOpenChange],
-  );
+  useEffect(() => {
+    if (open) {
+      setFilterName('');
+    }
+  }, [open]);
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent aria-describedby={undefined} className='max-w-[320px]'>
         <DialogHeader>
           <DialogTitle>{t('selector.saveFiltersTitle')}</DialogTitle>

--- a/dashboard/src/hooks/use-overlay-reset.ts
+++ b/dashboard/src/hooks/use-overlay-reset.ts
@@ -10,6 +10,7 @@ export function useOverlayReset(reset: () => void) {
   }, []);
 
   const onAnimationEnd = useCallback((e: AnimationEvent<HTMLElement>) => {
+    if (e.target !== e.currentTarget) return;
     const state = e.currentTarget.dataset.state;
     if (state === 'open') {
       pendingRef.current = false;

--- a/dashboard/src/hooks/use-overlay-reset.ts
+++ b/dashboard/src/hooks/use-overlay-reset.ts
@@ -1,0 +1,25 @@
+import { useCallback, useRef, type AnimationEvent } from 'react';
+
+export function useOverlayReset(reset: () => void) {
+  const pendingRef = useRef(false);
+  const resetRef = useRef(reset);
+  resetRef.current = reset;
+
+  const markPending = useCallback(() => {
+    pendingRef.current = true;
+  }, []);
+
+  const onAnimationEnd = useCallback((e: AnimationEvent<HTMLElement>) => {
+    const state = e.currentTarget.dataset.state;
+    if (state === 'open') {
+      pendingRef.current = false;
+      return;
+    }
+    if (state !== 'closed') return;
+    if (!pendingRef.current) return;
+    pendingRef.current = false;
+    resetRef.current();
+  }, []);
+
+  return { markPending, onAnimationEnd };
+}


### PR DESCRIPTION
Many of our dialogues reset the form before the dialogue has actually finished animation. This causes a layout shift / flicker, as the content clears before the overlay closes.

The pattern I have used to resolve this depends on the type of dialogue:
- If the dialogue should always be empty (default value) when it opens, the simplest fix is to clear it when it opens. 
   * Applied to `SaveQueryFilterDialog`
   * Applied to `CreateDashboardDialog` 

- If the dialogue should only clear on specific actions, the best pattern is to use a ref to track when to clear, and bind it to `onAnimationEnd` - I have created a reusable hook to simplify this (`useOverlayReset`) as part of this PR.
   * Applied to `CreateMonitorDialog`
   * Applied to `CreateFunnelDialog`
   * Applied to `EditMonitorSheet`
   * Applied to `BugReportDialog`
   * Applied to `AnnotationDialogs`

**Important**: `CreateMonitor` has a small behavior change beyond the flicker fix. I noticed that the Cancel button used to silently not clear at all.  I have adjusted it to actually clear, since there's no reason to have a cancel and close button, if they do the same