### PR TITLE
Added session cache warming on bootup

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -47,6 +47,8 @@ pub struct Config {
     pub monitor_incidents_table: String,
     // Session replay configuration
     pub enable_session_replay: bool,
+    // Warm the in-memory session cache from ClickHouse on boot (so sessions survive restarts)
+    pub session_cache_warm_enabled: bool,
     // S3 session replay storage configuration
     pub s3_enabled: bool,
     pub s3_region: Option<String>,
@@ -157,6 +159,10 @@ impl Config {
             enable_session_replay: env::var("SESSION_REPLAYS_ENABLED")
                 .map(|val| val.to_lowercase() == "true")
                 .unwrap_or(false),
+            // On by default; can be used to disable session warming if it catches a bad query plan
+            session_cache_warm_enabled: env::var("ENABLE_SESSION_CACHE_WARM")
+                .map(|val| val.to_lowercase() != "false")
+                .unwrap_or(true),
             // S3 configuration (optional; defaults to disabled)
             s3_enabled: env::var("S3_ENABLED").map(|v| v.to_lowercase() == "true").unwrap_or(false),
             s3_region: env::var("S3_REGION").ok(),

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -11,7 +11,7 @@ use crate::config::Config;
 use crate::processing::ProcessedEvent;
 
 mod models;
-pub use models::{EventRow, ReferrerSourceCategoryRow, SessionReplayRow};
+pub use models::{ActiveSessionRow, EventRow, ReferrerSourceCategoryRow, SessionReplayRow};
 
 const NUM_INSERT_WORKERS: usize = 1;
 const EVENT_CHANNEL_CAPACITY: usize = 100_000;
@@ -36,6 +36,17 @@ impl Database {
         Self::spawn_dispatcher(event_rx, worker_senders);
 
         Ok(Self { clickhouse, event_tx, config })
+    }
+
+    /// Fetch the current session of every visitor active within `window`, from `analytics.sessions`
+    pub async fn fetch_active_sessions(&self, window: Duration) -> Result<Vec<ActiveSessionRow>> {
+        let rows = self
+            .clickhouse
+            .inner()
+            .query(&active_sessions_query(window.as_secs()))
+            .fetch_all::<ActiveSessionRow>()
+            .await?;
+        Ok(rows)
     }
 
     fn create_channels() -> (mpsc::Sender<ProcessedEvent>, mpsc::Receiver<ProcessedEvent>) {
@@ -306,4 +317,18 @@ async fn run_inserter_worker(
         worker_id, stats
     );
     Ok(())
+}
+
+/// SQL to load each active visitor's most recent session. Filtering on `session_end` uses the
+/// `idx_session_end` minmax skip index, so the cost is bounded by the number of *active*
+/// sessions, not total history; `argMax(.., session_end)` picks each visitor's current session.
+fn active_sessions_query(window_secs: u64) -> String {
+    format!(
+        "SELECT site_id, toUInt64(visitor_id) AS visitor_id, \
+                argMax(session_id, session_end) AS session_id, \
+                argMax(session_created_at, session_end) AS session_created_at \
+         FROM analytics.sessions \
+         WHERE session_end > now() - toIntervalSecond({window_secs}) \
+         GROUP BY site_id, visitor_id"
+    )
 }

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -43,7 +43,7 @@ impl Database {
         let rows = self
             .clickhouse
             .inner()
-            .query(&active_sessions_query(window.as_secs()))
+            .query(&active_sessions_query(window))
             .fetch_all::<ActiveSessionRow>()
             .await?;
         Ok(rows)
@@ -322,7 +322,8 @@ async fn run_inserter_worker(
 /// SQL to load each active visitor's most recent session. Filtering on `session_end` uses the
 /// `idx_session_end` minmax skip index, so the cost is bounded by the number of *active*
 /// sessions, not total history; `argMax(.., session_end)` picks each visitor's current session.
-fn active_sessions_query(window_secs: u64) -> String {
+fn active_sessions_query(window: Duration) -> String {
+    let window_secs = window.as_secs();
     format!(
         "SELECT site_id, toUInt64(visitor_id) AS visitor_id, \
                 argMax(session_id, session_end) AS session_id, \

--- a/backend/src/db/models.rs
+++ b/backend/src/db/models.rs
@@ -56,6 +56,17 @@ pub struct EventRow {
     pub page_duration_seconds: u32,
 }
 
+/// One active session recovered from `analytics.sessions`, used to warm the in-memory
+/// session cache on boot. Field order must match the `SELECT` in `fetch_active_sessions`.
+#[derive(clickhouse::Row, Deserialize)]
+pub struct ActiveSessionRow {
+    pub site_id: String,
+    pub visitor_id: u64,
+    pub session_id: u64,
+    #[serde(with = "clickhouse::serde::chrono::datetime")]
+    pub session_created_at: DateTime<Utc>,
+}
+
 #[derive(clickhouse::Row, Serialize, Debug, Deserialize)]
 pub struct SessionReplayRow {
     pub site_id: String,

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -163,6 +163,10 @@ async fn main() {
         .await
         .expect("Failed to initialize salt service");
 
+    if config.session_cache_warm_enabled {
+        warm_session_cache(&db).await;
+    }
+
     let refresh_config = RefreshConfig::default();
 
     let site_cfg_cache =
@@ -258,7 +262,21 @@ async fn main() {
     .unwrap();
 }
 
-
+/// Warm the session cache from ClickHouse so in-flight sessions survive a restart
+async fn warm_session_cache(db: &Database) {
+    match db.fetch_active_sessions(session::SESSION_EXPIRY).await {
+        Ok(rows) => {
+            let warmed = session::warm(rows.into_iter().map(|r| session::WarmSession {
+                site_id: r.site_id,
+                visitor_fingerprint: r.visitor_id,
+                session_id: r.session_id,
+                created_at: r.session_created_at,
+            }));
+            info!("Warmed {} active sessions into the session cache", warmed);
+        }
+        Err(e) => warn!("Session cache warm failed (starting with empty cache): {}", e),
+    }
+}
 
 async fn health_check(
     State((db, _, _, _, _, _)): State<(

--- a/backend/src/processing/mod.rs
+++ b/backend/src/processing/mod.rs
@@ -178,17 +178,9 @@ impl EventProcessor {
             visitor::identify(&site_id, &attrs, timestamp)
         };
 
-        match identity {
-            Ok(identity) => {
-                processed.visitor_fingerprint = identity.fingerprint;
-                processed.session_id = identity.session_id;
-                processed.session_created_at = identity.session_created_at;
-            }
-            Err(e) => {
-                error!("Failed to get session ID: {}. Event processing aborted for: {:?}", e, processed.event);
-                return Ok(());
-            }
-        };
+        processed.visitor_fingerprint = identity.fingerprint;
+        processed.session_id = identity.session_id;
+        processed.session_created_at = identity.session_created_at;
 
         debug!("Site ID: {}", processed.site_id);
         debug!("Session ID: {}", processed.session_id);

--- a/backend/src/session/mod.rs
+++ b/backend/src/session/mod.rs
@@ -1,11 +1,11 @@
-use anyhow::Result;
 use chrono::{DateTime, Utc};
 use moka::sync::Cache;
-use std::time::Duration;
 use once_cell::sync::Lazy;
 use rand::Rng;
+use std::time::Duration;
 
-const SESSION_EXPIRY: Duration = Duration::from_secs(30 * 60);
+/// How long a session stays alive without activity
+pub const SESSION_EXPIRY: Duration = Duration::from_secs(30 * 60);
 
 #[derive(Clone)]
 struct SessionEntry {
@@ -13,46 +13,140 @@ struct SessionEntry {
     created_at: DateTime<Utc>,
 }
 
-static SESSION_CACHE: Lazy<Cache<String, SessionEntry>> = Lazy::new(|| {
-    Cache::builder()
-        .time_to_idle(SESSION_EXPIRY)
-        .build()
-});
-
-fn generate_session_id() -> u64 {
-    rand::thread_rng().r#gen()
+/// A session recovered from database, used to pre-populate the cache on boot.
+pub struct WarmSession {
+    pub site_id: String,
+    pub visitor_fingerprint: u64,
+    pub session_id: u64,
+    pub created_at: DateTime<Utc>,
 }
 
+/// In-memory `{site}-{fingerprint}` -> session map, expiring after `SESSION_EXPIRY` of inactivity.
+struct SessionCache {
+    entries: Cache<String, SessionEntry>,
+}
+
+impl SessionCache {
+    fn new() -> Self {
+        Self {
+            entries: Cache::builder().time_to_idle(SESSION_EXPIRY).build(),
+        }
+    }
+
+    /// Return the visitor's existing session, or assign a new one. On a miss, the lazily-computed
+    /// `previous_fingerprint` is tried so a visitor keeps their session across a midnight salt rotation.
+    fn get_or_create(
+        &self,
+        site_id: &str,
+        visitor_fingerprint: u64,
+        previous_fingerprint: impl FnOnce() -> Option<u64>,
+        event_timestamp: DateTime<Utc>,
+    ) -> (u64, DateTime<Utc>) {
+        let cache_key = format!("{}-{}", site_id, visitor_fingerprint);
+
+        if let Some(entry) = self.entries.get(&cache_key) {
+            return (entry.session_id, entry.created_at);
+        }
+
+        if let Some(prev_fp) = previous_fingerprint() {
+            if prev_fp != visitor_fingerprint {
+                let previous_key = format!("{}-{}", site_id, prev_fp);
+                if let Some(entry) = self.entries.get(&previous_key) {
+                    return (entry.session_id, entry.created_at);
+                }
+            }
+        }
+
+        let entry = SessionEntry {
+            session_id: rand::thread_rng().r#gen(),
+            created_at: event_timestamp,
+        };
+        self.entries.insert(cache_key, entry.clone());
+        (entry.session_id, entry.created_at)
+    }
+
+    /// Pre-populate with recovered sessions; returns the number inserted.
+    fn warm(&self, sessions: impl IntoIterator<Item = WarmSession>) -> usize {
+        let mut count = 0;
+        for s in sessions {
+            self.entries.insert(
+                format!("{}-{}", s.site_id, s.visitor_fingerprint),
+                SessionEntry {
+                    session_id: s.session_id,
+                    created_at: s.created_at,
+                },
+            );
+            count += 1;
+        }
+        count
+    }
+}
+
+static SESSION_CACHE: Lazy<SessionCache> = Lazy::new(SessionCache::new);
+
+/// Resolve (or create) the session id for an event.
 pub fn get_or_create_session_id(
     site_id: &str,
     visitor_fingerprint: u64,
     previous_fingerprint: impl FnOnce() -> Option<u64>,
     event_timestamp: DateTime<Utc>,
-) -> Result<(u64, DateTime<Utc>)> {
-    let cache_key = format!("{}-{}", site_id, visitor_fingerprint);
+) -> (u64, DateTime<Utc>) {
+    SESSION_CACHE.get_or_create(
+        site_id,
+        visitor_fingerprint,
+        previous_fingerprint,
+        event_timestamp,
+    )
+}
 
-    if let Some(entry) = SESSION_CACHE.get(&cache_key) {
-        return Ok((entry.session_id, entry.created_at));
-    }
+/// Pre-populate the cache with recovered sessions so they survive a restart; returns the number
+/// inserted. (moka resets the idle timer on insert, so a warmed entry can outlive its real last
+/// activity by up to `SESSION_EXPIRY`)
+pub fn warm(sessions: impl IntoIterator<Item = WarmSession>) -> usize {
+    SESSION_CACHE.warm(sessions)
+}
 
-    // A visitor crossing midnight has a different fingerprint under the previous salt; fall
-    // back to it to keep the session alive.
-    if let Some(prev_fp) = previous_fingerprint() {
-        if prev_fp != visitor_fingerprint {
-            let previous_key = format!("{}-{}", site_id, prev_fp);
-            if let Some(entry) = SESSION_CACHE.get(&previous_key) {
-                return Ok((entry.session_id, entry.created_at));
-            }
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn warm_session(fingerprint: u64, session_id: u64, created_at: DateTime<Utc>) -> WarmSession {
+        WarmSession {
+            site_id: "site".to_string(),
+            visitor_fingerprint: fingerprint,
+            session_id,
+            created_at,
         }
     }
 
-    let new_session_id = generate_session_id();
-    let created_at = event_timestamp;
+    #[test]
+    fn warmed_session_is_reused_by_subsequent_event() {
+        let cache = SessionCache::new();
+        let created_at = Utc::now();
 
-    SESSION_CACHE.insert(cache_key, SessionEntry {
-        session_id: new_session_id,
-        created_at,
-    });
+        assert_eq!(cache.warm([warm_session(1, 42, created_at)]), 1);
 
-    Ok((new_session_id, created_at))
+        let (session_id, session_start) = cache.get_or_create("site", 1, || None, Utc::now());
+        assert_eq!(session_id, 42);
+        assert_eq!(session_start, created_at);
+    }
+
+    #[test]
+    fn previous_fingerprint_bridges_a_rotation() {
+        let cache = SessionCache::new();
+
+        let (session_a, _) = cache.get_or_create("site", 100, || None, Utc::now());
+        // Current fp is now B (salt rotated), previous is A -> same session.
+        let (session_b, _) = cache.get_or_create("site", 200, || Some(100), Utc::now());
+
+        assert_eq!(session_a, session_b);
+    }
+
+    #[test]
+    fn distinct_visitors_get_distinct_sessions() {
+        let cache = SessionCache::new();
+        let (a, _) = cache.get_or_create("site", 1, || None, Utc::now());
+        let (b, _) = cache.get_or_create("site", 2, || None, Utc::now());
+        assert_ne!(a, b);
+    }
 }

--- a/backend/src/session_replay/mod.rs
+++ b/backend/src/session_replay/mod.rs
@@ -111,11 +111,7 @@ pub async fn presign_put_segment(
             root_domain: root_domain.as_deref(),
         };
         visitor::identify(&req.site_id, &attrs, Utc::now())
-    }
-    .map_err(|e| {
-        error!("Failed to get session ID: {}", e);
-        (StatusCode::INTERNAL_SERVER_ERROR, "internal error".to_string())
-    })?;
+    };
     let fingerprint = identity.fingerprint;
     let session_id = identity.session_id;
 

--- a/backend/src/visitor/mod.rs
+++ b/backend/src/visitor/mod.rs
@@ -1,6 +1,5 @@
 //! Visitor identification: turns request attributes into a salted fingerprint and a session id
 
-use anyhow::Result;
 use chrono::{DateTime, Utc};
 
 use crate::analytics::{VisitorAttrs, generate_fingerprint};
@@ -20,7 +19,7 @@ pub fn identify(
     site_id: &str,
     attrs: &VisitorAttrs<'_>,
     event_timestamp: DateTime<Utc>,
-) -> Result<VisitorIdentity> {
+) -> VisitorIdentity {
     let (current_salt, previous_salt) = salt::current_and_previous();
 
     let fingerprint = generate_fingerprint(&current_salt, attrs);
@@ -30,11 +29,11 @@ pub fn identify(
         fingerprint,
         || previous_salt.as_ref().map(|s| generate_fingerprint(s, attrs)),
         event_timestamp,
-    )?;
+    );
 
-    Ok(VisitorIdentity {
+    VisitorIdentity {
         fingerprint,
         session_id,
         session_created_at,
-    })
+    }
 }


### PR DESCRIPTION
Warms the session cache on startup. This is to prevent in-flight sessions from being assigned a new session when the backend is redeployed.