### PR TITLE
Highlight empty filter values in funnel steps and lock the contract

### DIFF
--- a/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/funnels/FunnelStepAccordionItem.tsx
+++ b/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/funnels/FunnelStepAccordionItem.tsx
@@ -307,6 +307,7 @@ function FunnelStepAccordionItemComponent({
             filters={step.filters}
             onChange={handleFiltersChange}
             globalPropertyKeys={globalPropertyKeys}
+            showEmptyValueErrors={showFilterEmptyError}
           />
         </AccordionContent>
       </AccordionItem>

--- a/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/funnels/FunnelStepFiltersEditor.tsx
+++ b/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/funnels/FunnelStepFiltersEditor.tsx
@@ -11,7 +11,7 @@ import { DisabledTooltip } from '@/components/tooltip/DisabledTooltip';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Separator } from '@/components/ui/separator';
-import { createEmptyQueryFilter, type QueryFilter } from '@/entities/analytics/filter.entities';
+import { createEmptyQueryFilter, isNonEmptyValue, type QueryFilter } from '@/entities/analytics/filter.entities';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { useSavedFiltersLimitReached } from '@/hooks/use-saved-filters';
 import { cn } from '@/lib/utils';
@@ -21,6 +21,7 @@ type FunnelStepFiltersEditorProps = {
   filters: QueryFilter[];
   onChange: (next: QueryFilter[]) => void;
   globalPropertyKeys?: string[];
+  showEmptyValueErrors?: boolean;
 };
 
 const INTERACTIVE_ELEMENT_SELECTOR =
@@ -30,6 +31,7 @@ function FunnelStepFiltersEditorComponent({
   filters,
   onChange,
   globalPropertyKeys,
+  showEmptyValueErrors,
 }: FunnelStepFiltersEditorProps) {
   const t = useTranslations('components.filters');
   const isMobile = useIsMobile();
@@ -99,6 +101,7 @@ function FunnelStepFiltersEditorComponent({
                 onFilterUpdate={handleUpdate}
                 requestRemoval={handleRemove}
                 globalPropertyKeys={globalPropertyKeys}
+                valueError={Boolean(showEmptyValueErrors) && !filter.values.some(isNonEmptyValue)}
                 hideClearAllButton
                 useExtendedRange
                 formatLength={isMobile ? 20 : 35}

--- a/dashboard/src/entities/analytics/filter.entities.ts
+++ b/dashboard/src/entities/analytics/filter.entities.ts
@@ -56,6 +56,10 @@ export function createEmptyQueryFilter(): QueryFilter {
   return { id: generateTempId(), column: 'url', operator: '=', values: [] };
 }
 
+export function isNonEmptyValue(value: string): boolean {
+  return value !== '';
+}
+
 /**
  * A filter is usable in a query once it has a column, an operator, and at least
  * one non-empty value. Incomplete filters are skipped.

--- a/dashboard/src/entities/analytics/funnels.entities.test.ts
+++ b/dashboard/src/entities/analytics/funnels.entities.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { CreateFunnelSchema } from '@/entities/analytics/funnels.entities';
+
+const DASHBOARD_ID = 'cjld2cyuq0000t3rmniod1foy';
+
+type RawFilter = { column: string; operator: string; values: string[] };
+
+function buildFunnel(steps: { name: string; filters: RawFilter[] }[]) {
+  return { name: 'Signup', dashboardId: DASHBOARD_ID, isStrict: false, funnelSteps: steps };
+}
+
+function step(name: string, values: string[]): { name: string; filters: RawFilter[] } {
+  return { name, filters: [{ column: 'url', operator: '=', values }] };
+}
+
+describe('CreateFunnelSchema empty-value handling', () => {
+  it('rejects a step whose only filter has no values', () => {
+    const result = CreateFunnelSchema.safeParse(buildFunnel([step('A', []), step('B', [])]));
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a step whose only filter value is the empty string', () => {
+    const result = CreateFunnelSchema.safeParse(buildFunnel([step('A', ['']), step('B', [''])]));
+    expect(result.success).toBe(false);
+  });
+
+  it('strips empty values but keeps the real ones within a filter', () => {
+    const result = CreateFunnelSchema.safeParse(buildFunnel([step('A', ['/a', '']), step('B', ['/b'])]));
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.funnelSteps[0].filters[0].values).toEqual(['/a']);
+  });
+
+  it('drops an empty filter when another filter in the same step is usable', () => {
+    const result = CreateFunnelSchema.safeParse(
+      buildFunnel([
+        {
+          name: 'A',
+          filters: [
+            { column: 'url', operator: '=', values: ['/a'] },
+            { column: 'url', operator: '=', values: [] },
+          ],
+        },
+        step('B', ['/b']),
+      ]),
+    );
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.funnelSteps[0].filters).toHaveLength(1);
+  });
+
+  it('preserves a whitespace-only value, which can be a real matchable data value', () => {
+    const result = CreateFunnelSchema.safeParse(buildFunnel([step('A', [' ']), step('B', ['/b'])]));
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.funnelSteps[0].filters[0].values).toEqual([' ']);
+  });
+});

--- a/dashboard/src/entities/analytics/funnels.entities.ts
+++ b/dashboard/src/entities/analytics/funnels.entities.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { QueryFilterSchema } from './filter.entities';
+import { isNonEmptyValue, QueryFilterSchema } from './filter.entities';
 
 export const FunnelStepSchema = z.object({
   id: z.string(),
@@ -39,7 +39,7 @@ export const CreateFunnelSchema = z.object({
           .array(CreateFunnelFilterSchema)
           .transform((filters) =>
             filters
-              .map((filter) => ({ ...filter, values: filter.values.filter(Boolean) }))
+              .map((filter) => ({ ...filter, values: filter.values.filter(isNonEmptyValue) }))
               .filter((filter) => filter.values.length > 0),
           )
           .pipe(z.array(CreateFunnelFilterSchema).min(1, 'At least one filter with a value is required')),

--- a/dashboard/src/utils/queryFilters.ts
+++ b/dashboard/src/utils/queryFilters.ts
@@ -1,4 +1,4 @@
-import { type QueryFilter } from '@/entities/analytics/filter.entities';
+import { isNonEmptyValue, type QueryFilter } from '@/entities/analytics/filter.entities';
 import { stableStringify } from './stableStringify';
 
 /**
@@ -12,5 +12,5 @@ export function isQueryFiltersEqual(a: QueryFilter, b: QueryFilter) {
  * Filters out empty query filters
  */
 export function filterEmptyQueryFilters(filters: QueryFilter[]) {
-  return filters.filter((filter) => filter.values.filter((value) => value !== '').length > 0);
+  return filters.filter((filter) => filter.values.some(isNonEmptyValue));
 }


### PR DESCRIPTION
Closes #946

Empty filter values were already blocked on save by the transform in #924 (the funnel dialog redesign): `''`/`[]` can't be persisted through create/update. This PR just makes that visible in the UI and pins it down with a small test (see screenshot):

  - Red border on empty value inputs, scoped to a step that's actually blocking the save, so it's clear *why* submit is disabled.
  - `isNonEmptyValue` one shared definition of "empty" across the funnel write-path checks.
  - `funnels.entities.test.ts` a regression test guarding the #924 behaviour so it can't silently regress: `''`/`[]` get stripped, while a whitespace-only value is deliberately preserved (ingestion stores whitespace global-property values verbatim, so a funnel may legitimately filter on them).

No schema change, no migration => the DB stays permissive for existing funnels.

<img width="1465" height="615" alt="image" src="https://github.com/user-attachments/assets/365be327-4429-45e7-aec2-6992acd8827d" />
