### PR TITLE
Added invoice list in user settings dialog

### DIFF
--- a/dashboard/messages/da.json
+++ b/dashboard/messages/da.json
@@ -2842,6 +2842,23 @@
           "description": "Betalingsmetode, fakturaer og faktureringsoplysninger.",
           "openPortal": "Åbn faktureringsportal"
         },
+        "invoices": {
+          "title": "Fakturaer",
+          "view": "Vis",
+          "columns": {
+            "date": "Dato",
+            "total": "Beløb",
+            "status": "Status",
+            "actions": "Handlinger"
+          },
+          "status": {
+            "draft": "Kladde",
+            "open": "Åben",
+            "paid": "Betalt",
+            "uncollectible": "Uinddrivelig",
+            "void": "Annulleret"
+          }
+        },
         "cancellation": {
           "title": "Annullering",
           "label": "Annullér abonnement",

--- a/dashboard/messages/en.json
+++ b/dashboard/messages/en.json
@@ -2836,6 +2836,23 @@
           "description": "Payment method, invoices, and billing details.",
           "openPortal": "Open Billing Portal"
         },
+        "invoices": {
+          "title": "Invoices",
+          "view": "View",
+          "columns": {
+            "date": "Date",
+            "total": "Total",
+            "status": "Status",
+            "actions": "Actions"
+          },
+          "status": {
+            "draft": "Draft",
+            "open": "Open",
+            "paid": "Paid",
+            "uncollectible": "Uncollectible",
+            "void": "Void"
+          }
+        },
         "cancellation": {
           "title": "Cancellation",
           "label": "Cancel subscription",

--- a/dashboard/messages/it.json
+++ b/dashboard/messages/it.json
@@ -2850,6 +2850,23 @@
           "description": "Metodo di pagamento, fatture e dettagli di fatturazione.",
           "openPortal": "Apri portale di fatturazione"
         },
+        "invoices": {
+          "title": "Fatture",
+          "view": "Visualizza",
+          "columns": {
+            "date": "Data",
+            "total": "Totale",
+            "status": "Stato",
+            "actions": "Azioni"
+          },
+          "status": {
+            "draft": "Bozza",
+            "open": "Aperta",
+            "paid": "Pagata",
+            "uncollectible": "Non riscuotibile",
+            "void": "Annullata"
+          }
+        },
         "cancellation": {
           "title": "Annullamento",
           "label": "Annulla abbonamento",

--- a/dashboard/messages/nb.json
+++ b/dashboard/messages/nb.json
@@ -2850,6 +2850,23 @@
           "description": "Betalingsmetode, fakturaer og faktureringsopplysninger.",
           "openPortal": "Åpne faktureringsportal"
         },
