### PR TITLE
feat(i18n): add Japanese (ja) language support

### DIFF
--- a/dashboard/messages/ja.json
+++ b/dashboard/messages/ja.json
@@ -1,0 +1,3913 @@
+{
+  "public": {
+    "root": {
+      "seo": {
+        "title": "Betterlytics | Privacy-First Web Analytics",
+        "description": "Betterlytics is a privacy-first, open-source alternative to Google Analytics. Get GDPR-compliant, cookieless insights without invasive tracking, while respecting user privacy.",
+        "keywords": [
+          "Google Analytics Alternative",
+          "Privacy-First Analytics",
+          "Cookieless Web Analytics",
+          "GDPR Compliant Analytics",
+          "Open Source Analytics Platform",
+          "Privacy-Friendly Analytics",
+          "Website Traffic Analysis",
+          "Visitor Analytics",
+          "Web Analytics Tool",
+          "Betterlytics"
+        ]
+      }
+    },
+    "notFound": {
+      "title": "404 - Page Not Found",
+      "description": "This page seems to have wandered off into the analytics dimension. Don't worry though, we've got you covered!",
+      "goHome": "Back to home"
+    },
+    "about": {
+      "seo": {
+        "title": "About Betterlytics | Privacy-First Web Analytics",
+        "description": "Learn how Betterlytics builds open-source, cookieless analytics that protect user privacy, stay fully GDPR-compliant, and empower transparent web insights.",
+        "keywords": [
+          "About Betterlytics",
+          "Privacy-First Analytics",
+          "Open Source Web Analytics",
+          "Cookieless Analytics",
+          "GDPR Compliant Analytics",
+          "Privacy Analytics Platform",
+          "Analytics Without Cookies",
+          "Open Source Analytics Tool"
+        ]
+      },
+      "aboutUs": "About Betterlytics",
+      "intro": "We're building the future of web analytics: privacy-first, open source, and designed for the modern web. No more choosing between powerful insights and respecting your visitors' privacy.",
+      "sections": {
+        "howWeStarted": {
+          "title": "How We Started",
+          "p1": "Betterlytics was born out of real frustration. Our team was developing a Vendor Management System when we hit a wall with web analytics. Every solution we evaluated forced us into the same impossible choice: either compromise our users' privacy or settle for inadequate insights.",
+          "p2": "Traditional analytics tools force you to choose between comprehensive insights and user privacy. We believe that's a false choice. Betterlytics proves you can have powerful, actionable analytics while being completely privacy-compliant and respectful of your visitors.",
+          "p3": "What started as a solution for our own needs became something much bigger: a mission to build analytics tools that respect both website owners and their visitors. Every feature is designed with privacy and performance as equal priorities."
+        },
+        "whyPrivacyFirst": {
+          "title": "Why Privacy-First Analytics Matter",
+          "p1": "The web analytics industry has been dominated by surveillance capitalism for too long. Major analytics providers collect vast amounts of personal data, track users across websites, and use this information to build detailed behavioral profiles for advertising purposes.",
+          "p2": "We don't believe website owners should have to compromise their visitors' privacy to understand how their site performs. Betterlytics collects only the essential metrics you need: no cookies, no personal data, no cross-site tracking. Your visitors' privacy is respected by default."
+        },
+        "builtInOpen": {
+          "title": "Built in the Open",
+          "p1": "Betterlytics is completely open source under the AGPL-3.0 license. This isn't just about transparency, it's about accountability. Anyone can inspect our code, verify our privacy claims, and contribute to making the platform better.",
+          "p2": "Open source also means freedom. You can self-host Betterlytics on your own infrastructure, ensuring complete control over your data. No vendor lock-in, no surprise policy changes, no sudden price increases."
+        },
+        "privacyPerformance": {
+          "title": "Privacy and Performance in Perfect Balance",
+          "p1": "We obsess over both privacy and performance equally because your website's speed matters just as much as your visitors' privacy. Our tracking script weighs less than 2KB. Compare that to Google Analytics' bloated 45KB+ payload. Built with modern web standards and optimized for speed, Betterlytics won't slow down your site.",
+          "p2": "Under the hood, we use cutting-edge technology: Rust for high-performance data processing, ClickHouse for lightning-fast analytical queries, and Next.js 15 for a modern, responsive dashboard experience. Every technical decision prioritizes both user privacy and system performance."
+        },
+        "builtForEveryone": {
+          "title": "Built for Everyone",
+          "p1": "Whether you're running a personal blog, a growing SaaS platform, an e-commerce store, or an enterprise website, Betterlytics is designed to meet your needs. We understand that different organizations have different requirements, from simple traffic insights to complex user journey analysis.",
+          "p2": "Integration takes minutes, not hours. Our dashboard is intuitive and well-documented, showing you what you need to know without drowning you in unnecessary complexity. While we don't have a public API yet, every dashboard feature is thoroughly documented to help you get the most out of your analytics."
+        },
+        "privacyRegulations": {
+          "title": "Privacy Regulations Made Simple",
+          "p1": "GDPR, CCPA, PECR compliant. Privacy regulations shouldn't be a compliance nightmare. Because Betterlytics doesn't collect personal data or use cookies, you're compliant by default. No cookie banners required, no consent management needed.",
+          "p2": "This simplicity extends to your users too. They can focus on your content instead of being interrupted by privacy notices and consent forms. Better experience for everyone.",
+          "p3Prefix": "We're based in the European Union and all data processing occurs within EU boundaries. Your data never leaves the EU, ensuring full compliance with GDPR requirements. For detailed information about how we handle your data, see our",
+          "privacyPolicyLabel": "privacy policy"
+        },
+        "communityDriven": {
+          "title": "Community-Driven Development",
+          "p1": "Betterlytics grows through community feedback and contributions. We listen to developers, implement requested features, and maintain the platform based on real user needs; not investor demands or advertising revenue requirements. We want to deeply thank our community for their feedback and contributions.",
+          "p2": "Our sustainable business model means we can focus on building the best analytics platform possible. We're funded by our users, not by selling their data. This alignment of incentives ensures we'll always prioritize privacy and performance and never compromise on either."
+        },
+        "future": {
+          "title": "The Future of Web Analytics",
+          "quote": "We believe businesses should be able to understand their audience without sacrificing privacy or making needless compromises on ethics. Analytics can be both powerful and respectful by design.",
+          "p1": "This vision drives everything we build. Every feature, every optimization, every decision is guided by our commitment to privacy-first analytics that everyone can trust and use."
+        }
+      },
+      "cta": {
+        "eyebrow": "Get Started",
+        "title": "Ready to Get Started?",
+        "lead": "Join the growing community of businesses who refuse to compromise on privacy.",
+        "getStarted": "Get Started Free",
+        "viewDocs": "View Documentation",
+        "docsTitle": "Complete Betterlytics Documentation"
+      }
+    },
+    "contact": {
+      "seo": {
+        "title": "Contact Betterlytics | Privacy-First Analytics",
+        "description": "Get in touch with the Betterlytics team for support, feedback, or partnership inquiries about our open-source, privacy-first web analytics platform.",
+        "keywords": [
+          "Contact Betterlytics",
+          "Betterlytics Support",
+          "Web Analytics Help",
+          "Privacy-First Analytics Support",
+          "GDPR Analytics Contact",
+          "Cookieless Analytics Support",
+          "Customer Support Betterlytics",
+          "Contact Page"
+        ]
+      },
+      "title": "Contact Us",
+      "intro": "Questions about Betterlytics? Need support with your analytics setup? Our team is ready to assist you.",
+      "getInTouch": {
+        "title": "Get in Touch",
+        "description": "Whether you need technical support, have questions about our features, or want to discuss enterprise solutions, we're here to help."
+      },
+      "methods": {
+        "email": {
+          "title": "Email",
+          "description": "hello@betterlytics.io"
+        },
+        "github": {
+          "title": "GitHub",
+          "description": "github.com/betterlytics/betterlytics"
+        },
+        "discord": {
+          "title": "Discord",
+          "description": "Join our Discord Server"
+        },
+        "bluesky": {
+          "title": "Bluesky",
+          "description": "@betterlytics.bsky.social"
+        }
+      },
+      "faq": {
+        "title": "Frequently Asked Questions",
+        "items": {
+          "integrate": {
+            "question": "How do I integrate Betterlytics with my website?",
+            "answer": "Integration is simple! Just add our lightweight script tag to your website or install our NPM package. Check our documentation for detailed setup guides for all major frameworks."
+          },
+          "gdpr": {
+            "question": "Is Betterlytics really GDPR compliant?",
+            "answer": "Yes, absolutely! We don't use cookies, don't collect personal data, and all data processing is done in compliance with GDPR, CCPA, and other privacy regulations."
+          },
+          "migrate": {
+            "question": "Can I migrate from Google Analytics?",
+            "answer": "Not yet! But we're working hard to implement this feature and will provide a migration guide and tools to help you transition from Google Analytics."
+          },
+          "freePlan": {
+            "question": "What's included in the free plan?",
+            "answer": "The free self-hosted plan includes up to 10,000 tracked events, full dashboard access and community support. Perfect for getting started! No credit card required, no strings attached."
+          },
+          "cloud": {
+            "question": "How does the cloud hosting work?",
+            "answer": "Our cloud hosting provides a fully managed Betterlytics instance with automatic updates, backups, and 99.9% uptime SLA. No server management required!"
+          },
+          "support": {
+            "question": "Do you offer support for self-hosted instances?",
+            "answer": "Partially! We provide community support through GitHub and Discord for self-hosted instances, but our priority is to support our cloud hosting customers."
+          }
+        }
+      },
+      "secondary": {
+        "discord": {
+          "cta": "Join Discord"
+        },
+        "github": {
+          "cta": "View on GitHub"
+        },
+        "bluesky": {
+          "cta": "Follow us"
+        },
+        "docs": {
+          "title": "Documentation",
+          "description": "Explore our guides for getting started, integrations with popular frameworks, and detailed feature documentation.",
+          "cta": "View Docs"
+        },
+        "email": {
+          "title": "General inquiries",
+          "description": "Questions, feedback, or anything else."
+        }
+      },
+      "cta": {
+        "lead": "Can't find what you're looking for?",
+        "docsLinkText": "Check our full documentation →",
+        "docsLinkTitle": "Complete Betterlytics Documentation"
+      }
+    },
+    "changelog": {
+      "seo": {
+        "title": "Changelog | Betterlytics Release Notes & Product Updates",
+        "description": "Read every Betterlytics release note in one place. Follow product updates, reliability fixes, and roadmap highlights for our privacy-first analytics platform.",
+        "keywords": [
+          "Betterlytics changelog",
+          "Product updates",
+          "Release notes",
+          "Analytics roadmap",
+          "Privacy-first analytics updates"
+        ]
+      },
+      "hero": {
+        "eyebrow": "Release history",
+        "title": "Betterlytics changelog",
+        "lead": "See what's new in Betterlytics! From fresh features to performance fixes, follow our journey and discover how your analytics experience keeps getting better."
+      },
+      "feed": {
+        "subhead": "Fresh releases ship monthly. Scroll chronologically to revisit every iteration.",
+        "loadMore": "Keep scrolling. Newer releases will load automatically.",
+        "end": "Thanks for reading all the way back. You've reached the beginning of the Betterlytics changelog."
+      }
+    },
+    "privacy": {
+      "seo": {
+        "title": "Privacy Policy | GDPR & Cookieless Analytics",
+        "description": "Betterlytics Privacy Policy — GDPR-compliant and cookieless by design. Learn how we protect your data and ensure privacy through anonymous analytics.",
+        "keywords": [
+          "Betterlytics Privacy Policy",
+          "GDPR Compliance",
+          "Data Privacy",
+          "Data Protection",
+          "Cookieless Analytics",
+          "Anonymous Analytics",
+          "User Privacy",
+          "Privacy-Focused Analytics"
+        ]
+      },
+      "translationDisclaimer": "This document is provided in multiple languages for convenience. In case of discrepancies, the English version shall prevail.",
+      "title": "Betterlytics Privacy Policy",
+      "lastUpdated": "Last updated:",
+      "tldr": {
+        "title": "TL;DR",
+        "body": "For website visitors, we do not use cookies and we do not collect any personal data. If you decide to create an account, we ask for the bare minimum and only share it with services that are absolutely necessary for the app to function."
+      },
+      "scope": {
+        "title": "Scope of This Policy",
+        "body": "This privacy policy applies exclusively to the Betterlytics hosted cloud service available at betterlytics.io and our official domains. It does not apply to self-hosted installations of our open source software. If you self-host Betterlytics, you are responsible for your own privacy policy, data processing practices, and legal compliance."
+      },
+      "intro": {
+        "p1": "At Betterlytics, we are committed to complying with GDPR, CCPA, PECR and other privacy regulations. The privacy of your data — and it is your data, not ours! — is a big deal to us. We are based in the European Union and all data processing occurs within EU boundaries.",
+        "p2": "In this policy, we lay out what data we collect and why, how your data is handled and your rights to your data. We promise we never sell your data: never have, never will."
+      },
+      "visitor": {
+        "title": "As a visitor to websites using Betterlytics",
+        "lead": "The privacy of website visitors is important to us. We have designed our analytics system to be completely cookieless and privacy-focused. As a visitor to websites using Betterlytics:",
+        "li1": "By default, Betterlytics does not collect personal information or use cookies.",
+        "li2": "No cookies or browser storage are ever used or stored.",
+        "li3": "No information is shared with, sent to or sold to third-parties.",
+        "li4": "No information is shared with advertising companies.",
+        "li5": "No information is mined and harvested for personal and behavioral trends.",
+        "li6": "No information is monetized.",
+        "finalRemarks1": "All analytics data is aggregated and anonymized to prevent identification of individual visitors. Certain optional features (such as session replay, custom identifiers, or user event tracking) may enable website owners to collect additional data, which could include personal or pseudo-anonymous information depending on configuration. In such cases, the website owner — not Betterlytics — is the data controller and is responsible for obtaining consent and ensuring compliance with applicable privacy laws (such as GDPR or CCPA).",
+        "finalRemarks2": "While Betterlytics is designed to collect only anonymized data by default, it is possible that personal data may be accidentally transmitted by website owners — for example, via URL paths, query parameters, or custom event data. In such cases, Betterlytics acts as a data processor of the received data and processes it solely according to our standard procedures. Website owners remain the data controllers and are responsible for masking or removing personal data and ensuring compliance with applicable privacy laws (such as GDPR or CCPA). We encourage website owners to follow best practices to prevent personal data from being sent accidentally. For more information about responsibilities related to the use of Betterlytics and optional features, please refer to our Terms of Service.",
+        "finalRemarks3": "When processing website visitor data that includes personal or pseudo-anonymous information on behalf of our customers, Betterlytics acts as a data processor under GDPR, and the website owner acts as the data controller responsible for determining the lawful basis for processing and ensuring compliance."
+      },
+      "anonymous": {
+        "title": "What anonymous data we collect and why",
+        "pageViews": {
+          "title": "Page Views and Navigation",
+          "body": "We track which pages are visited and navigation patterns to help website owners understand how their content is being consumed. We collect the URL path (without query parameters to prevent accidental tracking of sensitive data) and referrer information."
+        },
+        "deviceBrowser": {
+          "title": "Device and Browser Information",
+          "body": "We parse the user agent string to determine browser type, operating system, and device category (mobile, tablet, desktop, laptop). Screen resolution is bucketed into categories (small, medium, large) rather than storing exact dimensions."
+        },
+        "geographic": {
+          "title": "Geographic Information",
+          "body": "We determine the visitor's country from their IP address using a GeoIP database. The IP address itself is immediately anonymized by removing the last octet (IPv4) or using only the first 64 bits (IPv6) before any processing."
+        },
+        "anonymousId": {
+          "title": "Anonymous Visitor Identification",
+          "body": "We generate an anonymous visitor fingerprint using a cryptographic hash of the anonymized IP address, bucketed screen resolution, browser name, and a daily rotating salt. This allows us to count unique visitors without tracking individuals. The fingerprint changes daily, ensuring long-term anonymity."
+        },
+        "sessionTracking": {
+          "title": "Session Tracking",
+          "body": "We track sessions to understand how visitors engage with websites. Sessions automatically expire after 30 minutes of inactivity and are stored only in server memory, never in cookies or browser storage."
+        },
+        "finalRemarks": "This section describes Betterlytics' default, anonymized data collection. Customers who enable optional features that collect additional data are responsible for ensuring their own compliance with data protection laws."
+      },
+      "processStore": {
+        "title": "How we process and store data",
+        "li1": "EU-based hosting: All data is processed and stored on servers located within the European Union, ensuring GDPR compliance.",
+        "li2": "Immediate anonymization: IP addresses are anonymized immediately upon receipt, before any processing or storage occurs.",
+        "li3": "No cross-site tracking: Each website's data is isolated and tracked separately with unique site identifiers.",
+        "li4": "Aggregated reporting: All analytics reports show aggregated data only, with no ability to identify individual visitors.",
+        "li5": "Daily fingerprint rotation: Visitor fingerprints change daily, preventing long-term tracking of individuals."
+      },
+      "customer": {
+        "title": "As a customer and subscriber of Betterlytics",
+        "lead": "Our guiding principle is to collect only what we need and process this information solely to provide you with the service you signed up for.",
+        "whatWeCollect": {
+          "title": "What we collect and why",
+          "email": "Email address: Required to create an account, send you essential service communications, and provide customer support.",
+          "auth": "Authentication data: Secure session tokens to keep you logged in to your dashboard.",
+          "websiteConfig": "Website configuration: Domain names and site settings you configure for your analytics tracking.",
+          "usage": "Usage data: How you use our dashboard to improve our service and provide support."
+        },
+        "thirdParty": {
+          "title": "Third-party services",
+          "intro": "We use a select number of trusted, EU-based service providers:",
+          "li1": "Payment processing (if applicable) through EU-compliant payment processors",
+          "li2": "Email delivery for transactional emails and notifications",
+          "outro": "We only share the minimum necessary information with these providers and contractually bind them to protect your data according to GDPR standards."
+        },
+        "cookieUse": "Betterlytics uses cookies strictly for necessary service functionality. These cookies are not used for analytics or marketing purposes.",
+        "responsibility": "Website owners are responsible for ensuring their use of Betterlytics complies with applicable privacy laws. For more details, please see our Terms of Service and Data Processing Agreement."
+      },
+      "dataRetention": {
+        "title": "Data retention",
+        "li1": "Account deletion: When you delete your account, ALL data is permanently deleted immediately - this includes your personal data (email, payment information, account settings) AND all website analytics data. No exceptions, no retention period.",
+        "li2": "Subscription cancellation (without account deletion): If you cancel your subscription but keep your account, we retain your analytics data for up to 1 month in case you decide to reactivate, after which it is permanently deleted.",
+        "li3": "Session data: Visitor sessions are stored only in server memory and automatically expire after 30 minutes of inactivity.",
+        "footer": "You always have the right to immediate deletion of all data."
+      },
+      "rights": {
+        "title": "Your rights under GDPR",
+        "intro": "As a data subject under GDPR, you have the following rights:",
+        "li1": "Right of access: Request a copy of your personal data",
+        "li2": "Right to rectification: Correct inaccurate personal data",
+        "li3": "Right to erasure: Request deletion of your personal data",
+        "li4": "Right to restrict processing: Limit how we use your data",
+        "li5": "Right to data portability: Receive your data in a portable format",
+        "li6": "Right to object: Object to processing based on legitimate interests",
+        "li7": "Right to withdraw consent: Withdraw consent for data processing",
+        "contact": "To exercise any of these rights, please contact us at privacy@betterlytics.io"
+      },
+      "noCookies": {
+        "title": "No cookies policy",
+        "body": "Betterlytics does not use any cookies for tracking website visitors. We achieve all necessary analytics functionality through cookieless, server-side processing. This means websites using Betterlytics do not need to display cookie consent banners for our analytics tracking."
+      },
+      "security": {
+        "title": "Data security",
+        "li1": "All data transmission is encrypted using TLS 1.3",
+        "li2": "Data at rest is encrypted using industry-standard encryption",
+        "li3": "Access to data is strictly limited to authorized personnel",
+        "li4": "All servers are located in secure EU data centers"
+      },
+      "changes": {
+        "title": "Changes to this privacy policy",
+        "body": "We may update this policy as needed to comply with relevant regulations and reflect any new practices. Whenever we make significant changes to our policies, we will notify our customers via email and announce them on our website."
+      },
+      "contact": {
+        "title": "Contact us",
+        "lead": "If you have any questions, comments, or concerns about this privacy policy, your data, or your rights with respect to your information, please contact us:",
+        "email": "Email:",
+        "address": "Address:",
+        "footer1": "🇪🇺 Made and hosted in the European Union",
+        "footer2": "Committed to privacy, transparency, and GDPR compliance",
+        "termsLink": "Terms of Service",
+        "dpaLink": "Data Processing Agreement",
+        "subprocessorsLink": "Subprocessors"
+      }
+    },
+    "terms": {
+      "seo": {
+        "title": "Terms of Service | Privacy-First Analytics",
+        "description": "Read Betterlytics' Terms of Service — learn about your rights, responsibilities, and usage policies for our privacy-first web analytics platform.",
+        "keywords": [
+          "Betterlytics Terms of Service",
+          "Terms and Conditions",
+          "Analytics Service Agreement",
+          "Web Analytics Terms",
+          "Privacy Analytics Terms",
+          "Usage Terms",
+          "Legal Agreement Betterlytics",
+          "Privacy-First Analytics"
+        ]
+      },
+      "translationDisclaimer": "This document is provided in multiple languages for convenience. In case of discrepancies, the English version shall prevail.",
+      "title": "Betterlytics Terms of Service",
+      "lastUpdated": "Last updated:",
+      "scope": {
+        "title": "Scope of These Terms",
+        "body": "These Terms of Service apply exclusively to the Betterlytics hosted cloud service available at betterlytics.io and our official domains. They do not apply to self-hosted installations of our open source software. If you self-host Betterlytics, you are responsible for your own terms of service, data processing, and legal compliance."
+      },
+      "intro": {
+        "p1": "Thank you for using Betterlytics! When we say \"company\", \"we\", \"our\", \"us\", \"service\" or \"services\" in this document, we are referring to Betterlytics and our privacy-focused web analytics platform.",
+        "p2": "When we say \"customer\", \"you\", \"your\", \"yours\" or \"you're\" in this document, we are referring to the entity, individual, or organization that signs up for Betterlytics and installs our analytics script(s) on their website(s) to use our service.",
+        "p3": "We may update these Terms of Service in the future. Whenever we make significant changes to our policies, we will notify our customers via email and announce them on our website. When you use our service, now or in the future, you are agreeing to the latest Terms of Service.",
+        "p4": "If you do not agree to these Terms of Service, do not use this service. Violation of any of the terms below may result in the termination of your account."
+      },
+      "account": {
+        "title": "Account Terms",
+        "li1": "Security responsibility: You are responsible for maintaining the security of your account and password. Betterlytics cannot and will not be liable for any loss or damage from your failure to comply with this security obligation.",
+        "li2": "Account activity: You are responsible for any activity that occurs under your account, including activity by team members you invite to your account.",
+        "li3": "Legal compliance: You may not use our service for any illegal purpose or to violate any laws in your jurisdiction.",
+        "li4": "Registration requirements: You must provide a valid email address to complete the signup process. You must be a human - accounts registered by bots or automated methods are not permitted.",
+        "li5": "Website ownership: You must own or have explicit permission to install our analytics script on any website you track with Betterlytics.",
+        "li6": "Data accuracy: You agree to provide accurate information about your websites and not to intentionally send false or misleading data to our service.",
+        "li7": "Age requirements: You must be at least 18 years old to use our service. If you are between 13-17, you may use our service only with parental consent."
+      },
+      "acceptableUse": {
+        "title": "Acceptable Use",
+        "intro": "Betterlytics is designed for legitimate website analytics and is built as an open source project for transparency. You agree not to use our service to:",
+        "li1": "Track visitors without their knowledge or in violation of privacy laws",
+        "li2": "Collect or process personally identifiable information (PII) unless you have a lawful basis to do so under applicable privacy laws (such as valid user consent). By default, Betterlytics is designed to avoid collecting PII. Certain optional features — such as session replay, custom identifiers, or user event tracking — or accidental inclusion of personal data in URLs, query parameters, or event payloads, may result in the collection of personal or pseudo-anonymous information. In such cases, the website owner — not Betterlytics — is the data controller and is responsible for masking, obtaining consent, and ensuring compliance with applicable privacy laws (such as GDPR or CCPA).",
+        "li3": "Generate artificial or bot traffic to inflate statistics or abuse our infrastructure",
+        "li4": "Track websites you don't own without explicit permission",
+        "li5": "Abuse our service infrastructure, bypass rate limits, or send malformed data that could harm our systems",
+        "li6": "Use our service to harm, harass, or violate the privacy of any individual",
+        "li7": "Violate any applicable laws, including GDPR, CCPA, or other relevant privacy/data protection laws",
+        "li8": "Resell, sublicense, or provide the Service (or substantial parts thereof) to third parties as a hosted analytics service without prior written consent"
+      },
+      "payment": {
+        "title": "Payment, Refunds, and Plan Changes",
+        "freeTierTitle": "Free Tier",
+        "freeTierBody": "We offer a permanently free tier with a monthly event limit as specified on our pricing page. No credit card is required for the free tier. We do not sell your data - ever, regardless of which plan you use.",
+        "billingTitle": "Billing",
+        "billingBody": "You can use our free tier indefinitely within the monthly event limits. For higher usage, you need to upgrade to a paid plan and pay in advance. If you exceed plan limits without upgrading, you risk losing excess data. If paid accounts become overdue, we will freeze the account until payment is made.",
+        "limitsTitle": "Event Limits",
+        "limitsBody": "Each plan includes a monthly limit of events (pageviews, custom events, etc.). Unused events do not roll over to the next month. You will never be charged extra for occasional traffic spikes. If you consistently exceed your plan limits for two consecutive months, we will contact you to discuss upgrading.",
+        "planChangesTitle": "Plan Changes",
+        "planChangesBody": "You can upgrade or downgrade your plan at any time. Upgrades take effect immediately. Downgrading may result in loss of features or capacity. We do not accept liability for any data loss resulting from plan downgrades.",
+        "refundsTitle": "Refunds",
+        "refundsBody": "All fees are non-refundable. However, if you experience significant service issues within the first 30 days, please contact us and we'll work with you to find a fair solution.",
+        "overdueTitle": "Overdue Payments",
+        "overdueBody": "If payment is overdue, we may suspend access until you settle your balance."
+      },
+      "cancellation": {
+        "title": "Cancellation and Termination",
+        "importantTitle": "Important: Two Types of Cancellation",
+        "li1": "Subscription cancellation: Keeps your account but stops billing. Analytics data retained for 1 month.",
+        "li2": "Account deletion: Permanently deletes everything immediately, including all analytics data.",
+        "howToTitle": "How to Cancel",
+        "howToBody": "You can cancel your subscription or delete your account entirely through your account settings. An email request alone is not considered proper cancellation.",
+        "whatHappensTitle": "What Happens When You Cancel",
+        "whLi1": "Subscription cancellation: Your cancellation takes effect at the end of your current billing period. You won't be charged again. Your analytics data becomes inaccessible but is retained for 1 month in case you return, then permanently deleted.",
+        "whLi2": "Account deletion: All data (personal and analytics) is permanently deleted immediately. This cannot be undone.",
+        "residualCopies": "Residual copies of deleted data may remain in encrypted backups for up to 30 days for disaster recovery purposes but will not be used or accessed.",
+        "ourRightTitle": "Our Right to Terminate",
+        "ourRightBody": "We reserve the right to suspend or terminate your account for violation of these terms, illegal activity, or abuse of our service or team members. We will provide notice when possible, but immediate termination may be necessary in severe cases."
+      },
+      "serviceMods": {
+        "title": "Service Modifications and Pricing",
+        "li1": "Service changes: We reserve the right to modify or discontinue any part of the service with or without notice. We will communicate significant changes affecting your usage in advance when possible.",
+        "li2": "Pricing changes: We may change our pricing structure. Existing customers are typically exempt from price increases, but we reserve the right to change prices for all customers with at least 30 days notice via email.",
+        "li3": "Feature updates: We regularly improve our service with new features and enhancements. Some features may require plan upgrades.",
+        "li4": "Beta features: Beta or experimental features may be offered for testing. These are provided without warranty and may be modified or discontinued at any time."
+      },
+      "dataOwnership": {
+        "title": "Data Ownership and Privacy",
+        "yourRightsTitle": "Your Data Rights",
+        "yourRightsBody": "You own 100% of your analytics data. We claim no intellectual property rights over your website data and will never sell or share it with third parties.",
+        "anonymousDataTitle": "Anonymous Analytics",
+        "anonymousDataBody": "By default, analytics data collected through Betterlytics is anonymized and designed to prevent the identification of individual visitors. Personally identifiable information is not collected or stored unless customers enable specific features (e.g., session replays, custom identifiers) that may involve pseudo-anonymous or personal data. We act as a data processor when handling personal or pseudo-anonymous data you provide (e.g., in features like session replays). You are the data controller and must ensure compliance with GDPR, CCPA, or other applicable data laws (e.g. obtaining consent, disclosing in your privacy policy).",
+        "dpaTitle": "Data Processing Agreement",
+        "dpaBodyPrefix": "For enterprise customers and GDPR compliance, our comprehensive Data Processing Agreement (DPA) is available at",
+        "dpaBodySuffix": ". The DPA forms part of these Terms of Service and governs how we process data on your behalf.",
+        "yourResponsibilitiesTitle": "Your Responsibilities",
+        "yrLi1": "Ensure your use of our service complies with all applicable privacy laws (GDPR, CCPA, etc.)",
+        "yrLi2": "Update your privacy policy to mention the use of Betterlytics for anonymous analytics (note: no cookie consent banner is typically required since our service is cookieless)",
+        "yrLi3": "Do not attempt to send sensitive information (credit cards, personal data, etc.) through our service, including in URL paths or query parameters.",
+        "yrLi4": "Maintain security of your account and immediately report any unauthorized access",
+        "ourCommitmentsTitle": "Our Commitments",
+        "ocLi1": "Process your data only as described in our Privacy Policy",
+        "ocLi2": "Implement appropriate security measures to protect your data",
+        "ocLi3": "Never sell, share, or monetize your analytics data",
+        "ocLi4": "Provide EU-based hosting and processing for GDPR compliance",
+        "ocLi5": "Delete your data immediately upon account deletion",
+        "finalRemarks": "Your use of Betterlytics is also governed by our Privacy Policy, which explains how we collect, process, and store data, including website visitor analytics and your account information. By using our service, you agree to the practices described in the Privacy Policy in addition to these Terms of Service."
+      },
+      "sla": {
+        "title": "Service Level and Support",
+        "availabilityBody": "We strive for high availability but provide the service on an \"as is\" and \"as available\" basis. We do not guarantee uninterrupted operation or error-free performance.",
+        "availabilityBodySuffix": "We may schedule maintenance; we'll endeavor to give advance notice.",
+        "supportBody": "Technical support is provided via email on a reasonable effort basis. We aim to respond promptly but do not guarantee specific response times.",
+        "bugsBody": "We test our features extensively, but no software is perfect. We track reported bugs and prioritize fixes, especially for security or privacy issues. Not all reported bugs will be fixed immediately."
+      },
+      "liability": {
+        "title": "Liability and Disclaimers",
+        "p1": "You expressly understand and agree that Betterlytics shall not be liable for any direct, indirect, incidental, special, consequential, or exemplary damages, including but not limited to:",
+        "li1": "Loss of profits, goodwill, use, data, or other intangible losses",
+        "li2": "The use or inability to use our services",
+        "li3": "Unauthorized access to or alteration of your data",
+        "li4": "Statements or conduct of any third party",
+        "li5": "Any other matter relating to these Terms or our services",
+        "note": "What this means: While we work hard to provide reliable, privacy-focused analytics, technology isn't perfect and things can go wrong. By using Betterlytics, you understand that we can't be held responsible for any business losses or problems that might result from service issues. We're committed to earning your trust through transparency, strong security practices, and putting your privacy first.",
+        "p2": "No Warranty:  The Service is provided \"as is\" and \"as available,\" without warranties of any kind, whether express, implied, or statutory, including but not limited to implied warranties of merchantability, fitness for a particular purpose, title, and non-infringement.",
+        "p3": "Indemnification: You agree to indemnify, defend, and hold harmless Betterlytics, its affiliates, employees, and contractors from and against any claims, damages, liabilities, costs, and expenses (including reasonable legal fees) arising from your use of the Service, your violation of these Terms, or your violation of any law or third-party rights.",
+        "p4": "Force Majeure: Neither party shall be liable for any failure or delay in performance due to circumstances beyond reasonable control, including but not limited to acts of nature, power outages, internet failures, labor disputes, or government restrictions.",
+        "p5": "These Terms are governed by the laws of the Kingdom of Denmark and applicable laws of the European Union.",
+        "p6": "The courts of Copenhagen, Denmark have exclusive jurisdiction over disputes.",
+        "p7": "Parties will first attempt to resolve issues amicably. If unresolved, disputes may be submitted to arbitration in Denmark or another mutually agreed EU forum.",
+        "p8": "Our total liability shall not exceed the amount you paid in the past 12 months"
+      },
+      "ip": {
+        "title": "Intellectual Property",
+        "li1": "Your content: You retain all rights to any content you provide to our service. Your website data remains yours.",
+        "li2": "Our service: We hold all IP rights in the Service, user interface, infrastructure, trademarks, and proprietary software not covered by the AGPL.",
+        "li3": "Feedback: If you suggest features, improvements, or feedback, you grant us a perpetual, royalty-free license to use, modify, and incorporate that feedback without obligation to you.",
+        "li4": "Trademarks: \"Betterlytics\" and our logo are our trademarks. You may not use them without written permission, except to identify our service in connection with your legitimate use.",
+        "li5": "Open source components: Our open source parts are licensed under AGPL-3.0; this does not extend to our hosted backend, infrastructure, or service components not included in the public repositories."
+      },
+      "updates": {
+        "title": "Updates and Communication",
+        "p1": "We may revise these Terms from time to time.",
+        "li1": "If we make material changes, we will notify you at least 30 days in advance via email.",
+        "li2": "Your continued use after changes take effect constitutes acceptance.",
+        "li3": "If you disagree, you may cancel your account before the changes take effect."
+      },
+      "contact": {
+        "title": "Contact Us",
+        "lead": "If you have any questions about these Terms of Service, please contact us:",
+        "email": "Email:",
+        "support": "Support:",
+        "address": "Address:",
+        "footer1": "🇪🇺 Made and hosted in the European Union",
+        "footer2": "Privacy-focused analytics you can trust",
+        "privacyLink": "Privacy Policy",
+        "dpaLink": "Data Processing Agreement"
+      }
+    },
+    "dpa": {
+      "seo": {
+        "title": "Data Processing Agreement (DPA) | GDPR & Privacy Analytics",
+        "description": "Betterlytics Data Processing Agreement (DPA) — built for full GDPR compliance, privacy-first analytics, and secure, anonymous data processing.",
+        "keywords": [
+          "Betterlytics Data Processing Agreement",
+          "DPA",
+          "GDPR Compliance",
+          "GDPR DPA",
+          "Data Privacy",
+          "Data Protection Agreement",
+          "Privacy-First Analytics",
+          "Anonymous Analytics",
+          "Web Analytics GDPR"
+        ]
+      },
+      "translationDisclaimer": "This document is provided in multiple languages for convenience. In case of discrepancies, the English version shall prevail.",
+      "title": "Data Processing Agreement (DPA)",
+      "lastUpdated": "Last updated:",
+      "scope": {
+        "title": "Scope of This DPA",
+        "body": "This Data Processing Agreement (“DPA”) forms part of the Betterlytics Terms of Service and governs the processing of data when you use the Betterlytics hosted cloud service available at betterlytics.io and our official domains. This DPA does not apply to self-hosted installations of our open source software; if you self-host Betterlytics, you are responsible for your own data processing agreements and compliance with applicable laws.",
+        "appliesTo": "This DPA applies to the processing of website visitor data collected via Betterlytics analytics scripts, including both:",
+        "li1": "Anonymous data (default, anonymized analytics), and",
+        "li2": "Personal or pseudo-anonymous data (optional features, or any accidental inclusion of personal or pseudo-anonymous data in URLs, query parameters, or event payloads), e.g., session replay, custom identifiers, or custom events."
+      },
+      "definitions": {
+        "title": "Definitions",
+        "controller": "\"Data Controller\": You (the customer) who determines the purposes and means of processing data from your website visitors.",
+        "processor": "\"Data Processor\": Betterlytics, who processes data on your behalf according to your instructions and this DPA.",
+        "processing": "\"Processing\": Collection, storage, analysis, and reporting of website visitor data.",
+        "personalData": "\"Personal Data\": Any information relating to an identified or identifiable natural person. In Betterlytics, this includes any data collected via optional features or accidentally included in default tracking (URLs, query parameters, or event payloads).",
+        "subprocessor": "\"Subprocessor\": Any third-party service engaged by Betterlytics to assist with data processing."
+      },
+      "processingDetails": {
+        "title": "Data Processing Details",
+        "naturePurposeTitle": "Nature and Purpose",
+        "npLi1": "Providing analytics on website traffic and visitor behavior.",
+        "npLi2": "Generating aggregated reports on website traffic and usage patterns",
+        "npLi3": "Detecting and filtering bot traffic for accurate statistics",
+        "categoriesTitle": "Categories of Data",
+        "categoriesIntro": "Anonymous data (default):",
+        "catLi1": "Anonymized IP addresses (last octet removed immediately)",
+        "catLi2": "Bucketed screen resolutions (small/medium/large categories)",
+        "catLi3": "Browser and operating system information",
+        "catLi4": "Country and City-level geographic data",
+        "catLi5": "Page URLs and referrer information",
+        "catLi6": "Daily-rotating visitor fingerprints (anonymous identification)",
+        "subjectsTitle": "Data Subjects",
+        "sLi1": "Website visitors whose data is captured by the Betterlytics scripts.",
+        "sLi2": "When only anonymous data is collected, data subjects cannot be identified.",
+        "sLi3": "For optional features or accidental inclusion of personal/pseudo-anonymous data, data subjects may be identifiable. The Data Controller is responsible for lawful processing.",
+        "locationTitle": "Processing Location",
+        "locationBody": "All processing occurs on servers located within the European Union.",
+        "personalDataTitle": "Optional personal/pseudo-anonymous data:",
+        "pdLi1": "Session replay data containing user interaction details",
+        "pdLi2": "Custom event data containing user identifiers or PII",
+        "pdLi3": "Visitor identifiers or custom identifiers",
+        "pdLi4": "Potential personal/pseudo-anonymous data (via optional features or accidental inclusion in default tracking)"
+      },
+      "dataController": {
+        "title": "Obligations of the Data Controller",
+        "intro": "The Data Controller must:",
+        "li1": "Ensure that its use of Betterlytics is lawful under GDPR, CCPA, and other applicable data protection laws.",
+        "li2": "Determine the lawful basis for processing personal/pseudo-anonymous data collected via optional features or accidentally in default tracking.",
+        "li3": "Update its website privacy policy to disclose the use of Betterlytics and any optional features that may collect personal or pseudo-anonymous data.",
+        "li4": "Mask or remove personal data from URLs, query parameters, or custom events to prevent accidental collection.",
+        "li5": "Ensure that end users are provided appropriate privacy notices and consent mechanisms where required."
+      },
+      "dataProcessor": {
+        "title": "Obligations of the Data Processor (Betterlytics)",
+        "intro": "Betterlytics will:",
+        "li1": "Process data only on documented instructions from the Data Controller.",
+        "li2": "Implement appropriate technical and organizational measures to ensure data security, including:",
+        "li21": "TLS 1.2/1.3 encryption for data in transit",
+        "li22": "Industry-standard encryption for data at rest",
+        "li23": "Access controls limiting data access to authorized personnel only",
+        "li25": "EU-based servers in secure data centers",
+        "li26": "Immediate IP anonymization at data collection point",
+        "li3": "Assist the Data Controller in responding to requests from data subjects when personal/pseudo-anonymous data is processed.",
+        "li4": "Delete all analytics data immediately upon account deletion."
+      },
+      "subprocessors": {
+        "title": "Subprocessors",
+        "intro": "Betterlytics may engage subprocessors to perform parts of the processing, including:",
+        "li1": "EU-based cloud hosting and infrastructure providers",
+        "li2": "Payment processors (for account billing)",
+        "li3": "Email delivery services",
+        "notice": "Betterlytics maintains a current list of subprocessors at betterlytics.io/subprocessors and will notify the Data Controller of any additions or changes."
+      },
+      "rights": {
+        "title": "Data Subject Rights",
+        "li1": "For anonymous data: Data subject rights do not apply, as individuals cannot be identified.",
+        "li2": "When personal or pseudo-anonymous data is collected—whether through optional features (e.g., session replay, custom identifiers, custom events) or accidentally included in default tracking (URLs, query parameters, or event payloads)—Betterlytics will assist the Data Controller in fulfilling data subject rights under GDPR. This includes requests for access, correction, deletion, restriction of processing, or objection, as applicable."
+      },
+      "breach": {
+        "title": "Data Breach Notification",
+        "intro": "In the unlikely event of a security incident affecting our service:",
+        "li1": "Betterlytics will notify the Data Controller within 72 hours of discovering any personal data breach affecting optional features that process personal/pseudo-anonymous data.",
+        "li2": "Notifications will include details of the breach, potential impact, and mitigation measures."
+      },
+      "deletion": {
+        "title": "Data Deletion",
+        "accountTitle": "Account Deletion",
+        "accountBody": "All data, including optional personal/pseudo-anonymous data, is permanently deleted immediately.",
+        "subscriptionTitle": "Subscription Cancellation",
+        "subscriptionBody": "Data is retained for 1 month in case the account is reactivated, then permanently deleted."
+      },
+      "liability": {
+        "title": "Liability and Indemnification",
+        "li1": "Betterlytics is liable only for processing performed outside the instructions of the Data Controller or in breach of this DPA.",
+        "li2": "The Data Controller is responsible for ensuring lawful use of optional features that may process personal or pseudo-anonymous data.",
+        "li3": "Data Controller agrees to indemnify Betterlytics for any claims arising from unlawful use of any feature provided by Betterlytics."
+      },
+      "misc": {
+        "title": "Miscellaneous",
+        "li1": "This DPA forms part of the Terms of Service.",
+        "li2": "Any disputes regarding data processing will be governed by the laws of the European Union, with courts in Copenhagen, Denmark having exclusive jurisdiction.",
+        "li3": "This DPA is effective as of the last update date above and remains in effect while the customer uses Betterlytics services."
+      },
+      "contact": {
+        "title": "Contact for DPA Matters",
+        "lead": "For questions about this DPA or data processing practices:",
+        "legal": "Legal inquiries:",
+        "technical": "Technical questions:",
+        "footer": "This DPA is automatically accepted when you use Betterlytics and forms part of our Terms of Service. 🇪🇺 Anonymous-by-design analytics - Made and hosted in the European Union",
+        "termsLink": "Terms of Service",
+        "privacyLink": "Privacy Policy",
+        "subprocessorsLink": "Subprocessors"
+      }
+    },
+    "subprocessors": {
+      "seo": {
+        "title": "Subprocessors | GDPR Compliance & Data Processing",
+        "description": "View the complete list of Betterlytics subprocessors. Understand how we ensure GDPR compliance through carefully selected EU-based service providers.",
+        "keywords": [
+          "Betterlytics Subprocessors",
+          "Data Processors",
+          "GDPR Compliance",
+          "Third-Party Services",
+          "Data Processing",
+          "EU Data Hosting",
+          "Privacy Compliance"
+        ]
+      },
+      "translationDisclaimer": "This document is provided in multiple languages for convenience. In case of discrepancies, the English version shall prevail.",
+      "title": "Subprocessors",
+      "lastUpdated": "Last updated:",
+      "intro": "Betterlytics engages a limited number of carefully selected third-party service providers (subprocessors) to help deliver our analytics platform. This page lists all subprocessors that may process data on behalf of our customers.",
+      "commitment": {
+        "title": "Our Commitment",
+        "body": "We only work with subprocessors that meet our strict privacy and security standards. All subprocessors operate under data processing agreements and implement appropriate technical and organizational measures to protect your data."
+      },
+      "list": {
+        "title": "Current Subprocessors",
+        "intro": "The following third-party services are authorized to process data on behalf of Betterlytics:"
+      },
+      "table": {
+        "name": "Subprocessor",
+        "purpose": "Purpose",
+        "location": "Data Location"
+      },
+      "processors": {
+        "hetzner": {
+          "name": "Hetzner",
+          "purpose": "Cloud infrastructure and server hosting",
+          "location": "Germany (EU)"
+        },
+        "stripe": {
+          "name": "Stripe",
+          "purpose": "Payment processing for subscriptions",
+          "location": "USA (Standard Contractual Clauses)"
+        },
+        "mailersend": {
+          "name": "MailerSend",
+          "purpose": "Transactional email delivery",
+          "location": "EU"
+        },
+        "cloudflareR2": {
+          "name": "Cloudflare R2",
+          "purpose": "Session replay storage (opt-in feature only)",
+          "location": "EU data centers"
+        }
+      },
+      "changes": {
+        "title": "Changes to Subprocessors",
+        "body": "We will update this page when we add or remove subprocessors. If you have subscribed to Betterlytics services, we will notify you of any changes to this list in accordance with our Data Processing Agreement (DPA)."
+      },
+      "dataProtection": {
+        "title": "Data Protection Measures",
+        "li1": "All subprocessors operate under data processing agreements in accordance with data protection standards",
+        "li2": "We prioritize EU-based providers to minimize data transfers outside the EU",
+        "li3": "Where data transfers to third countries occur, appropriate safeguards (such as SCCs) are in place"
+      },
+      "contact": {
+        "title": "Questions?",
+        "lead": "If you have questions about our subprocessors or data processing practices:",
+        "email": "Email:"
+      },
+      "footer": {
+        "p1": "🇪🇺 Made and hosted in the European Union",
+        "dpaLink": "Data Processing Agreement",
+        "privacyLink": "Privacy Policy"
+      }
+    },
+    "auth": {
+      "signin": {
+        "seo": {
+          "title": "Sign In | Betterlytics Privacy-First Analytics",
+          "description": "Sign in to your Betterlytics dashboard — secure, cookieless, and privacy-first web analytics for GDPR-compliant insights.",
+          "keywords": [
+            "Sign In",
+            "Login",
+            "Betterlytics Account",
+            "User Dashboard",
+            "Privacy-First Analytics",
+            "Cookieless Analytics",
+            "Google Analytics Alternative",
+            "GDPR Compliant Analytics"
+          ]
+        },
+        "title": "Sign in to your account",
+        "subtitle": "Access your analytics dashboard",
+        "errors": {
+          "CredentialsSignin": "Invalid email or password. Please check your credentials and try again.",
+          "OAuthAccountNotLinked": "An account with this email already exists. Please sign in with your email and password instead.",
+          "default": "An error occurred during sign in. Please try again."
+        },
+        "cta": {
+          "noAccount": "Don't have an account?",
+          "createOne": "Create one"
+        },
+        "form": {
+          "emailLabel": "Email",
+          "emailPlaceholder": "Enter your email",
+          "passwordLabel": "Password",
+          "passwordPlaceholder": "Enter your password",
+          "forgotPassword": "Forgot your password?",
+          "submitButton": "Sign in",
+          "submitting": "Signing in...",
+          "orDivider": "or",
+          "continueWithGoogle": "Continue with Google",
+          "continueWithGithub": "Continue with GitHub",
+          "errors": {
+            "invalidOtp": "Invalid verification code. Please check your credentials and try again.",
+            "invalidCredentials": "Invalid email or password. Please check your credentials and try again.",
+            "generic": "An error occurred during sign in. Please try again."
+          },
+          "twoFactor": {
+            "title": "Two-factor authentication",
+            "description": "Enter the verification code from your authenticator app.",
+            "cancel": "Cancel"
+          }
+        }
+      },
+      "register": {
+        "seo": {
+          "title": "Create Your Betterlytics Account — Get Started Free",
+          "description": "Create a free Betterlytics account for privacy-first, cookieless web analytics. Start measuring your website and app traffic securely and GDPR-compliantly.",
+          "keywords": [
+            "Create Betterlytics Account",
+            "Register",
+            "Sign Up",
+            "Free Web Analytics",
+            "Privacy-First Analytics",
+            "Cookieless Analytics",
+            "Google Analytics Alternative",
+            "GDPR Compliant Analytics"
+          ]
+        },
+        "title": "Create your account",
+        "subtitle": "Get started for free — set up your analytics in minutes",
+        "cta": {
+          "haveAccount": "Already have an account?",
+          "signIn": "Sign in"
+        },
+        "disabled": {
+          "title": "Registration Disabled",
+          "description": "Registration is currently disabled on this instance.",
+          "backToSignIn": "Back to Sign In"
+        }
+      },
+      "forgotPassword": {
+        "seo": {
+          "title": "Forgot your password? | Betterlytics",
+          "description": "“Reset your Betterlytics password securely. Enter your email to receive a protected reset link and regain account access.",
+          "keywords": [
+            "Forgot Password",
+            "Password Reset",
+            "Account Recovery",
+            "Reset Betterlytics Password",
+            "Betterlytics Account",
+            "Secure Login"
+          ]
+        },
+        "title": "Reset your password",
+        "subtitle": "Enter your email and we'll send you a password reset link",
+        "emailField": "Email Address",
+        "emailFieldPlaceholder": "Enter your email address",
+        "emailFieldDescription": "Enter the email address associated with your account and we'll send you a password reset link.",
+        "successMessage": "Password reset email sent!",
+        "errorMessage": "Failed to send password reset email, please try again.",
+        "errorMessageInvalidEmail": "Please enter a valid email address",
+        "cta": {
+          "sendResetLink": "Send Password Reset Link",
+          "sending": "Sending...",
+          "remember": "Remember your password?",
+          "backToSignIn": "Back to Sign In"
+        }
+      },
+      "resetPassword": {
+        "seo": {
+          "title": "Reset your password | Betterlytics",
+          "description": "Set a new password for your Betterlytics account securely using your protected reset link and regain full access.",
+          "keywords": [
+            "Reset Password",
+            "Password Reset",
+            "Account Recovery",
+            "Betterlytics Account",
+            "Secure Password Reset",
+            "Login Help"
+          ]
+        },
+        "invalid": {
+          "title": "Invalid Reset Link",
+          "description": "This password reset link is invalid or missing a token.",
+          "note": "Please request a new password reset link.",
+          "requestLink": "Request New Reset Link"
+        },
+        "expired": {
+          "title": "Reset Link Expired",
+          "description": "This password reset link has expired or is invalid.",
+          "info": "Password reset links expire after 1 hour for security reasons. Please request a new one.",
+          "requestLink": "Request New Reset Link"
+        },
+        "form": {
+          "title": "Set your new password",
+          "description": "Enter your new password below"
+        },
+        "cta": {
+          "remember": "Remember your password?",
+          "backToSignIn": "Back to Sign In"
+        }
+      },
+      "verifyEmail": {
+        "invalid": {
+          "title": "Invalid Verification Link",
+          "description": "The verification link is invalid or missing. Please check your email and try again.",
+          "backToSignIn": "Back to Sign In"
+        },
+        "failed": {
+          "title": "Verification Failed",
+          "expiredInfo": "Verification links expire after 24 hours for security. You can request a new one and try again.",
+          "genericFallback": "An error occurred during verification."
+        },
+        "buttons": {
+          "returnToDashboard": "Return to Dashboard",
+          "backToSignIn": "Back to Sign In"
+        },
+        "helpLine": "Need help? Contact support at support@betterlytics.io",
+        "loading": {
+          "title": "Verifying...",
+          "description": "Please wait a moment while we verify your email address."
+        },
+        "success": {
+          "title": "Email Verified!",
+          "description": "Your email has been successfully verified.",
+          "celebration": "Welcome aboard!",
+          "redirecting": "Taking you to your dashboard...",
+          "clickHere": "Click here if not redirected automatically",
+          "redirectingToSignin": "Taking you to sign in...",
+          "errors": {
+            "redirectTimeout": "Redirect is taking longer than expected.",
+            "redirectFailed": "Something went wrong during the redirect."
+          }
+        },
+        "verifying": {
+          "title": "Verifying your email...",
+          "description": "Please wait while we confirm your email address."
+        }
+      }
+    },
+    "demo": {
+      "seo": {
+        "title": "Betterlytics | Demo Dashboard",
+        "description": "Explore Betterlytics' capabilities in this interactive demo dashboard.",
+        "keywords": [
+          "Betterlytics Demo",
+          "Analytics Demo",
+          "Product Tour",
+          "Web Analytics Demo",
+          "Privacy-First Analytics"
+        ]
+      }
+    },
+    "comparison": {
+      "getStartedFree": "Get Started Free",
+      "viewPricing": "View Pricing",
+      "featureComparison": {
+        "title": "Feature Comparison",
+        "subtitle": "See how Betterlytics and {competitor} compare side-by-side"
+      },
+      "whyBetterlytics": {
+        "title": "Why Betterlytics?",
+        "subtitle": "A deeper look at what makes Betterlytics different"
+      },
+      "disclaimer": "We strive to keep this comparison accurate and up-to-date."
+    },
+    "landing": {
+      "seo": {
+        "title": "Betterlytics | A Better Alternative to Google Analytics",
+        "description": "Betterlytics is a privacy-first, cookieless analytics platform — GDPR-compliant, no cookies, no tracking, no consent banners.",
+        "keywords": [
+          "Google Analytics Alternative",
+          "Cookieless Analytics",
+          "Privacy-First Analytics",
+          "GDPR Compliant Analytics",
+          "Open Source Analytics Platform",
+          "Privacy-Friendly Analytics",
+          "Website Analytics",
+          "Visitor Insights",
+          "Betterlytics"
+        ]
+      },
+      "hero": {
+        "title": "A <highlight>Better Alternative</highlight> to Google Analytics",
+        "description": "Simple, powerful analytics that respect privacy. <br></br>Cookieless, GDPR-ready, and no cookie banners required.",
+        "ctaPrimary": "Get Started for Free",
+        "ctaGithub": "View on GitHub",
+        "ctaDemo": "View live demo",
+        "eyebrow": "Try Betterlytics in action"
+      },
+      "framework": {
+        "title": "Works with your favorite tools",
+        "subtitle": "Universal compatibility - works with any website, framework, or platform",
+        "footer": "And countless more... If it runs on the web, we support it!"
+      },
+      "principles": {
+        "titleEmphasis": "High-performance",
+        "titleRest": "analytics that respects privacy",
+        "subtitle": "Real-time insights, lightning-fast performance, and complete privacy compliance for everyone",
+        "features": {
+          "euGdpr": {
+            "title": "EU-Based & GDPR Compliant",
+            "description": "Servers hosted in the EU with strict data protection standards. Complete GDPR compliance with anonymous data collection and robust privacy safeguards."
+          },
+          "noConsent": {
+            "title": "No Consent Banner Required",
+            "description": "Fully anonymous analytics mean no cookie banners, no GDPR consent forms, no user friction. Just install and start tracking immediately."
+          },
+          "dataOwnership": {
+            "title": "Complete Data Ownership",
+            "description": "Your data stays yours forever. Self-host with our open-source version or use our secure cloud infrastructure."
+          },
+          "realtime": {
+            "title": "Real-time Insights",
+            "description": "Lightning-fast visitor tracking and conversion analytics worldwide. Beautiful dashboards help you make data-driven decisions instantly."
+          },
+          "lightweight": {
+            "title": "Lightweight & Developer-Friendly",
+            "description": "Under 2KB script, open-source codebase, and comprehensive documentation. Built by developers, for developers."
+          },
+          "simpleSetup": {
+            "title": "Simple Setup, Powerful Features",
+            "description": "One-line integration for any website. Advanced customization options and enterprise-grade features available."
+          }
+        }
+      },
+      "showcase": {
+        "titleEmphasis": "Powerful features",
+        "titleRest": "at your fingertips",
+        "subtitle": "Explore the full arsenal of analytics capabilities",
+        "categories": {
+          "analytics": "Analytics & Insights",
+          "engagement": "Engagement & Behavior",
+          "performance": "Monitoring & Performance"
+        },
+        "featuresButton": "Explore All Features",
+        "featuresTitle": "Explore all Betterlytics features"
+      },
+      "ctaStrip": {
+        "eyebrow": "Get started free",
+        "title": "Ready to try Betterlytics?",
+        "subtitle": "Create an account and start tracking in minutes. Free plan included. No credit card.",
+        "primaryCta": "Get started free"
+      },
+      "integration": {
+        "titleStart": "Get started in",
+        "titleEmphasis": "under 2 minutes",
+        "subtitle": "Add our lightweight script and start collecting cookieless, privacy-friendly analytics immediately. No cookies, no personal data, no consent banners required.",
+        "cards": {
+          "script": {
+            "title": "Simple Script Tag",
+            "description": "Add one line to your HTML and start tracking immediately. Works with any website or CMS.",
+            "features": {
+              "f1": "One-line installation",
+              "f2": "Works anywhere",
+              "f3": "No build process needed"
+            }
+          },
+          "framework": {
+            "title": "Framework Ready",
+            "description": "Native support for React, Next.js, Vue, and other modern frameworks with TypeScript.",
+            "features": {
+              "f1": "TypeScript support",
+              "f2": "Framework components",
+              "f3": "Tree-shakeable"
+            }
+          },
+          "selfHosted": {
+            "title": "Self-Hosted Option",
+            "description": "Deploy on your own infrastructure with Docker for complete data ownership and control.",
+            "features": {
+              "f1": "Docker deployment",
+              "f2": "Complete control",
+              "f3": "GDPR compliant"
+            }
+          }
+        },
+        "guideButton": "View Integration Guide",
+        "guideTitle": "Betterlytics Integration Guide",
+        "footer": "Detailed installation instructions for all platforms and frameworks"
+      },
+      "openSource": {
+        "titleEmphasis": "Open Source",
+        "titleRest": "Community Driven",
+        "subtitle": "Transparent, community-driven development. Join our contributors, request features, or adapt the platform to your unique requirements.",
+        "starOnGithub": "Star on GitHub",
+        "viewDocs": "View Documentation",
+        "docsTitle": "Complete Betterlytics Documentation"
+      },
+      "pricing": {
+        "titleEmphasis": "Simple, scalable",
+        "titleRest": "pricing",
+        "subtitle": "Traffic-based plans that matches your growth. Start free, scale as you grow.",
+        "footer": "Start with our free plan - no credit card required.",
+        "compareLink": "Compare all features"
+      },
+      "cards": {
+        "advancedFilters": {
+          "title": "Advanced Filters",
+          "description": "Slice and dice your analytics data by any dimension to uncover actionable insights."
+        },
+        "coreWebVitals": {
+          "title": "Core Web Vitals",
+          "description": "Monitor and measure your site's performance with Core Web Vitals."
+        },
+        "trafficSources": {
+          "title": "Traffic Sources",
+          "description": "Discover where your visitors are arriving from and optimize your marketing efforts.",
+          "totalVisitors": "Total Visitors",
+          "thisMonth": "this month",
+          "visitorsLabel": "visitors",
+          "sources": {
+            "googleSearch": "Google Search",
+            "direct": "Direct",
+            "socialMedia": "Social Media",
+            "email": "Email",
+            "other": "Other"
+          }
+        },
+        "errorTracking": {
+          "title": "Error Tracking",
+          "description": "Catch client-side errors early. Inspect stack traces and replay sessions to see exactly what went wrong.",
+          "status": {
+            "unresolved": "Unresolved",
+            "resolved": "Resolved"
+          },
+          "watchReplay": "Watch replay",
+          "usersAffected": "{count} users",
+          "summary": "37 errors this month",
+          "unresolved": "{count} unresolved"
+        },
+        "funnels": {
+          "title": "Funnels",
+          "description": "Track the conversion rate of your website's key user journeys.",
+          "total": "Total",
+          "dropOff": "drop off",
+          "sinceLastWeek": "since last week"
+        },
+        "events": {
+          "title": "Real-time Events",
+          "description": "Track every user interaction as it happens with detailed event logging.",
+          "showing": "Showing {loaded} of {total} events"
+        },
+        "sessionReplay": {
+          "title": "Session Replay",
+          "description": "Watch anonymized, pixel-perfect recordings to quickly spot friction, rage clicks, and visual glitches.",
+          "cursorClick": "Cursor click captured",
+          "sessionPlayback": "Session playback",
+          "playing": "Playing"
+        },
+        "journeys": {
+          "title": "User Journeys",
+          "description": "Track multiple user paths and see how visitors navigate through your site."
+        },
+        "worldMap": {
+          "title": "Geographical Analytics",
+          "description": "See where your visitors are coming from around the world.",
+          "topCountries": "Top Countries"
+        },
+        "uptimeMonitoring": {
+          "title": "Uptime Monitoring",
+          "description": "Get alerts when your site goes down, plus automatic SSL certificate monitoring.",
+          "alertDown": "{site} is down",
+          "alertSent": "Alert sent to {email}",
+          "incidentDetected": "{count, plural, one {{count} incident detected} other {{count} incidents detected}}",
+          "allOperational": "All systems operational",
+          "ssl": "SSL"
+        }
+      }
+    },
+    "features": {
+      "seo": {
+        "title": "Features of Betterlytics | Privacy-First, Cookie-Less Analytics",
+        "description": "Discover all Betterlytics features: real-time dashboards, conversion funnels, Core Web Vitals, and more. Privacy-first, GDPR-compliant analytics without cookies or consent banners.",
+        "keywords": [
+          "Analytics Features",
+          "Privacy-First Analytics",
+          "Cookieless Analytics",
+          "GDPR Compliant Analytics",
+          "Real-time Dashboard",
+          "Conversion Funnels",
+          "Session Replay",
+          "Custom Events",
+          "Web Analytics Features"
+        ]
+      },
+      "hero": {
+        "title": "Every Feature You Need for <br></br><highlight>Better Analytics</highlight>",
+        "description": "Explore everything Betterlytics offers, from real-time dashboards to conversion funnels. All the analytics you need, without cookies, consent banners, or compromising on privacy.",
+        "ctaPrimary": "Get Started Free",
+        "ctaDemo": "View Live Demo"
+      },
+      "categories": {
+        "coreAnalytics": "Core Web Analytics",
+        "advancedAnalytics": "Advanced Analytics",
+        "performanceMonitoring": "Performance & Monitoring",
+        "privacyData": "Privacy & Compliance",
+        "accessSecurity": "Access & Security",
+        "developerDeployment": "Developer & Deployment",
+        "support": "Support"
+      },
+      "items": {
+        "pageViews": {
+          "title": "Page Views",
+          "description": "See which pages get the most traffic and understand overall engagement trends."
+        },
+        "visitors": {
+          "title": "Visitors",
+          "description": "Track unique visitors and monitor overall audience growth and behavior."
+        },
+        "bounceRate": {
+          "title": "Bounce Rate",
+          "description": "Identify pages that retain visitors versus those that cause quick exits, helping you optimize content."
+        },
+        "trafficSources": {
+          "title": "Traffic Sources",
+          "description": "Discover where visitors come from, including organic, social, referral, and campaigns."
+        },
+        "location": {
+          "title": "Location",
+          "description": "See visitor distribution by city, region, and country for geographic insights."
+        },
+        "devices": {
+          "title": "Devices",
+          "description": "Monitor which devices visitors use, whether desktop, mobile, or tablet."
+        },
+        "languages": {
+          "title": "Languages",
+          "description": "Track your visitors’ preferred languages to tailor content effectively."
+        },
+        "filtering": {
+          "title": "Filtering",
+          "description": "Segment your data by traffic, device, location, and other attributes quickly."
+        },
+        "realtimeData": {
+          "title": "Real-time Data",
+          "description": "See visitor activity as it happens, including page views, events, and sessions."
+        },
+        "customEvents": {
+          "title": "Custom Events",
+          "description": "Track specific user interactions like clicks, form submissions, or downloads to measure engagement."
+        },
+        "utmTracking": {
+          "title": "UTM Tracking",
+          "description": "Measure the performance of marketing campaigns with UTM parameters."
+        },
+        "linkTracking": {
+          "title": "Link Tracking",
+          "description": "Monitor clicks on internal and outbound links to understand user engagement."
+        },
+        "globalProperties": {
+          "title": "Global Properties",
+          "description": "Set persistent properties once and automatically attach them to all events, like user plan, role, or app version."
+        },
+        "sessionReplay": {
+          "title": "Session Replay",
+          "description": "Replay user sessions to see exactly how visitors interact with your site and uncover usability issues."
+        },
+        "errorTracking": {
+          "title": "Error Tracking",
+          "description": "Automatically capture and group client-side errors, with stack traces and session replay links so you can reproduce and fix bugs fast."
+        },
+        "userJourneys": {
+          "title": "User Journeys",
+          "description": "Visualize the paths visitors take across your site from entry to exit."
+        },
+        "funnels": {
+          "title": "Funnels",
+          "description": "Track user progress through defined steps and identify drop-off points."
+        },
+        "annotations": {
+          "title": "Annotations",
+          "description": "Add notes to your analytics timeline to track events or campaign changes."
+        },
+        "timePeriodComparison": {
+          "title": "Compare",
+          "description": "Compare metrics across different time periods to spot trends and changes."
+        },
+        "outboundLinks": {
+          "title": "Outbound Link Tracking",
+          "description": "Track clicks on links leaving your site to measure user engagement."
+        },
+        "emailReports": {
+          "title": "Email Reports",
+          "description": "Receive automated weekly or monthly analytics summaries delivered directly to your inbox."
+        },
+        "coreWebVitals": {
+          "title": "Core Web Vitals",
+          "description": "Measure and optimize Google's page performance metrics to improve loading, interactivity, and search rankings."
+        },
+        "uptimeMonitoring": {
+          "title": "Uptime Monitoring",
+          "description": "Ensure your site is live and accessible by tracking uptime automatically."
+        },
+        "sslMonitoring": {
+          "title": "SSL Certificate Monitoring",
+          "description": "Monitor SSL certificate status to avoid expired or insecure connections."
+        },
+        "notificationIntegrations": {
+          "title": "Notification Integrations",
+          "description": "Get alerted via Slack, Discord, Microsoft Teams, webhooks, and more when something needs your attention."
+        },
+        "cookieless": {
+          "title": "No Cookies",
+          "description": "Collect privacy-first analytics without cookies, providing accurate data without requiring consent banners."
+        },
+        "gdprCcpa": {
+          "title": "GDPR & CCPA",
+          "description": "Stay compliant with privacy laws while collecting anonymous analytics data."
+        },
+        "euHosting": {
+          "title": "Hosted in EU",
+          "description": "Ensure all data is stored in the EU for privacy and compliance."
+        },
+        "anonymousByDefault": {
+          "title": "Data Anonymization",
+          "description": "All visitor data is anonymized by default to protect privacy."
+        },
+        "dataOwnership": {
+          "title": "Data Ownership",
+          "description": "You maintain full control and ownership of all collected analytics data."
+        },
+        "openSource": {
+          "title": "Open Source",
+          "description": "Inspect, audit, and contribute to the analytics platform codebase."
+        },
+        "memberRoles": {
+          "title": "Role-Based Access",
+          "description": "Control user access with role-based permissions for team members."
+        },
+        "twoFactorAuth": {
+          "title": "Two-Factor Authentication",
+          "description": "Add an extra layer of security for all user accounts."
+        },
+        "oauthLogin": {
+          "title": "OAuth Login",
+          "description": "Sign in securely using OAuth providers like Google or GitHub."
+        },
+        "simpleScriptTag": {
+          "title": "Simple Script Tag",
+          "description": "Add analytics to your site with a single lightweight script."
+        },
+        "frameworkSdks": {
+          "title": "Framework SDKs",
+          "description": "Integrate Betterlytics easily with frameworks like React, Angular, Next.js, and more."
+        },
+        "selfHosting": {
+          "title": "Self-Hosting",
+          "description": "Deploy Betterlytics on your own servers for full control over data."
+        },
+        "fullyManaged": {
+          "title": "Fully Managed Cloud",
+          "description": "Use our managed cloud solution for quick setup and zero maintenance."
+        },
+        "lightweightScript": {
+          "title": "Lightweight Script",
+          "description": "Fast-loading script under 2KB that won't slow down your website."
+        },
+        "highPerformance": {
+          "title": "High Performance",
+          "description": "ClickHouse-powered analytics engine delivers sub-second query times at any scale."
+        },
+        "mcpServer": {
+          "title": "MCP Server",
+          "description": "Query your analytics data from AI assistants like Claude. Built-in MCP server for natural language access to metrics, funnels, and user journeys."
+        },
+        "emailSupport": {
+          "title": "Email Support",
+          "description": "Get help via email for any questions or issues."
+        },
+        "prioritySupport": {
+          "title": "Priority Support",
+          "description": "Receive faster responses from our support team for critical issues."
+        },
+        "dedicatedSupport": {
+          "title": "Dedicated Support",
+          "description": "Access a dedicated support manager for personalized assistance."
+        },
+        "slaGuarantee": {
+          "title": "SLA Guarantee",
+          "description": "Guaranteed uptime and support response times with a formal SLA."
+        }
+      }
+    },
+    "nav": {
+      "documentation": "Documentation",
+      "features": "Features",
+      "pricing": "Pricing",
+      "goToDashboard": "Go to Dashboard",
+      "getStarted": "Get Started",
+      "login": "Log in"
+    },
+    "footer": {
+      "blurb": "Privacy-first web analytics for the modern web. GDPR compliant, cookieless, and open source.",
+      "company": "Company",
+      "resources": "Resources",
+      "compare": "Compare",
+      "connect": "Connect",
+      "about": "About",
+      "contact": "Contact",
+      "privacyPolicy": "Privacy Policy",
+      "subprocessors": "Subprocessors",
+      "termsOfService": "Terms of Service",
+      "dpa": "Data Processing Agreement",
+      "documentation": "Documentation",
+      "changelog": "Changelog",
+      "pricing": "Pricing",
+      "features": "Features",
+      "github": "GitHub",
+      "bluesky": "Bluesky",
+      "discord": "Discord",
+      "copyright": "© {year} Betterlytics. Open source under AGPL-3.0 license."
+    },
+    "structuredData": {
+      "organization": {
+        "description": "Betterlytics is a privacy-first, cookieless, GDPR-compliant, open-source web analytics platform that respects user privacy while delivering actionable insights.",
+        "contactTypeCustomerService": "Customer Service",
+        "contactTypeTechnicalSupport": "Technical Support"
+      },
+      "webPage": {
+        "breadcrumbHome": "Home"
+      }
+    },
+    "pricing": {
+      "seo": {
+        "title": "Pricing | Betterlytics Privacy-First Analytics",
+        "description": "Simple, transparent pricing for Betterlytics. Start free, scale as you grow. Privacy-first, GDPR compliant web analytics for every business size.",
+        "keywords": [
+          "Analytics Pricing",
+          "Web Analytics Plans",
+          "Privacy Analytics Pricing",
+          "GDPR Analytics Cost",
+          "Betterlytics Plans",
+          "Affordable Analytics",
+          "Free Analytics Plan"
+        ]
+      },
+      "titleEmphasis": "Simple, transparent",
+      "titleRest": "pricing",
+      "subtitle": "Start free, upgrade when you need more. No hidden fees, no surprises.",
+      "footer": "Start with our free plan - no credit card required.",
+      "comparisonTitle": "Compare all features",
+      "exploreFeaturesLink": "Explore all features in detail"
+    }
+  },
+  "pricingSlider": {
+    "monthlyEvents": "Monthly Events",
+    "suggested": "Suggested",
+    "recommend": "Based on your estimated traffic, we recommend <emphasis>{events} events / month</emphasis>."
+  },
+  "pricingCards": {
+    "periodPerMonth": "/month",
+    "descriptions": {
+      "growth": "Perfect for small websites and personal projects",
+      "professional": "Advanced features for growing businesses",
+      "enterprise": "Complete solution for large organizations"
+    },
+    "features": {
+      "upToEventsPerMonth": "Up to {events} events/month",
+      "customEventVolume": "Custom event volume",
+      "twoSites": "Up to 2 sites",
+      "upTo50Sites": "Up to 50 sites",
+      "unlimitedSites": "Unlimited sites",
+      "threeTeamMembers": "Up to 3 team members",
+      "upTo50TeamMembers": "Up to 50 team members",
+      "unlimitedTeamMembers": "Unlimited team members",
+      "retention1PlusYear": "1+ year data retention",
+      "retention3PlusYears": "3+ years data retention",
+      "retention5PlusYears": "5+ years data retention",
+      "fullDashboard": "Full web analytics dashboard",
+      "funnelsJourneys": "Funnels & user journeys",
+      "sessionReplay": "Session replay",
+      "errorTracking": "Error tracking",
+      "uptime1": "1 uptime monitor",
+      "uptime50": "50 uptime monitors with 1-minute checks",
+      "uptimeUnlimited": "Unlimited uptime monitors",
+      "emailReports": "Scheduled email reports",
+      "customHttp": "Advanced uptime checks (custom HTTP methods, headers & status codes)",
+      "dedicatedSupport": "Dedicated support",
+      "slaGuarantee": "SLA guarantee",
+      "everythingInStarter": "Everything in Growth, plus:",
+      "everythingInProfessional": "Everything in Professional, plus:"
+    },
+    "cta": {
+      "getStartedForFree": "Get Started for Free",
+      "contactSales": "Contact Sales",
+      "getStarted": "Get Started",
+      "currentPlan": "Current Plan",
+      "changeToThisPlan": "Change to This Plan",
+      "contactUs": "Contact Us"
+    },
+    "badges": {
+      "mostPopular": "Recommended",
+      "current": "Current"
+    },
+    "labels": {
+      "free": "Free",
+      "custom": "Custom"
+    }
+  },
+  "pricingComparison": {
+    "headers": {
+      "features": "Features",
+      "growth": "Growth",
+      "professional": "Professional",
+      "enterprise": "Enterprise"
+    },
+    "categories": {
+      "usageLimits": "Usage & Limits",
+      "analytics": "Analytics",
+      "observability": "Observability",
+      "support": "Support"
+    },
+    "features": {
+      "monthlyEvents": {
+        "name": "Monthly events",
+        "values": {
+          "custom": "Custom"
+        }
+      },
+      "sites": {
+        "name": "Sites",
+        "values": {
+          "upTo2": "Up to 2",
+          "upTo50": "Up to 50",
+          "unlimited": "Unlimited"
+        }
+      },
+      "dataRetention": {
+        "name": "Data retention",
+        "values": {
+          "1year": "1+ year",
+          "3years": "3+ years",
+          "5years": "5+ years"
+        }
+      },
+      "teamMembers": {
+        "name": "Team members",
+        "values": {
+          "upTo3": "Up to 3",
+          "upTo50": "Up to 50",
+          "unlimited": "Unlimited"
+        }
+      },
+      "dashboardFeatures": {
+        "name": "All dashboard features"
+      },
+      "sessionReplay": {
+        "name": "Session replay"
+      },
+      "funnels": {
+        "name": "Funnels & conversions"
+      },
+      "userJourneys": {
+        "name": "User journey tracking"
+      },
+      "customEvents": {
+        "name": "Custom events"
+      },
+      "webVitals": {
+        "name": "Web Vitals monitoring"
+      },
+      "campaignTracking": {
+        "name": "Campaign & UTM tracking"
+      },
+      "errorTracking": {
+        "name": "Client-side error tracking"
+      },
+      "emailReports": {
+        "name": "Email reports"
+      },
+      "uptimeMonitoring": {
+        "name": "Uptime monitoring",
+        "values": {
+          "1": "1 monitor",
+          "50": "50 monitors",
+          "unlimited": "Unlimited monitors"
+        }
+      },
+      "sslMonitoring": {
+        "name": "SSL certificate monitoring"
+      },
+      "checkInterval": {
+        "name": "Minimum check interval",
+        "values": {
+          "5min": "5 min",
+          "1min": "1 min"
+        }
+      },
+      "customHttpMethods": {
+        "name": "GET HTTP method"
+      },
+      "customRequestHeaders": {
+        "name": "Custom request headers"
+      },
+      "customStatusCodes": {
+        "name": "Custom accepted status codes"
+      },
+      "notificationIntegrations": {
+        "name": "Notification integrations (Slack, Discord, etc.)"
+      },
+      "emailSupport": {
+        "name": "Email support"
+      },
+      "prioritySupport": {
+        "name": "Priority support"
+      },
+      "dedicatedSupport": {
+        "name": "Dedicated support"
+      },
+      "slaGuarantee": {
+        "name": "SLA guarantee"
+      }
+    },
+    "coreFeatures": {
+      "title": "Included in all plans",
+      "subtitle": "Every plan comes with our full analytics suite",
+      "items": {
+        "realtimeAnalytics": "Real-time analytics",
+        "sessionReplay": "Session replay",
+        "geographicInsights": "Geographic insights",
+        "trafficSources": "Traffic sources",
+        "utmCampaigns": "UTM campaign tracking",
+        "customEvents": "Custom events",
+        "funnels": "Funnels & conversions",
+        "userJourneys": "User journeys",
+        "webVitals": "Web Vitals",
+        "botFiltering": "Bot filtering",
+        "outboundLinks": "Outbound link tracking",
+        "advancedFiltering": "Advanced filtering",
+        "cookieFree": "Cookie-free",
+        "gdprCcpa": "GDPR & CCPA ready",
+        "errorTracking": "Client-side error tracking"
+      }
+    }
+  },
+  "dashboard": {
+    "sidebar": {
+      "overview": "概要",
+      "pages": "ページ",
+      "referrers": "参照元",
+      "outboundLinks": "外部リンク",
+      "geography": "地域",
+      "userJourney": "ユーザー導線",
+      "funnels": "ファネル",
+      "devices": "デバイス",
+      "campaigns": "キャンペーン",
+      "events": "イベント",
+      "activeUsers": "{count, plural, =0 {アクティブユーザー} one {アクティブユーザー} other {アクティブユーザー}}",
+      "webVitals": "Web Vitals",
+      "sessionReplay": "セッションリプレイ",
+      "monitoring": "監視",
+      "categories": {
+        "analytics": "アナリティクス",
+        "behavior": "行動",
+        "observability": "オブザーバビリティ"
+      },
+      "collapseNav": "ナビを折りたたむ",
+      "errorTracking": "エラー追跡"
+    },
+    "settings": {
+      "sidebar": {
+        "backToDashboard": "ダッシュボードに戻る",
+        "settings": "設定",
+        "data": "データ",
+        "rules": "ルール",
+        "members": "メンバー",
+        "reports": "メールレポート",
+        "mcp": "MCP",
+        "integrations": "連携",
+        "dangerZone": "危険な操作"
+      }
+    },
+    "metrics": {
+      "uniqueVisitors": "ユニーク訪問者",
+      "totalPageviews": "総ページビュー",
+      "bounceRate": "直帰率",
+      "avgVisitDuration": "平均滞在時間",
+      "sessions": "セッション",
+      "pagesPerSession": "セッションあたりのページ数",
+      "sessionDuration": "セッション時間"
+    },
+    "sections": {
+      "topPages": "人気ページ",
+      "geography": "地域",
+      "devicesBreakdown": "デバイス",
+      "trafficSources": "流入元",
+      "events": "イベント",
+      "weeklyTrends": "週次トレンド"
+    },
+    "goTo": "{section}へ移動",
+    "tabs": {
+      "pages": "ページ",
+      "entryPages": "入口ページ",
+      "exitPages": "離脱ページ",
+      "countries": "国",
+      "regions": "地域",
+      "cities": "都市",
+      "worldMap": "世界地図",
+      "browsers": "ブラウザ",
+      "devices": "デバイス",
+      "operatingSystems": "OS",
+      "referrers": "参照元",
+      "sources": "ソース",
+      "channels": "チャネル",
+      "events": "カスタムイベント",
+      "topProperties": "グローバルプロパティ"
+    },
+    "emptyStates": {
+      "adjustTimeRange": "期間またはフィルターを調整してください",
+      "noUserJourneyData": "ユーザー導線のデータがありません",
+      "noData": "データがありません"
+    }
+  },
+  "dashboardsPage": {
+    "title": "ダッシュボード一覧",
+    "subtitle": "すべてのウェブサイトのアナリティクスを管理・監視できます。",
+    "loadError": "ダッシュボードの読み込みに失敗しました",
+    "emptyTitle": "ダッシュボードがまだありません",
+    "emptyDescription": "最初のダッシュボードを作成して、ウェブサイトのアナリティクス計測を始めましょう。",
+    "memberCountTooltip": "{count, plural, one {{count}人のメンバー} other {{count}人のメンバー}}",
+    "goToDashboardTooltip": "{domain}へ移動",
+    "settingsTooltip": "ダッシュボード設定",
+    "createCard": {
+      "title": "ダッシュボードを作成",
+      "description": "新しいダッシュボードを追加"
+    },
+    "upgradeCard": {
+      "title": "ダッシュボードをもっと作成しますか？",
+      "description": "Proプランは最大50サイトまで対応",
+      "cta": "Proにアップグレード"
+    }
+  },
+  "monitoring": {
+    "status": {
+      "paused": "Paused",
+      "preparing": "Preparing",
+      "up": "Up",
+      "degraded": "Degraded",
+      "down": "Down"
+    },
+    "checkStatus": {
+      "ok": "OK",
+      "warn": "Warning",
+      "failed": "Failed"
+    },
+    "incidentStatus": {
+      "ongoing": "Ongoing",
+      "resolved": "Resolved"
+    },
+    "latency": {
+      "paused": "Paused",
+      "fast": "Fast",
+      "elevated": "Elevated",
+      "slow": "Slow",
+      "noData": "No data"
+    },
+    "ssl": {
+      "valid": "Valid",
+      "expiringSoon": "Expiring soon",
+      "expired": "Expired",
+      "error": "Error",
+      "notChecked": "Not checked",
+      "badgeValid": "Certificate valid",
+      "badgeExpiringSoon": "Certificate expiring soon",
+      "badgeExpired": "Certificate expired",
+      "badgeError": "Certificate error",
+      "badgeNotChecked": "Certificate not checked"
+    },
+    "labels": {
+      "noData": "No data",
+      "uptimeSuffix": "uptime",
+      "daysLeft": "{count, plural, one {{count}d left} other {{count}d left}}",
+      "hoursLeft": "{count, plural, one {{count}h left} other {{count}h left}}",
+      "daysLeftFull": "{count, plural, one {Expires in {count} day} other {Expires in {count} days}}",
+      "hoursLeftFull": "{count, plural, one {Expires in {count} hour} other {Expires in {count} hours}}"
+    },
+    "actions": {
+      "pause": "Pause monitor",
+      "resume": "Resume monitor",
+      "pausing": "Pausing...",
+      "resuming": "Resuming..."
+    }
+  },
+  "monitor": {
+    "reason": {
+      "ok": "Site is healthy",
+      "tls_handshake_failed": "SSL/TLS handshake failed",
+      "tls_missing_certificate": "SSL certificate not found",
+      "tls_expired": "SSL certificate has expired",
+      "tls_expiring_soon": "SSL certificate expiring soon",
+      "tls_parse_error": "Failed to parse SSL certificate",
+      "tls_hostname_mismatch": "SSL certificate hostname mismatch",
+      "tls_untrusted_ca": "SSL certificate issued by untrusted CA",
+      "tls_not_yet_valid": "SSL certificate not yet valid",
+      "tls_revoked": "SSL certificate has been revoked",
+      "tls_self_signed": "SSL certificate is self-signed",
+      "tls_connection_failed": "SSL connection failed",
+      "http_4xx": "Server returned a client error",
+      "http_5xx": "Server returned a server error",
+      "http_other": "Unexpected HTTP status code",
+      "http_timeout": "Request timed out",
+      "http_connect_error": "Could not connect to server",
+      "http_body_error": "Error reading response body",
+      "http_request_error": "Error sending request",
+      "http_error": "HTTP request failed",
+      "too_many_redirects": "Too many redirects",
+      "redirect_join_failed": "Invalid redirect location",
+      "scheme_blocked": "URL scheme not allowed",
+      "port_blocked": "Port not allowed",
+      "invalid_host": "Invalid hostname",
+      "blocked_ip_literal": "IP address not allowed",
+      "dns_blocked": "DNS resolved to blocked address",
+      "dns_error": "DNS resolution failed",
+      "keyword_not_found": "Expected keyword not found in response",
+      "unknown": "Unknown error"
+    }
+  },
+  "monitoringPage": {
+    "title": "Monitoring",
+    "filters": {
+      "statusLabel": "Status",
+      "sortLabel": "Sort",
+      "statusAll": "All",
+      "statusUp": "Up",
+      "statusDegraded": "Degraded",
+      "statusDown": "Down",
+      "statusSslExpiring": "Expiring SSL certificate",
+      "statusPaused": "Paused",
+      "statusPreparing": "Preparing",
+      "sortDownFirst": "Down first",
+      "sortUpFirst": "Up first",
+      "sortNewest": "Newest first",
+      "sortOldest": "Oldest first",
+      "sortNameAsc": "Name (A-Z)",
+      "sortNameDesc": "Name (Z-A)",
+      "sortSslExpires": "SSL expires"
+    },
+    "emptyState": {
+      "title": "Start monitoring your endpoints",
+      "description": "Get notified when your site goes down and track uptime alongside your analytics.",
+      "durationDays": "{value}d"
+    },
+    "list": {
+      "noData": "No data yet",
+      "intervalMinutes": "{value} min",
+      "intervalSeconds": "{value}s",
+      "backoffTooltip": "Monitoring temporarily reduced to {value} because this monitor has been down repeatedly. Normal frequency resumes automatically once the service is healthy.",
+      "emptyTitle": "No monitors yet",
+      "emptyDescription": "Create your first monitor to start tracking uptime.",
+      "upPrefix": "Up",
+      "downPrefix": "Down",
+      "uptimeSuffix": "uptime"
+    },
+    "form": {
+      "create": "New monitor",
+      "upgradeToCreate": "Upgrade to add more",
+      "title": "Create monitor",
+      "fields": {
+        "name": "Name",
+        "url": "URL"
+      },
+      "placeholders": {
+        "name": "Optional label"
+      },
+      "helper": {
+        "nameOptional": "(optional)",
+        "nameDescription": "Give your monitor a friendly name, or leave blank to use the URL"
+      },
+      "errors": {
+        "url": "Please enter a valid URL.",
+        "urlDomain": "URL must be on {domain} or a subdomain (e.g., api.{domain})",
+        "duplicate": "A monitor for this URL already exists.",
+        "customPort": "Custom ports are not supported",
+        "invalidProtocol": "URL must start with https:// or http://"
+      },
+      "timing": {
+        "title": "Timing & Sensitivity",
+        "interval": {
+          "label": "Monitor interval",
+          "description": "Your site will be checked every {value}"
+        },
+        "timeout": {
+          "label": "Request timeout",
+          "description": "Too short may cause false positives"
+        },
+        "sensitivity": {
+          "label": "Incident sensitivity",
+          "description": "Number of consecutive failures before an incident is triggered",
+          "valueOne": "1 failure",
+          "valueOther": "{count} failures",
+          "unit": "{count, plural, one {failure} other {failures}}"
+        }
+      },
+      "actions": {
+        "cancel": "Cancel",
+        "create": "Create monitor",
+        "creating": "Creating..."
+      },
+      "success": "Monitor created",
+      "successDescription": "Your monitor will start checking immediately.",
+      "error": "Failed to create monitor"
+    },
+    "actions": {
+      "renameTitle": "Rename monitor",
+      "renamePlaceholder": "Monitor name",
+      "renameSuccess": "Monitor renamed",
+      "renameError": "Failed to rename monitor",
+      "settings": "Settings",
+      "deleteConfirmTitle": "Delete monitor?",
+      "deleteConfirmDescription": "This will permanently delete the monitor and all its data.",
+      "deleteError": "Failed to delete monitor"
+    }
+  },
+  "monitoringDetailPage": {
+    "actions": {
+      "edit": "Edit monitor"
+    },
+    "header": {
+      "back": "Back to Monitors",
+      "monitoring": "Monitoring"
+    },
+    "responseTime": {
+      "title": "Response time",
+      "badge": "Last 24 hours",
+      "empty": "No latency data yet"
+    },
+    "downtime": {
+      "days": "{value}d down",
+      "hours": "{value}h down",
+      "minutes": "{value}m down",
+      "unknown": "— down"
+    },
+    "incidents": {
+      "title": "Incidents",
+      "badge": "Last 7 days",
+      "emptyTitle": "No incidents recorded",
+      "emptyDescription": "We'll list root causes, timelines, and downtime windows once incidents occur.",
+      "headers": {
+        "status": "Status",
+        "root": "Root cause",
+        "started": "Started",
+        "duration": "Duration"
+      }
+    },
+    "recent": {
+      "title": "Recent monitoring results",
+      "badge": "Last 10",
+      "empty": "No checks recorded yet",
+      "errorsOnly": "Errors",
+      "headers": {
+        "status": "Status",
+        "ran": "Ran",
+        "latency": "Latency",
+        "statusCode": "Status code",
+        "reason": "Reason"
+      }
+    },
+    "uptime": {
+      "title": "Uptime",
+      "badge": "Last {days} days",
+      "grid": {
+        "uptimeLabel": "{value} uptime"
+      },
+      "stats": {
+        "label": "Last {days} days",
+        "downFallback": "— down"
+      }
+    },
+    "summary": {
+      "responseTime": {
+        "avgResponseTime": "Avg response time",
+        "helper": "Last 24 hours"
+      },
+      "nextCheck": {
+        "title": "Next check",
+        "paused": "Paused",
+        "preparing": "Preparing first check",
+        "awaiting": "Awaiting check...",
+        "inSeconds": "In {seconds}s",
+        "helperPaused": "Resume monitor to restart checks.",
+        "helperPreparing": "We're scheduling your first check. Results will appear soon.",
+        "helperScheduled": "Scheduled every {seconds}s",
+        "helperUpFor": "Up for {duration}",
+        "helperDownFor": "Down for {duration}"
+      },
+      "last24h": {
+        "title": "Last 24 hours",
+        "helperNone": "No incidents",
+        "helperWithIncidents": "{count, plural, one {{count} incident} other {{count} incidents}}, {downtime}"
+      },
+      "ssl": {
+        "title": "SSL Certificate",
+        "disabled": "Disabled",
+        "notApplicable": "N/A",
+        "timeLeft": "Time left",
+        "hoursLeft": "{count, plural, one {hour left} other {hours left}}",
+        "daysLeft": "{count, plural, one {day left} other {days left}}",
+        "expires": "Exp. {date}",
+        "httpSite": "Not Applicable",
+        "httpSiteDescription": "This site uses HTTP",
+        "disabledDescription": "SSL monitoring disabled",
+        "enableInSettings": "Enable in settings"
+      }
+    },
+    "toast": {
+      "status": {
+        "paused": "Monitoring paused",
+        "resumed": "Monitoring resumed"
+      },
+      "statusError": "Unable to update monitor status. Try again."
+    }
+  },
+  "monitoringEditDialog": {
+    "success": "Monitor updated",
+    "error": "Unable to update monitor, please try again.",
+    "trigger": "Edit",
+    "title": "Edit monitor",
+    "unsavedChanges": "Unsaved changes",
+    "actions": {
+      "cancel": "Cancel",
+      "save": "Save",
+      "saving": "Saving..."
+    },
+    "confirmDiscard": {
+      "title": "Discard unsaved changes?",
+      "description": "You have unsaved changes that will be lost if you close this sheet.",
+      "keep": "Keep editing",
+      "discard": "Discard"
+    },
+    "delete": {
+      "trigger": "Delete monitor",
+      "title": "Delete this monitor?",
+      "description": "This action cannot be undone. All monitoring data and incident history will be permanently deleted.",
+      "cancel": "Cancel",
+      "confirm": "Delete monitor",
+      "deleting": "Deleting...",
+      "error": "Failed to delete monitor"
+    },
+    "sections": {
+      "timing": "Timing",
+      "advanced": "Advanced settings"
+    },
+    "advanced": {
+      "httpMethod": {
+        "label": "HTTP method",
+        "description": "HEAD is faster but some servers don't support it"
+      },
+      "sslMonitoring": {
+        "label": "Monitor SSL errors",
+        "description": "Create incidents when certificate errors are detected",
+        "httpDisabled": "Not available for HTTP sites (no certificate)"
+      },
+      "requestHeaders": {
+        "label": "Request headers",
+        "description": "Custom headers included with each request",
+        "namePlaceholder": "Header name",
+        "valuePlaceholder": "Value",
+        "blockedHeader": "This header is blocked for security reasons"
+      },
+      "acceptedStatusCodes": {
+        "label": "Accepted status codes",
+        "description": "Other codes will trigger incidents",
+        "validation": {
+          "maxCodes": "Maximum of {max} status codes allowed",
+          "alreadyAdded": "{code} is already added",
+          "invalidRange": "Only ranges 2xx-5xx are valid HTTP status codes",
+          "invalidFormat": "Please enter a valid status code (e.g., 200) or range (e.g., 2xx)",
+          "outOfRange": "Status code must be between 100 and 599"
+        }
+      },
+      "expectedKeyword": {
+        "label": "Expected keyword",
+        "description": "Alert if this text is missing from the HTML source (first 32 KB). Use text visible in the raw HTML, not content rendered by JavaScript.",
+        "placeholder": "e.g. Welcome, Dashboard, OK",
+        "requiresGet": "Keyword validation requires the GET method"
+      }
+    },
+    "alerts": {
+      "title": "Alerts",
+      "enabled": "On",
+      "enableAlerts": "Enable alerts",
+      "description": "Get notified when your monitor goes down, recovers, or when SSL certificates are expiring.",
+      "onDown": "Alert on down",
+      "onDownDescription": "Send an alert when the monitor goes down",
+      "onRecovery": "Alert on recovery",
+      "onRecoveryDescription": "Send an alert when the monitor recovers from being down",
+      "onSslExpiry": "Alert on SSL expiry",
+      "onSslExpiryDescription": "Send an alert when the SSL certificate is about to expire",
+      "sslExpiryDisabledTooltip": "Enable SSL monitoring in Advanced Settings first",
+      "failureThreshold": "Failure threshold",
+      "failureThresholdDescription": "Number of consecutive failures before sending an alert",
+      "failureCount": "{count, plural, one {{count} failure} other {{count} failures}}",
+      "sslExpiryDays": "Days before expiry",
+      "sslExpiryDaysDescription": "Send an alert this many days before the SSL certificate expires",
+      "daysCount": "{count, plural, one {{count} day} other {{count} days}}",
+      "unit": "{count, plural, one {day} other {days}}"
+    }
+  },
+  "charts": {
+    "tooltip": {
+      "vs": "対",
+      "currentPeriod": "今回の期間",
+      "previousPeriod": "前回の期間",
+      "partial": "途中経過",
+      "total": "合計"
+    }
+  },
+  "misc": {
+    "loading": "読み込み中...",
+    "created": "作成日",
+    "unknown": "不明",
+    "noChange": "変化なし",
+    "good": "良好",
+    "fair": "普通",
+    "poor": "不良",
+    "rename": "名前を変更",
+    "renaming": "名前を変更中",
+    "delete": "削除",
+    "deleting": "削除中",
+    "cancel": "キャンセル",
+    "confirm": "確定",
+    "openMenu": "メニューを開く",
+    "save": "保存",
+    "saving": "保存中..."
+  },
+  "components": {
+    "pagination": {
+      "pageOf": "{totalPages}ページ中{currentPage}ページ目",
+      "showing": "{totalItems}件中{startItem}〜{endItem}件を表示中",
+      "perPage": "件ずつ"
+    },
+    "annotations": {
+      "dialogs": {
+        "addTitle": "Add Annotation",
+        "editTitle": "Edit Annotation",
+        "nameLabel": "Name",
+        "createNamePlaceholder": "Annotation name (e.g., \"Product Launch\")",
+        "editNamePlaceholder": "Annotation name",
+        "descriptionLabel": "Description (optional)",
+        "descriptionPlaceholder": "Add a description...",
+        "dateTimeLabel": "Date & time",
+        "colorLabel": "Color",
+        "selectColorAria": "Select color {token}",
+        "cancel": "Cancel",
+        "add": "Add",
+        "save": "Save",
+        "delete": "Delete",
+        "deleteAnnotationAria": "Delete annotation",
+        "deleteConfirmTitle": "Confirm Deletion",
+        "deleteConfirmDescription": "Are you sure you want to delete the annotation?"
+      },
+      "chart": {
+        "exitAnnotationMode": "Exit annotation mode",
+        "enterAnnotationMode": "Add annotation",
+        "annotationModeHint": "Click on the chart to add an annotation"
+      },
+      "groupMarker": {
+        "clickToSeeAll": "Click to see all"
+      },
+      "popover": {
+        "annotationsCount": "{count, plural, one {# annotation} other {# annotations}}",
+        "edit": "Edit",
+        "delete": "Delete",
+        "editAria": "Edit annotation",
+        "deleteAria": "Delete annotation"
+      }
+    },
+    "dashboards": {
+      "createDialog": {
+        "title": "新しいダッシュボードを作成",
+        "description": "ウェブサイトのドメインを入力して、アナリティクスの計測を始めましょう。",
+        "label": {
+          "domain": "ウェブサイトのドメイン"
+        },
+        "placeholder": {
+          "domain": "example.com"
+        },
+        "helper": {
+          "domain": "https://やwww.を付けずにドメインを入力してください。"
+        },
+        "buttons": {
+          "cancel": "キャンセル",
+          "create": "ダッシュボードを作成",
+          "creating": "作成中..."
+        },
+        "toast": {
+          "createdInitializing": "ダッシュボードを作成しました。連携を設定中...",
+          "createFailed": "ダッシュボードの作成に失敗しました。"
+        },
+        "errors": {
+          "invalidDomain": "無効なドメインです"
+        },
+        "limitTooltip": "ダッシュボードの上限に達しました。さらに作成するにはプランをアップグレードしてください。"
+      }
+    },
+    "slider": {
+      "recommended": "推奨"
+    },
+    "proFeature": {
+      "badge": "PRO",
+      "upgradeRequired": "この機能を使うにはProにアップグレードしてください"
+    },
+    "billing": {
+      "navigation": {
+        "backToDashboards": "Back to Dashboards",
+        "title": "Choose Your Plan"
+      },
+      "page": {
+        "heading": "Upgrade your plan",
+        "subheading": "Choose the perfect plan for your analytics needs."
+      },
+      "faq": {
+        "title": "Frequently Asked Questions",
+        "subtitle": "Everything you need to know about our pricing and plans",
+        "items": {
+          "changePlan": {
+            "q": "Can I change my plan anytime?",
+            "a": "Yes! You can upgrade or downgrade your plan at any time. Changes take effect immediately, and we will prorate the billing accordingly."
+          },
+          "exceedLimit": {
+            "q": "What happens if I exceed my event limit?",
+            "a": "We will continue tracking your events and you will receive an email notification when you exceed your limit. If you exceed your limits for more than 30 days, there is a chance that your excessive tracked data will be deleted."
+          },
+          "annualBilling": {
+            "q": "Do you offer annual billing?",
+            "a": "Currently we offer monthly billing only. Annual billing with discounts is coming soon!"
+          },
+          "freeOption": {
+            "q": "Is there a free option?",
+            "a": "Yes! Our Growth plan includes 10,000 free events per month forever. No credit card required to get started."
+          },
+          "cancelAnytime": {
+            "q": "Can I cancel anytime?",
+            "a": "Absolutely. You can cancel your subscription at any time. Your plan will remain active until the end of your current billing period."
+          },
+          "paymentMethods": {
+            "q": "What payment methods do you accept?",
+            "a": "We accept all major credit cards (Visa, MasterCard, American Express) and support secure payments through our payment processor."
+          }
+        }
+      },
+      "interactive": {
+        "contactForCustomPlan": "Please contact us for a custom plan",
+        "subscriptionChangesNote": "Changes to your subscription will be processed immediately, with prorated billing for any difference.",
+        "freePlanNote": "Start with our free plan — no credit card required."
+      },
+      "embeddedCheckout": {
+        "title": "Complete your subscription",
+        "description": "Securely complete your purchase with Stripe.",
+        "loadError": "We couldn't load the checkout. Please try again.",
+        "creatingSession": "Creating a secure checkout session…",
+        "successTitle": "Payment successful",
+        "successDescription": "You're now on {tier}. Welcome to Betterlytics!"
+      },
+      "planPicker": {
+        "title": "Choose your plan",
+        "description": "Choose the plan that fits your needs.",
+        "showComparison": "Compare all features",
+        "hideComparison": "Hide feature comparison"
+      },
+      "changePlan": {
+        "title": "Confirm plan change",
+        "description": "Review the prorated charges before confirming.",
+        "resumeNote": "Your subscription is scheduled to cancel — confirming this change keeps it active and resumes billing.",
+        "summaryCharge": "You'll switch to {tier} ({events} events / month) right away. {amount} will be charged now for the remaining period, and {nextAmount}/month thereafter starting {date}.",
+        "summaryCredit": "You'll switch to {tier} ({events} events / month). {amount} credit for unused time will be applied to your next invoice of {nextAmount}/month on {date}.",
+        "loading": "Calculating proration…",
+        "error": "Could not calculate proration. Please try again.",
+        "newPlanCharge": "New plan charge (prorated)",
+        "unusedTimeCredit": "Credit for unused time",
+        "accountCreditApplied": "Account credit applied",
+        "totalDueToday": "Due today",
+        "totalCreditedToday": "Credited today",
+        "confirm": "Confirm change",
+        "back": "Back",
+        "successLabel": "Plan changed",
+        "successDescription": "You're now on {tier}.",
+        "failureLabel": "Plan change failed",
+        "authRequiredLabel": "Verification needed",
+        "authenticatingLabel": "Verifying your payment",
+        "authenticatingDescription": "Complete the verification from your bank to finish your upgrade.",
+        "finalizingLabel": "Completing your upgrade…",
+        "close": "Close",
+        "tryAgain": "Try again",
+        "updatePaymentMethod": "Update payment method",
+        "errors": {
+          "cardDeclined": "We could not charge your payment method. Please update your card and try again.",
+          "authenticationRetry": "We couldn't verify your payment. Please try again to complete your upgrade.",
+          "unexpected": "Something went wrong. Please try again."
+        }
+      },
+      "creditBalance": {
+        "label": "Account credit",
+        "hint": "Applied automatically to future invoices"
+      },
+      "currentPlan": {
+        "title": "Current Plan",
+        "canceledBannerTitle": "Subscription Canceled",
+        "canceledBannerBody": "Your subscription will remain active until {date}. You can reactivate anytime before then.",
+        "description": "Your current subscription details",
+        "plan": "Plan",
+        "monthlyPrice": "Monthly Price",
+        "free": "Free",
+        "eventUsage": "Event Usage",
+        "usageProgress": "{current} of {limit} events",
+        "resetsInDays": "Resets in {days} days",
+        "expiresInDays": "Expires in {days} days",
+        "manage": "Manage Subscription",
+        "reactivate": "Reactivate Subscription",
+        "cancel": "Cancel Subscription",
+        "pastDueBannerTitle": "Payment Past Due",
+        "pastDueBannerBody": "We couldn't process your last payment. Update your payment method to keep your subscription active.",
+        "updatePayment": "Update Payment Method"
+      },
+      "planStatus": {
+        "active": "Active",
+        "canceling": "Canceling",
+        "pastDue": "Past due",
+        "inactive": "Inactive"
+      },
+      "planNames": {
+        "growth": "Growth Plan",
+        "professional": "Pro Plan",
+        "enterprise": "Enterprise"
+      }
+    },
+    "timeRange": {
+      "disabled": "無効",
+      "disableCompare": "比較を無効にする",
+      "previousPeriod": "前の期間",
+      "previousYear": "前年",
+      "nextPeriod": "次の期間",
+      "customPeriod": "カスタム期間",
+      "sameLengthAsMain": "メイン期間と同じ長さ",
+      "compareToPeriod": "比較する期間",
+      "dateRange": "期間",
+      "granularityNotAvailable": "選択した期間では、この粒度は利用できません",
+      "presets": {
+        "today": "今日",
+        "yesterday": "昨日",
+        "realtime": "リアルタイム",
+        "1h": "過去1時間",
+        "24h": "過去24時間",
+        "7d": "過去7日間",
+        "28d": "過去28日間",
+        "90d": "過去90日間",
+        "mtd": "今月（月初から）",
+        "last_month": "先月",
+        "ytd": "今年（年初から）",
+        "1y": "過去1年"
+      },
+      "granularityLabels": {
+        "month": "月",
+        "week": "週",
+        "day": "日",
+        "hour": "時間",
+        "minute_30": "30分",
+        "minute_15": "15分",
+        "minute_1": "1分"
+      },
+      "matchDayOfWeek": "曜日を揃える"
+    },
+    "loading": {
+      "dashboard": {
+        "initializing": "ダッシュボードを初期化中",
+        "loadingSettings": "ダッシュボードの設定を読み込み中..."
+      },
+      "geography": {
+        "title": "世界地図を初期化中",
+        "description": "訪問者データの地理的な可視化を準備中..."
+      }
+    },
+    "devices": {
+      "tables": {
+        "columns": {
+          "os": "OS",
+          "browser": "ブラウザ",
+          "visitors": "訪問者",
+          "percentage": "割合"
+        },
+        "topOperatingSystems": "上位のOS",
+        "topBrowsers": "上位のブラウザ"
+      },
+      "charts": {
+        "deviceTypes": "デバイスタイプ",
+        "deviceUsageTrend": "デバイス利用の推移"
+      }
+    },
+    "campaign": {
+      "title": "Campaigns",
+      "pagination": {
+        "pageOf": "Page {currentPage} of {totalPages}",
+        "showing": "Showing {startItem}-{endItem} of {totalItems} campaigns",
+        "perPage": "per page"
+      },
+      "emptyState": {
+        "title": "No campaigns captured yet",
+        "description": "Campaigns will appear here once URLs with utm_campaign tags are captured. Start tagging your links to view performance metrics.",
+        "docsHint": "Need help getting campaigns to show up?",
+        "docsLinkLabel": "Read the campaign tracking guide"
+      },
+      "loading": "Loading campaigns...",
+      "campaignRow": {
+        "visitors": "{count, plural, one {# visitor} other {# visitors}}",
+        "bounceRate": "Bounce Rate",
+        "avgSessionDuration": "Avg. Duration",
+        "pagesPerSession": "Pages / Session",
+        "campaignDetails": "Campaign Details"
+      },
+      "campaignExpandedRow": {
+        "onlyAvailableOnLargerScreens": "Detailed UTM table is only available on larger screens.",
+        "loading": "Loading campaign details...",
+        "error": "Failed to load campaign details. Please try again.",
+        "campaignDetails": "Campaign Details"
+      },
+      "audienceProfile": {
+        "title": "Audience Profile",
+        "noData": "No audience data for this campaign in the selected range.",
+        "deviceTitle": "devices",
+        "browserTitle": "browsers",
+        "osTitle": "OS",
+        "countryTitle": "countries"
+      },
+      "utm": {
+        "table": {
+          "title": "UTM Parameter Breakdown"
+        },
+        "chart": {
+          "title": "UTM Distribution"
+        },
+        "tabs": {
+          "entryPages": "Entry Pages",
+          "source": "Source",
+          "medium": "Medium",
+          "content": "Content",
+          "term": "Term"
+        },
+        "columns": {
+          "visitors": "Visitors",
+          "bounceRate": "Bounce Rate",
+          "avgSessionDuration": "Avg. Session Duration",
+          "pagesPerSession": "Pages / Session"
+        }
+      }
+    },
+    "events": {
+      "log": {
+        "waiting": "イベントを待機中...",
+        "realTimeDesc": "イベントが発生すると、ここにリアルタイムで表示されます",
+        "loadingMore": "さらにイベントを読み込み中...",
+        "noEvents": "イベントが見つかりません",
+        "showingAll": "{count}件すべてのイベントを表示中",
+        "showingPartial": "{total}件中{loaded}件のイベントを表示中",
+        "title": "イベントログ",
+        "description": "リアルタイムのアクティビティ計測",
+        "loading": "イベントを読み込み中..."
+      },
+      "table": {
+        "eventName": "イベント名",
+        "count": "回数",
+        "uniqueUsers": "ユニークユーザー",
+        "avgPerUser": "ユーザーあたりの平均",
+        "lastSeen": "最終発生",
+        "percentage": "割合",
+        "noEvents": "イベントが見つかりません",
+        "noEventsDesc": "この期間中にカスタムイベントは計測されませんでした。記録が始まると、ここに表示されます。",
+        "eventDetails": "イベントの詳細",
+        "uniqueEvent": "ユニークイベント",
+        "uniqueEvents": "ユニークイベント"
+      },
+      "expandedEventContent": {
+        "loading": "プロパティを読み込み中...",
+        "noProperties": "プロパティなし",
+        "noPropertiesDesc": "このイベントにはカスタムプロパティがありません。"
+      }
+    },
+    "tabbedTable": {
+      "searchPlaceholder": "{field}で絞り込む..."
+    },
+    "filters": {
+      "type": "種類",
+      "operator": "演算子",
+      "is": "が次に一致",
+      "isNot": "が次に一致しない",
+      "globalProperties": "{count, plural, one {グローバルプロパティ} other {グローバルプロパティ}}",
+      "selectProperty": "プロパティを選択",
+      "noProperties": "プロパティが見つかりません",
+      "namePlaceholder": "ステップ名を入力",
+      "columns": {
+        "url": "URL",
+        "domain": "ホスト名",
+        "device_type": "デバイスタイプ",
+        "country_code": "国",
+        "subdivision_code": "地域",
+        "city": "都市",
+        "browser": "ブラウザ",
+        "os": "OS",
+        "referrer_source": "参照元ソース",
+        "referrer_source_name": "参照元名",
+        "referrer_search_term": "参照元の検索語",
+        "referrer_url": "参照元URL",
+        "utm_source": "UTMソース",
+        "utm_medium": "UTMメディア",
+        "utm_campaign": "UTMキャンペーン",
+        "utm_term": "UTMキーワード",
+        "utm_content": "UTMコンテンツ",
+        "custom_event_name": "イベント",
+        "event_type": "イベントタイプ",
+        "outbound_link_url": "外部リンク"
+      },
+      "selector": {
+        "triggerLabel": "フィルター",
+        "title": "フィルター",
+        "emptyNoneSelected": "フィルターが選択されていません。適用して保存してください",
+        "addFilter": "フィルターを追加",
+        "cancel": "キャンセル",
+        "apply": "適用",
+        "selectValue": "値を選択",
+        "noValuesForCurrentPeriod": "現在の期間に該当する値がありません",
+        "savedFilters": "保存済みフィルター",
+        "noSavedFilters": "保存済みフィルターはまだありません",
+        "saveFilters": "保存",
+        "saveFiltersTitle": "フィルターセットを保存",
+        "filterNamePlaceholder": "フィルター名を入力",
+        "toastFilterSavedSuccess": "フィルターを保存しました",
+        "toastFilterSavedError": "フィルターの保存に失敗しました",
+        "toastFilterDeletedSuccess": "フィルターを削除しました",
+        "toastFilterDeletedError": "フィルターの削除に失敗しました",
+        "toastUndo": "元に戻す",
+        "savedFiltersLimitReached": "保存できるフィルターの上限に達しました",
+        "maxFiltersReached": "最大{max}件のフィルター",
+        "maxFiltersReachedToast": "適用できるフィルターは最大{max}件です。追加するには1件削除してください。"
+      },
+      "filterBy": "{label}で絞り込む",
+      "removeFilter": "フィルターを削除"
+    },
+    "funnels": {
+      "skeleton": {
+        "steps": {
+          "homepage": "Homepage",
+          "pricing": "Pricing",
+          "signup": "Sign up",
+          "purchase": "Purchase"
+        },
+        "step": "Step",
+        "visitors": "Visitors"
+      },
+      "create": {
+        "defaultName": "My new funnel",
+        "createFunnel": "Create Funnel",
+        "createFunnelLower": "Create funnel",
+        "name": "Funnel Name",
+        "namePlaceholder": "My Funnel Name",
+        "strictMode": "Strict Mode",
+        "addStep": "Add Step",
+        "livePreview": "Live Preview",
+        "cancel": "Cancel",
+        "create": "Create",
+        "createDisabledHint": "Enter a funnel name and define at least two steps. <br></br> Each step needs both a name and a selected value.",
+        "successMessage": "Funnel created!",
+        "errorMessage": "Funnel creation failed!",
+        "filterCount": "{count, plural, =0 {No filters} =1 {1 filter} other {# filters}}",
+        "tooltip": {
+          "deleteStep": "Delete step {index}",
+          "minStepsHint": "A funnel needs at least {count} steps",
+          "reorderStep": "Reorder step {index}",
+          "toggleStep": "Toggle step {index}"
+        }
+      },
+      "edit": {
+        "title": "Edit funnel",
+        "name": "Funnel Name",
+        "strictMode": "Strict Mode",
+        "addStep": "Add Step",
+        "cancel": "Cancel",
+        "save": "Save",
+        "livePreview": "Live Preview",
+        "disabledHint": "Enter a funnel name and define at least two steps. <br></br> Each step needs both a name and a selected value.",
+        "successMessage": "Funnel updated!",
+        "errorMessage": "Funnel update failed!"
+      },
+      "clone": {
+        "title": "Clone funnel",
+        "name": "Funnel Name",
+        "namePlaceholder": "My funnel (copy)",
+        "strictMode": "Strict Mode",
+        "addStep": "Add Step",
+        "livePreview": "Live Preview",
+        "defineAtLeastTwoSteps": "Define at least 2 steps to see the preview.",
+        "cancel": "Cancel",
+        "cta": "Create clone",
+        "successMessage": "Funnel cloned!",
+        "errorMessage": "Funnel clone failed!"
+      },
+      "plot": {
+        "stepLabel": "Step {index}",
+        "visitors": "Visitors",
+        "dropOff": "Drop-off",
+        "conversion": "Conversion",
+        "and": "and"
+      },
+      "delete": {
+        "title": "Delete funnel",
+        "description": "Are you sure you want to delete this funnel? This action cannot be undone.",
+        "cancel": "Cancel",
+        "delete": "Delete funnel",
+        "successMessage": "Funnel deleted!",
+        "errorMessage": "Funnel deletion failed!"
+      },
+      "strictModeInfo": "When enabled, visitors must complete the steps in order without visiting any other pages in between.",
+      "preview": {
+        "defineAtLeastTwoSteps": "Define at least 2 steps to see the preview."
+      },
+      "emptyState": {
+        "title": "Visualize your conversion funnel",
+        "description": "See where users drop off and optimize your conversion paths step by step.",
+        "createButton": "Create funnel"
+      }
+    },
+    "pages": {
+      "summary": {
+        "pagesPerSession": "セッションあたりのページ数",
+        "totalPageviews": "総ページビュー",
+        "avgTimeOnPage": "平均ページ滞在時間",
+        "avgBounceRate": "平均直帰率"
+      },
+      "table": {
+        "path": "パス",
+        "filterByPath": "{path}で絞り込む",
+        "visitors": "訪問者",
+        "pageviews": "ページビュー",
+        "sessionPageviews": "セッションページビュー",
+        "bounceRate": "直帰率",
+        "avgTime": "平均滞在時間",
+        "avgSessionTime": "平均セッション時間",
+        "entryRate": "入口率",
+        "exitRate": "離脱率",
+        "avgScrollDepth": "スクロール深度",
+        "allPages": "すべてのページ",
+        "entryPages": "入口ページ",
+        "exitPages": "離脱ページ",
+        "title": "ページ分析"
+      }
+    },
+    "referrers": {
+      "summary": {
+        "referralSessions": "参照元からのセッション",
+        "referralTrafficPct": "参照トラフィック率",
+        "topReferrerSource": "上位の参照元ソース",
+        "avgSessionDuration": "平均セッション時間",
+        "none": "なし"
+      },
+      "charts": {
+        "distribution": "参照元の内訳",
+        "trafficTrends": "参照トラフィックの推移"
+      },
+      "table": {
+        "details": "参照元の詳細",
+        "tabs": {
+          "all": "すべて",
+          "search": "検索",
+          "social": "ソーシャル",
+          "direct": "直接",
+          "email": "メール",
+          "other": "その他"
+        },
+        "columns": {
+          "source": "ソース",
+          "type": "種類",
+          "visits": "訪問数",
+          "percentage": "割合",
+          "bounceRate": "直帰率",
+          "avgVisitDuration": "平均滞在時間",
+          "direct": "直接",
+          "unknown": "不明"
+        }
+      }
+    },
+    "geography": {
+      "noData": "選択した期間の地域データがありません",
+      "loading": "地図を読み込み中...",
+      "visitors": "訪問者",
+      "regionLoadError": "地域データの読み込みに失敗しました"
+    },
+    "userJourney": {
+      "steps": "ステップ",
+      "topJourneys": "上位{journeys}件の導線",
+      "sessions": "セッション"
+    },
+    "outboundLinks": {
+      "table": {
+        "title": "外部リンクのパフォーマンス",
+        "destinationUrl": "リンク先URL",
+        "uniqueClicks": "ユニーククリック数",
+        "topReferrerPage": "上位の参照元ページ",
+        "sourcePages": "参照元ページ"
+      },
+      "chart": {
+        "title": "ユニーク外部クリック数の推移",
+        "tooltipTitle": "ユニーク外部クリック数"
+      },
+      "pieChart": {
+        "title": "外部リンクの内訳"
+      }
+    },
+    "webVitals": {
+      "metrics": {
+        "CLS": "Cumulative Layout Shift",
+        "LCP": "Largest Contentful Paint",
+        "INP": "Interaction to Next Paint",
+        "FCP": "First Contentful Paint",
+        "TTFB": "Time to First Byte"
+      },
+      "thresholds": {
+        "good": "Good",
+        "fair": "Fair",
+        "poor": "Poor"
+      },
+      "table": {
+        "title": "Performance breakdown",
+        "performance": "Performance",
+        "performanceAria": "About performance score",
+        "performanceDescr": "Performance score (0–100) based on the following metric weights: LCP 30%, CLS 15%, FCP 15%, TTFB 10%, INP 30%.",
+        "performanceGreat": "Great: ≥ {min}",
+        "performanceOkay": "Okay: ≥ {min}",
+        "performancePoor": "Poor: < {min}",
+        "opportunity": "Opportunity",
+        "opportunityAria": "About opportunity",
+        "opportunityDescr": "Traffic-weighted potential improvement: traffic share × (100 − Performance).",
+        "opportunityNote": "Changes with the selected percentile (P50/P75/P90/P99)",
+        "pageloads": "Pageloads",
+        "badges": {
+          "great": "Great",
+          "okay": "Okay",
+          "poor": "Poor"
+        },
+        "tabs": {
+          "page": "Page",
+          "deviceType": "Device Type",
+          "country": "Country",
+          "browser": "Browser",
+          "operatingSystem": "Operating System",
+          "pages": "Pages",
+          "devices": "Devices",
+          "countries": "Countries",
+          "browsers": "Browsers",
+          "operatingSystems": "Operating Systems"
+        }
+      },
+      "info": {
+        "aboutMetricAria": "About metric",
+        "good": "Good",
+        "fair": "Fair",
+        "descriptions": {
+          "CLS": "Measures visual stability. CLS captures how much content unexpectedly shifts while the page loads.",
+          "LCP": "Measures loading performance. LCP is the moment the largest text or image becomes visible.",
+          "INP": "Measures responsiveness. INP is the time from a user action until the next visual update.",
+          "FCP": "Shows when the first piece of content appears on the screen during page load.",
+          "TTFB": "Measures server response speed — the time from request until the first byte is received."
+        }
+      }
+    },
+    "sessionReplay": {
+      "sessionList": {
+        "header": "Sessions",
+        "subHeader": "{count} sessions",
+        "durationFilter": "Min duration (s)",
+        "durationFilterAria": "Filter sessions by minimum duration in seconds",
+        "loading": "Loading sessions…",
+        "unknownUrl": "Unknown URL",
+        "endOfList": "You've reached the end",
+        "loadingMore": "Loading more…",
+        "scrollToLoadMore": "Scroll to load more",
+        "empty": {
+          "title": "No session replays available",
+          "description": "Try expanding your time range or adjusting filters."
+        },
+        "sessionErrorsTooltip": "This session captured {count}+ client-side errors"
+      },
+      "playerTopbar": {
+        "startLabel": "Start:",
+        "startUrlTitle": "Start URL (first page of this session)"
+      },
+      "eventTimeline": {
+        "header": "Timeline",
+        "subHeader": "{count} events captured ({groupCount} groups)",
+        "prefetching": "Prefetching remaining segments…",
+        "emptyReplay": {
+          "title": "No key events detected in this replay yet.",
+          "noSessionSelected": "Select a replay to view its timeline."
+        }
+      },
+      "events": {
+        "fullSnapshot": "Full snapshot",
+        "mouseInteraction": "Mouse interaction",
+        "selection": "Selection",
+        "scroll": "Scroll",
+        "input": "Input",
+        "pageview": "Pageview",
+        "blacklist": "Blacklisted",
+        "viewportResize": "Viewport Resize",
+        "mediaInteraction": "Media Interaction",
+        "clientError": "Client Error"
+      },
+      "player": {
+        "skipInactive": "Skip inactivity",
+        "playbackSpeedAria": "Playback speed",
+        "recordingDisabled": "Recording is disabled on this page"
+      }
+    },
+    "integration": {
+      "integrationSetup": "Integration Setup",
+      "title": "Website Integration",
+      "description": "Select your framework and follow the setup steps to start collecting analytics",
+      "fullyIntegrated": "Fully Integrated",
+      "notFullyIntegrated": "Not Fully Integrated",
+      "loadingDetails": "Loading integration details...",
+      "unableToLoadSiteId": "Unable to load site ID",
+      "failedToCopy": "Failed to copy",
+      "npmPackageNote": "Or install our <npm>npm</npm> package <package>@betterlytics/tracker</package> for easy setup for Node projects.",
+      "yourSiteId": "Your Site ID",
+      "trackingScript": "Tracking Script",
+      "copied": "Copied",
+      "copy": "Copy",
+      "htmlInstallation": "HTML Installation",
+      "nextjsInstallation": "Next.js Installation",
+      "reactInstallation": "React Installation",
+      "initializeNpmPackage": "Initialize using our <npm>npm</npm> package",
+      "integrationStatus": "Integration Status",
+      "trackProgress": "Track your progress",
+      "accountCreated": "Account Created",
+      "accountReady": "Your account is ready",
+      "siteIdGenerated": "Site ID Generated",
+      "uniqueIdentifier": "Your unique identifier",
+      "dataReceiving": "Data Receiving",
+      "analyticsDataFlowing": "Analytics data flowing",
+      "needHelp": "Need Help?",
+      "resourcesToGetStarted": "Resources to get started",
+      "documentation": "Documentation",
+      "troubleshooting": "Troubleshooting",
+      "contactSupport": "Contact Support",
+      "verifying": "Verifying...",
+      "verifyInstallation": "Verify Installation",
+      "selectFramework": "Select your framework"
+    },
+    "settingsButton": {
+      "dashboardSettings": "ダッシュボード設定"
+    },
+    "accountVerification": {
+      "requiredModal": {
+        "title": "Email Verification Required",
+        "subtitle": "Please verify your email to upgrade your plan",
+        "whyTitle": "Why verify your email?",
+        "whyItems": {
+          "secureBilling": "Secure billing and payment confirmations",
+          "notifications": "Important account notifications and alerts",
+          "security": "Enhanced account security and recovery"
+        },
+        "verifyLine": "Hi {name}, we need to verify your email address <strong>{email}</strong> before you can upgrade to a paid plan.",
+        "sentTitle": "Verification email sent!",
+        "sentInfo": "Please check your inbox and spam folder. The verification link will expire in 24 hours.",
+        "cancel": "Cancel",
+        "continue": "Continue to Dashboard",
+        "resend": "Resend verification email",
+        "sending": "Sending...",
+        "toastSuccess": "Verification email sent! Please check your inbox.",
+        "toastFailure": "Failed to send verification email"
+      }
+    },
+    "topbar": {
+      "userMenu": {
+        "userFallback": "ユーザー",
+        "dashboards": "ダッシュボード",
+        "upgradePlan": "プランをアップグレード",
+        "reportBug": "バグを報告",
+        "settings": "設定",
+        "documentation": "ドキュメント",
+        "documentationTitle": "Betterlyticsの完全なドキュメント",
+        "logout": "ログアウト"
+      }
+    },
+    "sidebar": {
+      "dashboardDropdown": {
+        "switch": "ダッシュボードを切り替え",
+        "viewAll": "すべてのダッシュボードを表示"
+      }
+    },
+    "userSettings": {
+      "tabs": {
+        "account": "Account",
+        "preferences": "Preferences",
+        "billing": "Billing"
+      },
+      "dialog": {
+        "title": "User Settings",
+        "description": "Manage your account settings and preferences.",
+        "upgradePlan": "Upgrade plan",
+        "toast": {
+          "error": "Failed to save settings. Please try again."
+        },
+        "help": {
+          "trigger": "Need help?",
+          "documentation": "Documentation",
+          "reportBug": "Report a bug",
+          "contactSupport": "Contact support"
+        }
+      },
+      "profile": {
+        "title": "Profile",
+        "nameLabel": "Name",
+        "namePlaceholder": "Enter your name",
+        "emailLabel": "Email",
+        "verified": "Verified",
+        "unverified": "Unverified",
+        "signedInWith": "Signed in with {provider}",
+        "memberSince": "Member since {date}",
+        "updateButton": "Update",
+        "toast": {
+          "nameSuccess": "Name updated"
+        }
+      },
+      "preferences": {
+        "appearance": {
+          "title": "Appearance",
+          "themeLabel": "Theme",
+          "themeDescription": "Choose a personal theme for the dashboard",
+          "light": "Light",
+          "dark": "Dark",
+          "system": "System"
+        },
+        "avatar": {
+          "label": "Avatar",
+          "description": "How your profile picture is shown",
+          "none": "None",
+          "gravatar": "Gravatar",
+          "noteIntro": "Note: Gravatar is a third-party service - enabling it may share your email hash with their servers.",
+          "terms": "you agree to their terms"
+        },
+        "localization": {
+          "title": "Localization",
+          "language": "Language",
+          "languageDescription": "Choose your dashboard language"
+        },
+        "notifications": {
+          "title": "Notifications",
+          "marketingEmails": "Marketing emails",
+          "marketingEmailsDescription": "Product updates, announcements, and tips"
+        }
+      },
+      "billing": {
+        "loadError": "Unable to load billing data.",
+        "currentPlan": {
+          "title": "Current Plan",
+          "free": "Free",
+          "pricePerMonth": "{price} / month",
+          "renewsOn": "Renews on {date}",
+          "endsOn": "Subscription ends on {date}",
+          "upgrade": "Upgrade",
+          "changePlan": "Change plan",
+          "pastDue": "Payment past due"
+        },
+        "usage": {
+          "title": "Usage",
+          "eventsLabel": "Events",
+          "eventsUsed": "{current} / {limit} ({percentage})",
+          "resetsInDays": "Resets in {days} days"
+        },
+        "payment": {
+          "title": "Payment & Invoices",
+          "label": "Manage in billing portal",
+          "description": "Payment method, invoices, and billing details.",
+          "openPortal": "Open Billing Portal"
+        },
+        "invoices": {
+          "title": "Invoices",
+          "view": "View",
+          "columns": {
+            "date": "Date",
+            "total": "Total",
+            "status": "Status",
+            "actions": "Actions"
+          },
+          "status": {
+            "draft": "Draft",
+            "open": "Open",
+            "paid": "Paid",
+            "uncollectible": "Uncollectible",
+            "void": "Void",
+            "credit": "Credit"
+          }
+        },
+        "cancellation": {
+          "title": "Cancellation",
+          "label": "Cancel subscription",
+          "description": "Stop billing at the end of the current period.",
+          "cancel": "Cancel"
+        },
+        "portal": {
+          "openError": "Failed to open billing portal, please try again."
+        }
+      },
+      "security": {
+        "title": "Account security",
+        "passwordRowLabel": "Password",
+        "description": "Change your account password",
+        "currentPassword": "Current Password",
+        "newPassword": "New Password",
+        "confirmNewPassword": "Confirm New Password",
+        "passwordHelp": "Password must be at least 8 characters long",
+        "passwordsMatch": "Passwords match",
+        "changePassword": "Change Password",
+        "passwordManagedByOAuth": "Password managed by OAuth",
+        "togglePasswordVisibility": "Toggle {field} visibility",
+        "cancel": "Cancel",
+        "toast": {
+          "success": "Password updated successfully"
+        },
+        "totp": {
+          "title": "Two-Factor Authentication",
+          "description": "Add an extra layer of security to your account.",
+          "enable": "Enable 2FA",
+          "instructions": "To enable 2FA, scan the QR code with your authenticator app or use the <setup>setup key</setup> to manually configure it, then enter the verification code below.",
+          "cancel": "Cancel",
+          "confirm": "Confirm",
+          "enabled": "Enabled",
+          "disable": "Disable",
+          "disableTitle": "Disable 2FA",
+          "disableDescription": "Enter the verification code from your authenticator app to disable two-factor authentication.",
+          "disabledSuccess": "Two-factor authentication disabled successfully",
+          "disableFailed": "Failed to disable two-factor authentication. Please try again.",
+          "setupFailed": "Failed to setup two-factor authentication. Please try again.",
+          "copyFailed": "Failed to copy",
+          "enabledSuccess": "Two-factor authentication enabled successfully",
+          "enableFailed": "Failed to enable two-factor authentication. Please try again.",
+          "managedByOAuth": "Two-factor authentication is managed by your sign-in provider"
+        }
+      },
+      "sessions": {
+        "title": "Sessions",
+        "activeCount": "Signed in on {count, plural, =0 {no devices} =1 {1 device} other {# devices}}",
+        "description": "Sign out from everywhere except this device.",
+        "signOutOthers": "Sign out other devices",
+        "dialog": {
+          "title": "Sign out other devices?",
+          "description": "All other sessions will be ended immediately. Your current device will stay signed in.",
+          "cancel": "Cancel",
+          "confirm": "Sign out other devices"
+        },
+        "toast": {
+          "success": "Signed out {count, plural, =0 {no other devices} =1 {1 other device} other {# other devices}}."
+        }
+      },
+      "danger": {
+        "sectionTitle": "Danger Zone",
+        "details": "Permanently delete your account and all associated data.",
+        "delete": "Delete Account",
+        "dialog": {
+          "title": "Delete Account Permanently",
+          "description": "Are you absolutely sure you want to delete your account? This action cannot be undone and will permanently:",
+          "li1": "Delete all your personal information",
+          "li2": "Remove access to all your dashboards",
+          "li3": "Delete all your account settings",
+          "li4": "Sign you out of all devices",
+          "cancel": "Cancel",
+          "confirm": "Delete Account Permanently"
+        },
+        "toast": {
+          "success": "Account deleted successfully",
+          "error": "Failed to delete account. Please try again.",
+          "unable": "Unable to delete account. Please try signing in again."
+        }
+      }
+    },
+    "dashboardSettingsDialog": {
+      "title": "Dashboard Settings",
+      "description": "Configure your dashboard preferences and data collection settings.",
+      "loading": "Loading settings...",
+      "saveChanges": "Save Changes",
+      "toastSuccess": "Settings saved successfully",
+      "toastError": "Failed to save settings",
+      "tabs": {
+        "data": "Data",
+        "danger": "Danger Zone"
+      },
+      "data": {
+        "title": "Data Management",
+        "description": "Configure data retention and collection preferences",
+        "retentionTitle": "Data Retention",
+        "retentionLabel": "Data Retention Period",
+        "retentionHelp": "How long to keep analytics data before automatic deletion",
+        "presets": {
+          "m6": "6 months",
+          "y1": "1 year",
+          "y2": "2 years",
+          "y3": "3 years",
+          "y5": "5 years"
+        },
+        "retentionConfirm": {
+          "title": "Change retention period?",
+          "description": "Changing retention to {period} means events older than {period} may be permanently deleted during the next scheduled cleanup."
+        },
+        "siteRules": {
+          "title": "Site Rules",
+          "description": "Control which incoming events are accepted.",
+          "enforceDomain": "Enforce domain",
+          "enforceDomainDescription": "Reject events whose domain does not match the dashboard domain.",
+          "enableValidation": "Enable domain validation",
+          "enableValidationDescription": "Only accept events from your configured domain",
+          "rename": {
+            "title": "Change Domain",
+            "description": "Change the domain associated with this dashboard. Your analytics data will be preserved.",
+            "info": "Your Site ID and tracking script remain unchanged.",
+            "success": "Domain updated successfully",
+            "error": "Failed to update domain"
+          }
+        },
+        "blacklistedIps": {
+          "title": "Blacklisted IPs",
+          "description": "Manage IP addresses for which incoming events are blocked.",
+          "addIp": "Add IP",
+          "addIpPlaceholder": "Enter IPv4/IPv6 or CIDR (e.g., 192.168.1.1, 10.0.0.0/8, 2001:db8::/32)",
+          "addIpError": "Enter a valid IPv4/IPv6 or CIDR range",
+          "noIps": "No IP addresses are currently blacklisted",
+          "remove": "Remove"
+        }
+      },
+      "danger": {
+        "title": "Dashboard",
+        "sectionTitle": "Delete Dashboard",
+        "sectionDescription": "Permanently remove this dashboard and all its data.",
+        "deleteButton": "Delete",
+        "toastSuccess": "Dashboard deleted successfully",
+        "toastError": "Failed to delete dashboard",
+        "dialog": {
+          "title": "Delete Dashboard",
+          "description": "Are you sure you want to delete this dashboard? This action cannot be undone.",
+          "cancel": "Cancel",
+          "confirm": "Delete Dashboard"
+        }
+      },
+      "leaveDashboard": {
+        "title": "Leave Dashboard",
+        "description": "Are you sure you want to leave this dashboard?",
+        "button": "Leave Dashboard",
+        "buttonPending": "Leaving...",
+        "dialog": {
+          "title": "Leave Dashboard",
+          "description": "Are you sure you want to leave this dashboard? You will no longer be able to access it, and will need to be reinvited to join it again.",
+          "cancel": "Cancel",
+          "confirm": "Leave Dashboard"
+        },
+        "toast": {
+          "success": "Left dashboard",
+          "error": "Failed to leave dashboard"
+        }
+      }
+    },
+    "termsRequiredDialog": {
+      "title": "Accept Updated Terms of Service",
+      "body": "To continue using your account, please review and accept our <termsLink>Terms of Service</termsLink>.",
+      "acceptAndContinue": "Accept and Continue",
+      "logout": "Log Out"
+    },
+    "demoMode": {
+      "notAvailable": "デモダッシュボードでは利用できません",
+      "interactionDisabled": "デモでは、この操作からの絞り込みは無効になっています。"
+    },
+    "permissions": {
+      "demoNotAvailable": "デモダッシュボードでは利用できません",
+      "insufficientPermissions": "この操作を実行する権限がありません"
+    },
+    "bugReport": {
+      "trigger": "Report bug",
+      "title": "Report a bug",
+      "description": "Tell us what went wrong or what feels off. The more detail, the better!",
+      "placeholder": "Describe what happened, what you expected, and anything else that might help us reproduce the issue.",
+      "submit": "Send report",
+      "submitting": "Sending...",
+      "toast": {
+        "success": "Thanks! We received your report.",
+        "error": "Couldn't send the report. Please try again.",
+        "empty": "Please add a short description before sending."
+      }
+    },
+    "changelog": {
+      "title": "新着情報",
+      "haveFeedback": "ご意見はありますか？お聞かせいただければ、次のリリースがさらに良くなります。",
+      "viewAll": "すべての更新を見る",
+      "gotIt": "了解",
+      "badgeNew": "新着",
+      "tooltipWhatsNew": "新着情報を見る",
+      "openButtonAria": "バージョン{version}の新着情報を見る"
+    }
+  },
+  "onboarding": {
+    "registrationDisabled": "このインスタンスでは現在、新規登録が無効になっています。",
+    "account": {
+      "features": {
+        "feature1": {
+          "title": "2分以内で始められる",
+          "description": "コードを1行追加するか、npmパッケージをインストールするだけ。Cookieもポップアップもありません。"
+        },
+        "feature2": {
+          "title": "無料で始められる",
+          "description": "月10,000イベントまで無料。クレジットカード不要、契約の縛りもありません。"
+        },
+        "feature3": {
+          "title": "プライバシー重視・オープンソース",
+          "description": "CookieレスでGDPR準拠、EUでホスティング。透明性が高く安全です。"
+        }
+      },
+      "form": {
+        "title": "アカウントを作成",
+        "signUpWith": "次で登録",
+        "termsAgreeLabel": "<termsLink>利用規約</termsLink>と<privacyLink>プライバシーポリシー</privacyLink>を読み、同意します。",
+        "orDivider": "または",
+        "emailLabel": "メールアドレス",
+        "emailPlaceholder": "メールアドレスを入力",
+        "passwordLabel": "パスワード",
+        "passwordPlaceholder": "パスワードを入力（8文字以上）",
+        "confirmPasswordLabel": "パスワードの確認",
+        "confirmPasswordPlaceholder": "パスワードを再入力",
+        "continueButton": "続行",
+        "creatingAccount": "アカウントを作成中...",
+        "signingUpGoogle": "登録中...",
+        "signingUpGitHub": "登録中...",
+        "googleButton": "Google",
+        "gitHubButton": "GitHub",
+        "passwordsDoNotMatch": "パスワードが一致しません",
+        "registrationSuccessfulButSignInFailed": "登録は成功しましたが、サインインに失敗しました。手動でサインインしてください。",
+        "signUpError": "登録中にエラーが発生しました。もう一度お試しください。",
+        "checkInput": "入力内容を確認してください"
+      }
+    },
+    "website": {
+      "title": "ダッシュボードを設定",
+      "description": "計測したいウェブサイトについて教えてください",
+      "domainLabel": "ドメイン",
+      "domainPlaceholder": "example.com",
+      "domainHelp": "https://やwww.を付けずにドメインを入力してください（例: example.com）",
+      "termsAgreeLabel": "<termsLink>利用規約</termsLink>と<privacyLink>プライバシーポリシー</privacyLink>を読み、同意します。",
+      "createDashboardButton": "ダッシュボードを作成",
+      "creatingDashboard": "ダッシュボードを作成中...",
+      "dashboardCreatedSuccess": "ダッシュボードを作成しました。"
+    },
+    "integration": {
+      "siteId": {
+        "title": "サイトID",
+        "description": "この一意の識別子が、ウェブサイトとダッシュボードを紐付けます",
+        "installationVerified": "✓ 設置を確認しました",
+        "waitingForInstallation": "設置を待機中"
+      },
+      "instructions": {
+        "title": "設置手順",
+        "selectFramework": "フレームワークを選択すると設置手順が表示されます",
+        "description": "ウェブサイトの構成に合った方法を選んでください",
+        "htmlTab": "HTML",
+        "nextjsTab": "Next.js",
+        "reactTab": "React",
+        "npmTab": "npm",
+        "htmlDescription": "HTMLの{head}セクションに追加します",
+        "nextjsDescription": "ルートレイアウトに追加します",
+        "reactDescription": "メインのAppコンポーネントに追加します",
+        "npmDescription": "npmパッケージをインストールします",
+        "npmInstallFirst": "まず、パッケージをインストールします:",
+        "npmThenInitialize": "次に、コード内で初期化します:"
+      },
+      "buttons": {
+        "skipForNow": "後で設定",
+        "continueToDashboard": "ダッシュボードに進む"
+      },
+      "frameworkGrid": {
+        "showLess": "閉じる",
+        "showMore": "他{count}件のフレームワーク"
+      },
+      "redirectingIn": "{seconds}秒後にリダイレクトします...",
+      "noSiteId": "サイトIDが見つかりません。先に前の手順を完了してください。"
+    }
+  },
+  "validation": {
+    "termsOfServiceRequired": "続行するには利用規約に同意する必要があります。",
+    "urlMustBeOnDomain": "URLは{domain}またはそのサブドメインである必要があります",
+    "monitorAlreadyExists": "このURLの監視はすでに存在します",
+    "capabilities": {
+      "dashboardLimit": "ダッシュボードの上限に達しました。さらに作成するにはProにアップグレードしてください。",
+      "monitorLimit": "監視の上限に達しました。さらに作成するにはProにアップグレードしてください。",
+      "minInterval": "より短い監視間隔にはProfessionalプランが必要です",
+      "httpMethod": "カスタムHTTPメソッドにはProfessionalプランが必要です",
+      "statusCodes": "カスタムステータスコードにはProfessionalプランが必要です",
+      "customHeaders": "カスタムリクエストヘッダーにはProfessionalプランが必要です",
+      "keywordValidation": "キーワード検証にはProfessionalプランが必要です"
+    },
+    "invitations": {
+      "userAlreadyHasAccess": "このユーザーはすでにこのダッシュボードへのアクセス権を持っています",
+      "memberLimitReached": "現在のプランでは、このダッシュボードに招待できるメンバーは最大{limit}人です。さらに招待するにはアップグレードしてください。",
+      "invitationAlreadySent": "このメールアドレスにはすでに招待を送信済みです",
+      "invitationNotFoundOrProcessed": "招待が見つからないか、すでに処理されています",
+      "invitationExpired": "この招待は有効期限が切れています",
+      "invitationEmailMismatch": "この招待は別のメールアドレス宛てに送信されています",
+      "invitationNotFound": "招待が見つかりません"
+    }
+  },
+  "banners": {
+    "verifyEmail": {
+      "title": "メールアドレスを確認してください",
+      "description": "{email}に確認メールを送信しました。",
+      "success": "確認メールを送信しました。",
+      "failure": "確認メールの送信に失敗しました",
+      "sending": "送信中...",
+      "resend": "メールを再送"
+    },
+    "integrationSetup": {
+      "title": "連携が検出されていません",
+      "description": "ダッシュボードの準備は完了していますが、ウェブサイトからのデータをまだ受信していません。連携の設定を完了して、訪問者の計測を始めてください。",
+      "setup": "連携の設定"
+    },
+    "usageAlert": {
+      "title": "イベント上限が近づいています",
+      "description": "今月のクォータの{percentage}を使用しました（{current} / {limit}イベント）。中断を避けるためアップグレードをご検討ください。",
+      "action": "プランをアップグレード"
+    },
+    "usageLimitExceeded": {
+      "title": "イベント上限に達しました",
+      "description": "今月のクォータの{percentage}を使用しました（{current} / {limit}イベント）。データの損失を避けるためプランをアップグレードしてください。",
+      "action": "プランをアップグレード"
+    },
+    "webVitalsNoData": {
+      "title": "Core Web Vitalsのデータがまだありません",
+      "description": "計測が有効になっているか確認してください。",
+      "action": "詳細を見る"
+    }
+  },
+  "githubStar": {
+    "title": "Betterlyticsは気に入りましたか？",
+    "description": "GitHubでスターを付けると、より多くの開発者にこのプロジェクトを知ってもらえます。",
+    "action": "GitHubでスター",
+    "dismiss": "閉じる"
+  },
+  "members": {
+    "table": {
+      "title": "Members",
+      "searchPlaceholder": "Search members...",
+      "columns": {
+        "member": "Member",
+        "email": "Email",
+        "role": "Role",
+        "joined": "Joined"
+      },
+      "noResults": "No members found matching \"{query}\"",
+      "you": "(you)",
+      "unknown": "Unknown"
+    },
+    "actions": {
+      "changeRole": "Change Role",
+      "removeFromDashboard": "Remove from dashboard"
+    },
+    "roles": {
+      "owner": "Owner",
+      "admin": "Admin",
+      "editor": "Editor",
+      "viewer": "Viewer"
+    },
+    "toast": {
+      "roleUpdated": "Role updated",
+      "roleUpdateFailed": "Failed to update role",
+      "memberRemoved": "Member removed",
+      "memberRemoveFailed": "Failed to remove member"
+    },
+    "settings": {
+      "invite": {
+        "title": "Invite",
+        "description": "Invite members to view, edit, or administrate your dashboard"
+      },
+      "activeMembers": {
+        "title": "Active members"
+      },
+      "leaveDashboard": {
+        "title": "Dashboard"
+      }
+    }
+  },
+  "invitations": {
+    "section": {
+      "title": "Invite new members",
+      "description": "Send an invitation to collaborate on this dashboard",
+      "emailLabel": "Email Address",
+      "emailPlaceholder": "colleague@example.com",
+      "roleLabel": "Role",
+      "inviteButton": "Invite",
+      "upgradeToInvite": "Upgrade to invite more",
+      "sending": "Sending...",
+      "pending": "Pending",
+      "invited": "Invited",
+      "invalidEmail": "Please enter a valid email address"
+    },
+    "toast": {
+      "sent": "Invitation sent",
+      "sendFailed": "Failed to send invitation",
+      "cancelled": "Invitation cancelled",
+      "cancelFailed": "Failed to cancel invitation",
+      "accepted": "Joined {domain} successfully!",
+      "joinedSuccess": "Invitation accepted!",
+      "acceptFailed": "Failed to accept invitation",
+      "declined": "Invitation declined",
+      "declineFailed": "Failed to decline invitation"
+    },
+    "pendingModal": {
+      "title": "Dashboard Invitation",
+      "description": "You've been invited to collaborate on a dashboard",
+      "unknownDashboard": "Dashboard",
+      "accept": "Accept",
+      "accepting": "Accepting...",
+      "decline": "Decline",
+      "declining": "Declining...",
+      "pendingCount": "{current} of {total} pending invitations"
+    },
+    "acceptPage": {
+      "notFoundTitle": "Invitation Not Found",
+      "notFoundDescription": "This invitation link is invalid or has already been used.",
+      "goToSignIn": "Go to Sign In",
+      "expiredTitle": "Invitation Expired",
+      "expiredDescription": "This invitation is no longer valid.",
+      "expiredHint": "Please ask the dashboard owner to send you a new invitation.",
+      "emailMismatchTitle": "Wrong Account",
+      "emailMismatchDescription": "This invitation was sent to {invitedEmail}, but you are signed in as {currentEmail}.",
+      "emailMismatchHint": "Sign out and sign in with the correct account to accept this invitation.",
+      "errorTitle": "Could Not Accept Invitation",
+      "errorDescription": "Something went wrong while accepting the invitation. It may have already been accepted or cancelled.",
+      "goToDashboards": "Go to Dashboards"
+    }
+  },
+  "integration": {
+    "frameworks": {
+      "html": {
+        "step1": {
+          "title": "Add the tracking script",
+          "description": "Paste this inside your <head> tag"
+        }
+      },
+      "nextjs": {
+        "variants": {
+          "next153": {
+            "step1": {
+              "title": "Install the package",
+              "description": "Run this in your project directory"
+            },
+            "step2": {
+              "title": "Create instrumentation-client.ts",
+              "description": "Create this file in your project root"
+            }
+          },
+          "approuter": {
+            "step1": {
+              "title": "Install the package",
+              "description": "Run this in your project directory"
+            },
+            "step2": {
+              "title": "Create a client provider",
+              "description": "Create app/providers.tsx with the 'use client' directive"
+            },
+            "step3": {
+              "title": "Wrap your app",
+              "description": "Add the provider to your root layout (app/layout.tsx)"
+            }
+          },
+          "pagesrouter": {
+            "step1": {
+              "title": "Install the package",
+              "description": "Run this in your project directory"
+            },
+            "step2": {
+              "title": "Initialize in _app.tsx",
+              "description": "Add to pages/_app.tsx"
+            }
+          }
+        }
+      },
+      "react": {
+        "step1": {
+          "title": "Install the package",
+          "description": "Run this in your project directory"
+        },
+        "step2": {
+          "title": "Initialize the tracker",
+          "description": "Add this to your app entry (e.g., src/main.tsx)"
+        }
+      },
+      "vue": {
+        "step1": {
+          "title": "Install the package",
+          "description": "Run this in your project directory"
+        },
+        "step2": {
+          "title": "Initialize the tracker",
+          "description": "Add this to your main.ts before mounting your app"
+        }
+      },
+      "nuxt": {
+        "step1": {
+          "title": "Install the package",
+          "description": "Run this in your project directory"
+        },
+        "step2": {
+          "title": "Create a client plugin",
+          "description": "Create plugins/betterlytics.client.ts"
+        }
+      },
+      "svelte": {
+        "step1": {
+          "title": "Install the package",
+          "description": "Run this in your project directory"
+        },
+        "step2": {
+          "title": "Initialize in your root layout",
+          "description": "Add this to src/routes/+layout.svelte"
+        }
+      },
+      "astro": {
+        "step1": {
+          "title": "Install the package",
+          "description": "Run this in your project directory"
+        },
+        "step2": {
+          "title": "Add to your base layout",
+          "description": "Add a script tag to your layout (e.g., src/layouts/Layout.astro)"
+        }
+      },
+      "remix": {
+        "step1": {
+          "title": "Install the package",
+          "description": "Run this in your project directory"
+        },
+        "step2": {
+          "title": "Initialize in root.tsx",
+          "description": "Add this to app/root.tsx using useEffect"
+        }
+      },
+      "gatsby": {
+        "step1": {
+          "title": "Install the package",
+          "description": "Run this in your project directory"
+        },
+        "step2": {
+          "title": "Initialize in gatsby-browser.js",
+          "description": "Add this to gatsby-browser.js in your project root"
+        }
+      },
+      "angular": {
+        "step1": {
+          "title": "Install the package",
+          "description": "Run this in your project directory"
+        },
+        "step2": {
+          "title": "Initialize in main.ts",
+          "description": "Add this to your src/main.ts file"
+        }
+      },
+      "solidjs": {
+        "step1": {
+          "title": "Install the package",
+          "description": "Run this in your project directory"
+        },
+        "step2": {
+          "title": "Initialize in your entry file",
+          "description": "Add this to src/index.tsx"
+        }
+      },
+      "laravel": {
+        "step1": {
+          "title": "Add to your Blade layout",
+          "description": "Paste this in your layout file's <head> section (e.g., resources/views/layouts/app.blade.php)"
+        }
+      },
+      "wordpress": {
+        "step1": {
+          "title": "Open your theme editor",
+          "description": "Go to Appearance > Theme Editor, or use a plugin like \"Insert Headers and Footers\""
+        },
+        "step2": {
+          "title": "Add the tracking script",
+          "description": "Paste this before </head> in your header.php"
+        },
+        "note": "Consider using a child theme or plugin to prevent losing changes on theme updates."
+      },
+      "shopify": {
+        "step1": {
+          "title": "Open theme editor",
+          "description": "Go to Online Store > Themes > Edit code"
+        },
+        "step2": {
+          "title": "Edit theme.liquid",
+          "description": "Open theme.liquid in the Layout folder"
+        },
+        "step3": {
+          "title": "Add the tracking script",
+          "description": "Paste this before the closing </head> tag"
+        },
+        "note": "Theme updates may overwrite your changes. Consider duplicating your theme as a backup."
+      },
+      "webflow": {
+        "step1": {
+          "title": "Open project settings",
+          "description": "Go to Project Settings > Custom Code"
+        },
+        "step2": {
+          "title": "Add the tracking script",
+          "description": "Paste this in the Head Code section, then publish your site"
+        }
+      },
+      "wix": {
+        "step1": {
+          "title": "Open site settings",
+          "description": "Go to Settings > Custom Code"
+        },
+        "step2": {
+          "title": "Add new custom code",
+          "description": "Click Add Custom Code and paste the script below"
+        },
+        "step3": {
+          "title": "Configure and apply",
+          "description": "Set placement to Head, apply to All pages, then click Apply"
+        },
+        "note": "Custom Code requires a Wix Premium plan."
+      },
+      "squarespace": {
+        "step1": {
+          "title": "Open code injection",
+          "description": "Go to Settings > Developer Tools > Code Injection"
+        },
+        "step2": {
+          "title": "Add the tracking script",
+          "description": "Paste this in the Header section, then save"
+        },
+        "note": "Code Injection requires a Squarespace Business plan or higher."
+      },
+      "gtm": {
+        "step1": {
+          "title": "Create a new tag",
+          "description": "In Google Tag Manager, go to Tags > New > Custom HTML"
+        },
+        "step2": {
+          "title": "Add the tracking script",
+          "description": "Paste this code and set trigger to All Pages"
+        },
+        "step3": {
+          "title": "Publish your container",
+          "description": "Click Submit to publish the changes"
+        },
+        "note": "Make sure GTM is properly installed on your website."
+      },
+      "default": {
+        "step1": {
+          "title": "Add the tracking script",
+          "description": "Paste this inside your HTML <head> section"
+        }
+      }
+    }
+  },
+  "reportsSettings": {
+    "title": "Email Reports",
+    "emailsNotConfigured": {
+      "title": "Email delivery is not configured",
+      "description": "Report settings can be saved, but emails won't be sent until an email provider is configured (SMTP or MailerSend)."
+    },
+    "weekly": {
+      "title": "Weekly Reports",
+      "description": "Receive a summary of your website's performance each week",
+      "toggle": "Enable weekly email reports",
+      "dayLabel": "Report day",
+      "dayDescription": "Which day of the week to send the report"
+    },
+    "monthly": {
+      "title": "Monthly Reports",
+      "description": "Send a monthly email report on the 1st of each month",
+      "toggle": "Enable monthly email reports"
+    },
+    "recipients": {
+      "weeklyLabel": "Recipients ({count}/{max})",
+      "monthlyLabel": "Recipients ({count}/{max})",
+      "placeholder": "colleague@example.com",
+      "addButton": "Add",
+      "invalidEmail": "Please enter a valid email address",
+      "emailRequired": "Email address is required",
+      "duplicateEmail": "This email is already added",
+      "maxReached": "Maximum of {max} recipients reached"
+    },
+    "toast": {
+      "saved": "Report settings saved",
+      "error": "Failed to save report settings"
+    }
+  },
+  "mcp": {
+    "settings": {
+      "title": "API Tokens",
+      "description": "Create tokens to connect AI agents to your analytics data via the Model Context Protocol.",
+      "tokenNameLabel": "Token name",
+      "tokenNamePlaceholder": "e.g. Claude Desktop",
+      "createButton": "Create token",
+      "creating": "Creating...",
+      "newTokenNotice": "Copy this token now. You won't be able to see it again.",
+      "created": "Created {date}",
+      "lastUsed": "Last used {date}"
+    },
+    "toast": {
+      "created": "Token created",
+      "createError": "Failed to create token",
+      "deleted": "Token deleted",
+      "deleteError": "Failed to delete token"
+    },
+    "deleteDialog": {
+      "title": "Delete {name}",
+      "description": "This token will be permanently revoked. Any MCP clients using it will lose access immediately."
+    }
+  },
+  "integrationsSettings": {
+    "title": "Integrations",
+    "section": {
+      "description": "Connect third-party services to receive uptime monitoring notifications when your website goes down or recovers."
+    },
+    "integrations": {
+      "pushover": {
+        "name": "Pushover",
+        "description": "Push notifications to your mobile devices and desktop."
+      },
+      "discord": {
+        "name": "Discord",
+        "description": "Get important status updates in your Discord messages."
+      },
+      "slack": {
+        "name": "Slack",
+        "description": "Receive notifications in a Slack channel."
+      },
+      "teams": {
+        "name": "Microsoft Teams",
+        "description": "Receive notifications in a Microsoft Teams channel."
+      },
+      "webhook": {
+        "name": "Webhook",
+        "description": "Send notifications to any URL via HTTP POST."
+      }
+    },
+    "moreIntegrations": "Need a different integration? Contact us and we'll consider adding it.",
+    "history": {
+      "title": "Notification Log",
+      "button": "Notification Log",
+      "empty": "No notifications sent yet.",
+      "error": "Failed to load notification history.",
+      "attempts": "{count} attempts",
+      "columns": {
+        "time": "Time",
+        "integration": "Integration",
+        "notification": "Notification",
+        "status": "Status",
+        "error": "Error"
+      },
+      "status": {
+        "sent": "Sent",
+        "failed": "Failed"
+      }
+    },
+    "status": {
+      "connected": "Connected",
+      "disabled": "Disabled"
+    },
+    "actions": {
+      "configure": "Configure",
+      "add": "Add",
+      "edit": "Edit",
+      "disconnect": "Disconnect"
+    },
+    "disconnect": {
+      "title": "Disconnect {name}",
+      "description": "Are you sure you want to disconnect this integration? This will remove the configuration and stop all notifications from this source.",
+      "confirm": "Disconnect"
+    },
+    "pushoverDialog": {
+      "title": "Pushover Integration",
+      "userKeyLabel": "User Key",
+      "userKeyPlaceholder": "Your Pushover user key",
+      "priorityLabel": "Notification Priority",
+      "priorities": {
+        "-2": "Lowest: No notification",
+        "-1": "Low: No sound or vibration",
+        "0": "Normal (Recommended)",
+        "1": "High: Bypass quiet hours"
+      },
+      "credentialsHint": "Find your user key at <link>pushover.net</link>",
+      "priorityHint": "Learn more about priority levels <link>here</link>.",
+      "errors": {
+        "userKeyRequired": "User key is required",
+        "userKeyInvalid": "Invalid user key"
+      },
+      "cancel": "Cancel",
+      "save": "Save"
+    },
+    "discordDialog": {
+      "title": "Discord Integration",
+      "webhookUrlLabel": "Webhook URL",
+      "webhookHint": "Learn how to create a webhook <link>here</link>.",
+      "errors": {
+        "webhookUrlRequired": "Webhook URL is required",
+        "webhookUrlInvalid": "Must be a valid Discord webhook URL"
+      },
+      "cancel": "Cancel",
+      "save": "Save"
+    },
+    "slackDialog": {
+      "title": "Slack Integration",
+      "webhookUrlLabel": "Webhook URL",
+      "webhookUrlPlaceholder": "https://hooks.slack.com/services/...",
+      "webhookHint": "Follow steps 1–3 of the <link>Incoming Webhooks guide</link> to get your webhook URL.",
+      "errors": {
+        "webhookUrlRequired": "Webhook URL is required",
+        "webhookUrlInvalid": "Must be a valid Slack webhook URL"
+      },
+      "cancel": "Cancel",
+      "save": "Save"
+    },
+    "teamsDialog": {
+      "title": "Microsoft Teams Integration",
+      "webhookUrlLabel": "Webhook URL",
+      "webhookUrlPlaceholder": "Your Teams webhook URL",
+      "webhookHint": "Create an Incoming Webhook using a Teams Workflow. <link>Learn how</link>.",
+      "errors": {
+        "webhookUrlRequired": "Webhook URL is required",
+        "webhookUrlInvalid": "Must be a valid HTTPS URL"
+      },
+      "cancel": "Cancel",
+      "save": "Save"
+    },
+    "webhookDialog": {
+      "title": "Webhook Integration",
+      "webhookUrlLabel": "Webhook URL",
+      "webhookUrlPlaceholder": "https://example.com/webhook",
+      "webhookHint": "Enter a publicly accessible HTTPS URL. Notifications are sent as JSON POST requests with title, message, url, and url_title fields.",
+      "errors": {
+        "webhookUrlRequired": "Webhook URL is required",
+        "webhookUrlInvalid": "Must be a valid HTTPS URL"
+      },
+      "cancel": "Cancel",
+      "save": "Save"
+    },
+    "toast": {
+      "saved": "Integration saved",
+      "deleted": "Integration disconnected",
+      "error": "Failed to update integration",
+      "fetchError": "Failed to load integrations",
+      "invalidPushoverKey": "Invalid Pushover user key or no devices registered",
+      "invalidDiscordWebhook": "Invalid Discord webhook URL",
+      "invalidSlackWebhook": "Invalid Slack webhook URL",
+      "invalidTeamsWebhook": "Invalid Teams webhook URL",
+      "invalidWebhookUrl": "Invalid webhook URL"
+    }
+  },
+  "errors": {
+    "page": {
+      "title": "Error Overview"
+    },
+    "table": {
+      "columns": {
+        "error": "Error",
+        "volume": "Volume",
+        "occurrences": "Occurrences",
+        "sessions": "Sessions",
+        "firstSeen": "First seen",
+        "lastSeen": "Last seen",
+        "status": "Status"
+      },
+      "selectAll": "Select all",
+      "selectRow": "Select row",
+      "rowActionsAria": "Row actions",
+      "ago": "{time} ago",
+      "emptySearch": "No errors matching your search.",
+      "emptyPeriod": "No errors recorded in this period."
+    },
+    "toolbar": {
+      "searchPlaceholder": "Search by type and message...",
+      "selectedCount": "{count} selected",
+      "reload": "Reload",
+      "reloadAria": "Reload errors"
+    },
+    "statusFilter": {
+      "all": "All",
+      "unresolved": "Unresolved",
+      "resolved": "Resolved",
+      "ignored": "Ignored"
+    },
+    "statusActions": {
+      "resolve": "Resolve",
+      "ignore": "Ignore",
+      "unresolve": "Unresolve",
+      "markResolved": "Mark resolved",
+      "markUnresolved": "Mark unresolved"
+    },
+    "status": {
+      "unresolved": "Unresolved",
+      "resolved": "Resolved",
+      "ignored": "Ignored"
+    },
+    "emptyState": {
+      "title": "No errors detected",
+      "description": "When client-side errors occur on your site, they will appear here grouped by type. Set up error tracking to catch and monitor client-side exceptions.",
+      "learnMore": "Learn about error tracking"
+    },
+    "detail": {
+      "header": {
+        "backToErrors": "Back to errors",
+        "copied": "Copied!",
+        "share": "Share"
+      },
+      "sidebar": {
+        "overview": "Overview",
+        "firstSeen": "First seen",
+        "lastSeen": "Last seen",
+        "occurrences": "Occurrences",
+        "sessions": "Sessions",
+        "occurrenceHistory": "Occurrence history",
+        "browsers": "Browsers",
+        "deviceType": "Device type",
+        "watchReplay": "Watch latest session replay",
+        "watchReplayDescription": "See what the user did before this error",
+        "noReplay": "No session replay for this error",
+        "noReplayDescription": "Replay captures what users did before an error occurred.",
+        "learnMore": "Learn more"
+      },
+      "navigator": {
+        "occurrenceOf": "Occurrence {number} of {total}",
+        "firstOccurrence": "First occurrence",
+        "olderOccurrence": "Older occurrence",
+        "newerOccurrence": "Newer occurrence",
+        "latestOccurrence": "Latest occurrence"
+      },
+      "stacktrace": {
+        "title": "Stacktrace",
+        "frames": "{count, plural, one {# frame} other {# frames}}",
+        "showLess": "Show less",
+        "showMoreFrames": "Show {count} more {count, plural, one {frame} other {frames}}",
+        "at": "at",
+        "inApp": "in app"
+      },
+      "sessionTrail": {
+        "title": "Session trail",
+        "eventCount": "{count, plural, one {# event} other {# events}} in this session",
+        "watchReplay": "Watch replay"
+      },
+      "occurrence": {
+        "browser": "Browser",
+        "operatingSystem": "Operating System",
+        "device": "Device",
+        "country": "Country"
+      },
+      "volumeChart": {
+        "errorCount": "{count, plural, one {# error} other {# errors}}"
+      }
+    }
+  }
+}

