### PR TITLE
Fix outbound-link tracking crashing on browsers without URL.parse()

### DIFF
--- a/static/analytics.js
+++ b/static/analytics.js
@@ -387,9 +387,13 @@
   }
 
   function parseOutboundLink(link) {
-    var linkUrl = URL.parse(link.href, window.location.origin);
+    var linkUrl;
+    try {
+      linkUrl = new URL(link.href, window.location.origin);
+    } catch (e) {
+      return false;
+    }
     if (
-      linkUrl &&
       linkUrl.hostname !== window.location.hostname &&
       linkUrl.hostname !== ""
     ) {


### PR DESCRIPTION
## What
`parseOutboundLink()` in `static/analytics.js` called the **static** `URL.parse(href, base)`. That method only exists in Chrome/Firefox 126+ and Safari 18+. On older browsers and many in-app webviews it's `undefined`, so the call threw:

> TypeError: URL.parse is not a function

## Why it matters
This is the **client tracking script shipped to every customer site** (served from `static/analytics.js`, minified into `analytics.js` at build). The throw aborts `parseOutboundLink`, so **outbound-link tracking silently breaks for any visitor on an older browser** — i.e. data loss in the core product, on customer sites where we have no visibility. Found via the Betterlytics error dashboard; 7 sessions observed on our own site alone.

## Fix
Use `new URL(link.href, window.location.origin)` wrapped in `try/catch`, returning `false` on failure.

Behavior is unchanged:
- Invalid URL → `false` (previously `URL.parse` returned `null`, caught by the `linkUrl &&` guard; now the throw is caught).
- Valid URL → identical `hostname` / `origin` / `pathname` logic.

`new URL` is supported in every browser the tracker targets (and is what the rest of the script already relies on).

## Risk
This is the all-users tracking script, hence a separate PR. Change is a minimal, behavior-preserving swap; `node --check` passes. Worth a careful look before merge.

## Test plan
- [ ] Click an outbound link on a tracked page; confirm the outbound event is recorded.
- [ ] Click an internal link / a malformed `href`; confirm no event and no console error.
- [ ] Sanity check in an older browser / webview (or one with `URL.parse` shimmed away).