+        "invoices": {
+          "title": "Fakturaer",
+          "view": "Vis",
+          "columns": {
+            "date": "Dato",
+            "total": "Totalt",
+            "status": "Status",
+            "actions": "Handlinger"
+          },
+          "status": {
+            "draft": "Utkast",
+            "open": "Åpen",
+            "paid": "Betalt",
+            "uncollectible": "Ikke innkrevbar",
+            "void": "Annullert"
+          }
+        },
         "cancellation": {
           "title": "Avbestilling",
           "label": "Avbestill abonnement",

--- a/dashboard/src/actions/billing.action.ts
+++ b/dashboard/src/actions/billing.action.ts
@@ -2,7 +2,12 @@
 
 import { withUserAuth, withDashboardAuthContext } from '@/auth/auth-actions';
 import { getUserBillingStats, getDashboardOwnerBillingStats } from '@/services/billing/billing.service';
-import { type UserBillingData, buildSelfHostedBillingData } from '@/entities/billing/billing.entities';
+import { listUserInvoices } from '@/services/billing/invoice.service';
+import {
+  type UserBillingData,
+  type UserInvoice,
+  buildSelfHostedBillingData,
+} from '@/entities/billing/billing.entities';
 import { User } from 'next-auth';
 import { isFeatureEnabled } from '@/lib/feature-flags';
 import { AuthContext } from '@/entities/auth/authContext.entities';
@@ -13,6 +18,14 @@ export const getUserBillingData = withUserAuth(async (user: User): Promise<UserB
   }
 
   return getUserBillingStats(user.id);
+});
+
+export const getUserInvoices = withUserAuth(async (user: User): Promise<UserInvoice[]> => {
+  if (!isFeatureEnabled('enableBilling')) {
+    return [];
+  }
+
+  return listUserInvoices(user.id);
 });
 
 export const getDashboardOwnerBillingData = withDashboardAuthContext(

--- a/dashboard/src/components/userSettings/billing/UserBillingInvoicesSettings.tsx
+++ b/dashboard/src/components/userSettings/billing/UserBillingInvoicesSettings.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { useLocale, useTranslations } from 'next-intl';
+import { ExternalLink as ExternalLinkIcon } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useUserInvoices } from '@/hooks/useUserInvoices';
+import type { UserInvoice } from '@/entities/billing/billing.entities';
+import type { SupportedLanguages } from '@/constants/i18n';
+import { formatPrice } from '@/utils/pricing';
+import UserSettingsSection from '../shared/UserSettingsSection';
+
+export default function UserBillingInvoicesSettings() {
+  const t = useTranslations('components.userSettings.billing.invoices');
+  const locale = useLocale();
+  const { invoices, isLoading, error } = useUserInvoices();
+
+  if (error) {
+    return null;
+  }
+
+  if (isLoading) {
+    return (
+      <UserSettingsSection title={t('title')}>
+        <Skeleton className='h-20 w-full' />
+      </UserSettingsSection>
+    );
+  }
+
+  if (invoices.length === 0) {
+    return null;
+  }
+
+  return (
+    <UserSettingsSection title={t('title')}>
+      <div className='-mx-2 overflow-x-auto'>
+        <table className='w-full text-sm'>
+          <thead>
+            <tr className='text-muted-foreground border-border border-b text-left text-xs font-medium'>
+              <th className='px-2 py-2 font-medium'>{t('columns.date')}</th>
+              <th className='px-2 py-2 font-medium'>{t('columns.total')}</th>
+              <th className='px-2 py-2 font-medium'>{t('columns.status')}</th>
+              <th className='px-2 py-2 font-medium'>
+                <span className='sr-only'>{t('columns.actions')}</span>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {invoices.map((invoice) => (
+              <InvoiceRow key={invoice.id} invoice={invoice} locale={locale} />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </UserSettingsSection>
+  );
+}
+
+interface InvoiceRowProps {
+  invoice: UserInvoice;
+  locale: string;
+}
+
+function InvoiceRow({ invoice, locale }: InvoiceRowProps) {
+  const t = useTranslations('components.userSettings.billing.invoices');
+  const date = invoice.created.toLocaleDateString(locale, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+  const total = formatPrice(invoice.total, invoice.currency, locale as SupportedLanguages);
+  const viewUrl = invoice.hostedInvoiceUrl ?? invoice.invoicePdf;
+
+  return (
+    <tr className='border-border/60 border-b last:border-b-0'>
+      <td className='px-2 py-3'>{date}</td>
+      <td className='px-2 py-3 tabular-nums'>{total}</td>
+      <td className='px-2 py-3'>
+        <InvoiceStatusBadge status={invoice.status} />
+      </td>
+      <td className='px-2 py-3 text-right'>
+        {viewUrl && (
+          <a
+            href={viewUrl}
+            target='_blank'
+            rel='noopener noreferrer'
+            className='text-primary inline-flex items-center gap-1 text-sm hover:underline'
+          >
+            {t('view')}
+            <ExternalLinkIcon className='h-3 w-3' />
+          </a>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+const INVOICE_BADGE_STYLES: Record<
+  NonNullable<UserInvoice['status']>,
+  { variant: 'default' | 'secondary' | 'destructive' | 'outline'; className?: string }
+> = {
+  paid: {
+    variant: 'default',
+    className: 'border-transparent bg-emerald-600 text-white dark:bg-emerald-800',
+  },
+  open: { variant: 'default' },
+  draft: { variant: 'secondary' },
+  uncollectible: { variant: 'destructive' },
+  void: { variant: 'destructive' },
+};
+
+function InvoiceStatusBadge({ status }: { status: UserInvoice['status'] }) {
+  const t = useTranslations('components.userSettings.billing.invoices.status');
+  if (!status) {
+    return null;
+  }
+
+  const { variant, className } = INVOICE_BADGE_STYLES[status];
+  return (
+    <Badge variant={variant} className={className}>
+      {t(status)}
+    </Badge>
+  );
+}

--- a/dashboard/src/components/userSettings/billing/UserBillingSettings.tsx
+++ b/dashboard/src/components/userSettings/billing/UserBillingSettings.tsx
@@ -14,6 +14,7 @@ import { formatPrice } from '@/utils/pricing';
 import { formatNumber, formatPercentage } from '@/utils/formatters';
 import UserSettingsSection from '../shared/UserSettingsSection';
 import SettingRow from '../shared/SettingRow';
+import UserBillingInvoicesSettings from './UserBillingInvoicesSettings';
 
 interface UserBillingSettingsProps {
   onCloseDialog?: () => void;
@@ -139,6 +140,8 @@ export default function UserBillingSettings({ onCloseDialog }: UserBillingSettin
           />
         </UserSettingsSection>
       )}
+
+      <UserBillingInvoicesSettings />
 
       {isPaid && isActive && !isCanceled && (
         <UserSettingsSection title={t('cancellation.title')}>

--- a/dashboard/src/entities/billing/billing.entities.ts
+++ b/dashboard/src/entities/billing/billing.entities.ts
@@ -139,6 +139,19 @@ export const SubscriptionEndingSoonCandidateSchema = z.object({
   currentPeriodEnd: z.date(),
 });
 
+export const InvoiceStatusSchema = z.enum(['draft', 'open', 'paid', 'uncollectible', 'void']);
+
+export const UserInvoiceSchema = z.object({
+  id: z.string(),
+  number: z.string().nullable(),
+  created: z.date(),
+  total: z.number(),
+  currency: z.string(),
+  status: InvoiceStatusSchema.nullable(),
+  hostedInvoiceUrl: z.string().nullable(),
+  invoicePdf: z.string().nullable(),
+});
+
 export const UserBillingDataSchema = z.object({
   subscription: z.object({
     tier: TierSchema,
@@ -165,3 +178,5 @@ export type SubscriptionWithOwnedSites = z.infer<typeof SubscriptionWithOwnedSit
 export type SubscriptionEndingSoonCandidate = z.infer<typeof SubscriptionEndingSoonCandidateSchema>;
 export type PaymentStatus = z.infer<typeof PaymentStatusSchema>;
 export type UserBillingData = z.infer<typeof UserBillingDataSchema>;
+export type InvoiceStatus = z.infer<typeof InvoiceStatusSchema>;
+export type UserInvoice = z.infer<typeof UserInvoiceSchema>;

--- a/dashboard/src/hooks/useUserInvoices.ts
+++ b/dashboard/src/hooks/useUserInvoices.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { getUserInvoices } from '@/actions/billing.action';
+
+const USER_INVOICES_QUERY_KEY = ['userInvoices'] as const;
+
+export function useUserInvoices(enabled: boolean = true) {
+  const query = useQuery({
+    queryKey: USER_INVOICES_QUERY_KEY,
+    queryFn: async () => {
+      const result = await getUserInvoices();
+      if (!result.success) {
+        throw new Error(result.error.message);
+      }
+      return result.data;
+    },
+    enabled,
+  });
+
+  return {
+    invoices: query.data ?? [],
+    isLoading: query.isLoading,
+    error: query.error ? query.error.message : null,
+  };
+}

--- a/dashboard/src/services/billing/invoice.service.ts
+++ b/dashboard/src/services/billing/invoice.service.ts
@@ -1,0 +1,47 @@
+'server-only';
+
+import { stripe } from '@/lib/billing/stripe';
+import { getUserSubscription } from '@/repositories/postgres/subscription.repository';
+import { UserInvoiceSchema, type UserInvoice } from '@/entities/billing/billing.entities';
+import { UserException } from '@/lib/exceptions';
+
+const INVOICE_LIST_LIMIT = 12;
+
+export async function listUserInvoices(userId: string): Promise<UserInvoice[]> {
+  try {
+    const subscription = await getUserSubscription(userId);
+
+    if (!subscription?.paymentCustomerId) {
+      return [];
+    }
+
+    const invoices = await stripe.invoices.list({
+      customer: subscription.paymentCustomerId,
+      limit: INVOICE_LIST_LIMIT,
+    });
+
+    return invoices.data.flatMap<UserInvoice>((invoice) => {
+      if (!invoice.id) return [];
+      try {
+        return [
+          UserInvoiceSchema.parse({
+            id: invoice.id,
+            number: invoice.number,
+            created: new Date(invoice.created * 1000),
+            total: invoice.total,
+            currency: invoice.currency.toUpperCase(),
+            status: invoice.status,
+            hostedInvoiceUrl: invoice.hosted_invoice_url ?? null,
+            invoicePdf: invoice.invoice_pdf ?? null,
+          }),
+        ];
+      } catch (parseError) {
+        console.error(`Failed to parse invoice ${invoice.id}, skipping:`, parseError);
+        return [];
+      }
+    });
+  } catch (error) {
+    console.error('Failed to list user invoices:', error);
+    throw new UserException('Failed to load invoices');
+  }
+}

--- a/dashboard/src/utils/pricing.ts
+++ b/dashboard/src/utils/pricing.ts
@@ -1,13 +1,12 @@
-import { Currency } from '@/entities/billing/billing.entities';
 import type { SupportedLanguages } from '@/constants/i18n';
 
-export function formatPrice(cents: number, currency: Currency = 'USD', locale?: SupportedLanguages): string {
+export function formatPrice(cents: number, currency: string = 'USD', locale?: SupportedLanguages): string {
   const amount = cents / 100;
 
   const resolvedLocale = locale ?? (currency === 'EUR' ? 'de-DE' : 'en-US');
 
   return new Intl.NumberFormat(resolvedLocale, {
     style: 'currency',
-    currency: currency,
+    currency,
   }).format(amount);
 }


### PR DESCRIPTION
Added overview of invoices in user settings dialog - links to Stripe invoices and receipts.

<img width="1011" height="913" alt="{C0F721FE-1CA5-44AE-9921-D6E2AF2825CC}" src="https://github.com/user-attachments/assets/7b050966-6f08-4bab-b05c-e0db6a3f4257" />

Had to widen the Currency formatter to accept strings to support Stripe's free-form ISO 4217 code 