--- a/dashboard/src/constants/i18n.ts
+++ b/dashboard/src/constants/i18n.ts
@@ -1,7 +1,7 @@
-import { enGB, da, it, nb } from 'date-fns/locale';
+import { enGB, da, it, nb, ja } from 'date-fns/locale';
 import type { Locale } from 'date-fns';
 
-export const SUPPORTED_LANGUAGES = ['en', 'da', 'it', 'nb'] as const;
+export const SUPPORTED_LANGUAGES = ['en', 'da', 'it', 'nb', 'ja'] as const;
 
 export type SupportedLanguages = (typeof SUPPORTED_LANGUAGES)[number];
 
@@ -10,6 +10,7 @@ export const LANGUAGE_METADATA = {
   da: { name: 'Dansk', code: 'DK', ogLocale: 'da_DK', dateFnsLocale: da },
   it: { name: 'Italiano', code: 'IT', ogLocale: 'it_IT', dateFnsLocale: it },
   nb: { name: 'Norsk', code: 'NO', ogLocale: 'nb_NO', dateFnsLocale: nb },
+  ja: { name: '日本語', code: 'JP', ogLocale: 'ja_JP', dateFnsLocale: ja },
 } as const satisfies Record<
   SupportedLanguages,
   { name: string; code: string; ogLocale: string; dateFnsLocale: Locale }


### PR DESCRIPTION
## Problem

Closes #842. Japanese was not available as a UI language.

## Change

Registers `ja` as a supported language:
- `dashboard/src/constants/i18n.ts` — adds `ja` to `SUPPORTED_LANGUAGES`, its metadata (name 日本語, code `JP`, ogLocale `ja_JP`), and the `date-fns/locale` `ja` import.
- `dashboard/messages/ja.json` — new locale file.

This is a **first pass** covering the dashboard application UI: navigation, metrics, filters, time ranges, the pages / referrers / devices / geography / events views, onboarding, banners, validation messages and toasts. Marketing/legal pages (`public.*`), pricing, monitoring, integrations and member/invitation flows are intentionally left in English for now and will follow up in subsequent PRs to keep this review manageable.

Translations follow standard Japanese analytics conventions (直帰率 = bounce rate, 参照元/流入元 = referrers, セッション, ユニーク訪問者, …). Product and technical names are kept in English (Next.js, React, npm, UTM, Cookie, GDPR, SSL, Web Vitals). All ICU placeholders (`{count, plural, ...}`, `{domain}`) and inline tags are preserved verbatim.

## Testing

- `ja.json` parses as valid JSON; key structure is identical to `en.json` for the translated sections (0 missing / extra keys).
- No new dependencies — the `date-fns` `ja` locale is already bundled.
- ICU argument names, plural categories and tags verified against `en.json`.
