### PR TITLE
Fix/cjk aware string truncation

### DIFF
--- a/dashboard/src/app/(protected)/admin/bug-reports/page.tsx
+++ b/dashboard/src/app/(protected)/admin/bug-reports/page.tsx
@@ -33,10 +33,6 @@ function statusBadgeVariant(status: BugReportStatus): 'default' | 'secondary' | 
   return 'outline';
 }
 
-function truncate(text: string, length = 80) {
-  return text.length > length ? `${text.slice(0, length)}…` : text;
-}
-
 function parseStatusFilter(raw: string | undefined): BugReportStatus | 'all' {
   if (raw === 'open' || raw === 'resolved' || raw === 'ignored' || raw === 'all') return raw;
   return 'open';
@@ -103,7 +99,7 @@ export default async function AdminBugReportsPage({ searchParams }: PageProps) {
               reports.map((report) => (
                 <TableRow key={report.id}>
                   <TableCell className='font-medium'>{report.userEmail}</TableCell>
-                  <TableCell className='text-muted-foreground max-w-sm'>{truncate(report.message)}</TableCell>
+                  <TableCell className='text-muted-foreground max-w-sm truncate'>{report.message}</TableCell>
                   <TableCell className='text-muted-foreground font-mono text-xs'>
                     {report.dashboardId ?? '—'}
                   </TableCell>

--- a/dashboard/src/utils/formatters.test.ts
+++ b/dashboard/src/utils/formatters.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { formatString } from './formatters';
+import { getStringWidth } from './stringWidth';
+
+describe('formatString', () => {
+  it('returns short strings unchanged', () => {
+    expect(formatString('short', 50)).toBe('short');
+    expect(formatString('exactly-ten', 50)).toBe('exactly-ten');
+  });
+
+  it('middle-truncates long Latin strings identically to the legacy slice formula', () => {
+    const url = 'https://example.com/some/very/long/path/that/keeps/going/forever';
+    const half = 10;
+    const legacy = `${url.slice(0, half)}...${url.slice(-half)}`;
+    expect(formatString(url, 20)).toBe(legacy);
+  });
+
+  it('keeps Japanese output within the column budget rather than the character count', () => {
+    const jp = 'これは非常に長い日本語のフィルター値の例です';
+    const result = formatString(jp, 20);
+
+    expect(result).toContain('...');
+    const ellipsisColumns = 3;
+    expect(getStringWidth(result)).toBeLessThanOrEqual(20 + ellipsisColumns);
+  });
+
+  it('truncates far fewer wide characters than the raw maxLength', () => {
+    const jp = '東'.repeat(40);
+    const result = formatString(jp, 20);
+    const kept = result.replace('...', '');
+
+    expect([...kept].length).toBeLessThan(20);
+    expect(getStringWidth(kept)).toBeLessThanOrEqual(20);
+  });
+
+  it('never emits a broken surrogate pair when truncating emoji', () => {
+    const emoji = '🎉'.repeat(40);
+    const result = formatString(emoji, 20);
+    expect(result.includes('�')).toBe(false);
+  });
+});

--- a/dashboard/src/utils/formatters.ts
+++ b/dashboard/src/utils/formatters.ts
@@ -1,4 +1,5 @@
 import type { SupportedLanguages } from '@/constants/i18n';
+import { getStringWidth, sliceToWidth } from '@/utils/stringWidth';
 
 /**
  * Format a number using locale-aware compact notation (e.g., 1.5K, 1,5 t).
@@ -33,16 +34,20 @@ export function formatPercentage(
 }
 
 /**
- * Format a string, adds ellipsis to middle of string instead of end
+ * Format a string, adds ellipsis to the middle of the string instead of the end.
+ *
+ * `maxLength` is a budget of rendered columns, not code units, so wide scripts
+ * (Japanese, Chinese, Korean) and emoji stay within the same visual width as
+ * Latin text instead of overflowing. Slicing is grapheme-safe.
  */
 export function formatString(value: string, maxLength: number = 50) {
-  if (value.length <= maxLength) {
+  if (getStringWidth(value) <= maxLength) {
     return value;
   }
   const half = Math.floor(maxLength / 2);
 
-  const start = value.slice(0, half);
-  const end = value.slice(-half);
+  const start = sliceToWidth(value, half);
+  const end = sliceToWidth(value, half, true);
 
   return `${start}...${end}`;
 }

--- a/dashboard/src/utils/stringWidth.test.ts
+++ b/dashboard/src/utils/stringWidth.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { getStringWidth, sliceToWidth } from './stringWidth';
+
+describe('getStringWidth', () => {
+  it('counts Latin characters as one column each', () => {
+    expect(getStringWidth('hello')).toBe(5);
+    expect(getStringWidth('')).toBe(0);
+  });
+
+  it('counts CJK ideographs and kana as two columns each', () => {
+    expect(getStringWidth('家')).toBe(2);
+    expect(getStringWidth('日本語')).toBe(6);
+    expect(getStringWidth('ひらがな')).toBe(8);
+    expect(getStringWidth('カタカナ')).toBe(8);
+  });
+
+  it('counts half-width katakana as one column', () => {
+    expect(getStringWidth('ｶﾀｶﾅ')).toBe(4);
+  });
+
+  it('treats emoji and flags as two columns and does not count combining marks', () => {
+    expect(getStringWidth('🎉')).toBe(2);
+    expect(getStringWidth('🇯🇵')).toBe(2);
+    expect(getStringWidth('é')).toBe(1);
+    expect(getStringWidth('é')).toBe(1);
+  });
+
+  it('mixes scripts additively', () => {
+    expect(getStringWidth('A家B')).toBe(4);
+  });
+});
+
+describe('sliceToWidth', () => {
+  it('takes whole graphemes from the start up to the budget', () => {
+    expect(sliceToWidth('hello world', 5)).toBe('hello');
+    expect(sliceToWidth('日本語テスト', 6)).toBe('日本語');
+  });
+
+  it('takes whole graphemes from the end when fromEnd is set', () => {
+    expect(sliceToWidth('hello world', 5, true)).toBe('world');
+    expect(sliceToWidth('日本語テスト', 6, true)).toBe('テスト');
+  });
+
+  it('never splits a wide grapheme across the budget boundary', () => {
+    expect(sliceToWidth('日本語', 5)).toBe('日本');
+    expect(getStringWidth(sliceToWidth('日本語', 5))).toBeLessThanOrEqual(5);
+  });
+
+  it('never splits a surrogate-pair emoji', () => {
+    const result = sliceToWidth('🎉🎉🎉', 5);
+    expect(result).toBe('🎉🎉');
+    expect([...result].every((ch) => ch.codePointAt(0) !== 0xfffd)).toBe(true);
+  });
+});

--- a/dashboard/src/utils/stringWidth.ts
+++ b/dashboard/src/utils/stringWidth.ts
@@ -1,0 +1,88 @@
+/**
+ * Visual-width helpers for truncating display strings.
+ *
+ * Counting `String.length` (UTF-16 code units) is wrong for any non-Latin
+ * script: a CJK ideograph such as 家 is a single code unit but renders at
+ * roughly twice the advance width of a Latin glyph, and many emoji are
+ * surrogate pairs (length 2) yet render as one wide cell. We instead measure
+ * in "columns" using the Unicode East Asian Width property (Wide/Fullwidth = 2,
+ * everything else = 1) and slice on grapheme boundaries so we never cut a
+ * surrogate pair, flag, or combining sequence in half.
+ */
+
+/* East Asian Width = Wide (W) or Fullwidth (F), ascending by code point. */
+const WIDE_RANGES: ReadonlyArray<readonly [number, number]> = [
+  [0x1100, 0x115f],
+  [0x2329, 0x232a],
+  [0x2e80, 0x303e],
+  [0x3041, 0x33ff],
+  [0x3400, 0x4dbf],
+  [0x4e00, 0x9fff],
+  [0xa000, 0xa4cf],
+  [0xa960, 0xa97f],
+  [0xac00, 0xd7a3],
+  [0xf900, 0xfaff],
+  [0xfe10, 0xfe19],
+  [0xfe30, 0xfe6f],
+  [0xff00, 0xff60],
+  [0xffe0, 0xffe6],
+  [0x1b000, 0x1b16f],
+  [0x1f200, 0x1f2ff],
+  [0x1f300, 0x1faff],
+  [0x20000, 0x3fffd],
+];
+
+function isWideCodePoint(codePoint: number): boolean {
+  for (const [start, end] of WIDE_RANGES) {
+    if (codePoint < start) return false;
+    if (codePoint <= end) return true;
+  }
+  return false;
+}
+
+/** Width in columns of a single grapheme cluster: 2 for wide/emoji, else 1. */
+function graphemeWidth(grapheme: string): number {
+  for (const char of grapheme) {
+    const codePoint = char.codePointAt(0);
+    if (codePoint === undefined) continue;
+    const isEmojiPresentation = codePoint === 0xfe0f;
+    const isRegionalIndicator = codePoint >= 0x1f1e6 && codePoint <= 0x1f1ff;
+    if (isEmojiPresentation || isRegionalIndicator || isWideCodePoint(codePoint)) {
+      return 2;
+    }
+  }
+  return 1;
+}
+
+function segmentGraphemes(value: string): string[] {
+  if (typeof Intl !== 'undefined' && 'Segmenter' in Intl) {
+    const segmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
+    return Array.from(segmenter.segment(value), (entry) => entry.segment);
+  }
+  return Array.from(value);
+}
+
+/** Total rendered width of a string in columns. */
+export function getStringWidth(value: string): number {
+  return segmentGraphemes(value).reduce((total, grapheme) => total + graphemeWidth(grapheme), 0);
+}
+
+/**
+ * Take whole grapheme clusters from the start (or end) of `value` until adding
+ * the next one would exceed `maxWidth` columns. Never splits a cluster.
+ */
+export function sliceToWidth(value: string, maxWidth: number, fromEnd = false): string {
+  const graphemes = segmentGraphemes(value);
+  const ordered = fromEnd ? [...graphemes].reverse() : graphemes;
+
+  const taken: string[] = [];
+  let width = 0;
+  for (const grapheme of ordered) {
+    const next = width + graphemeWidth(grapheme);
+    if (next > maxWidth) break;
+    taken.push(grapheme);
+    width = next;
+  }
+
+  return (fromEnd ? taken.reverse() : taken).join('');
+}


### PR DESCRIPTION
 Makes formatString truncate by rendered width instead of character count so full-width scripts stop hitting the worst-case overflow. This is a risk-reducer to gate glyph-language translations behind some handling - it does not actually guarantee text fits. Read the limitations.

## Description of why

  - Several display formatters trim text by counting UTF-16 code units, which silently assumes every character is Latin-width.
  - CJK glyphs (Japanese/Chinese/Korean) render ~2x as wide, so a string of full-width characters counts well under a char limit, escapes truncation entirely, and renders at roughly double the intended width - gross overflow.
  - We will not merge a glyph-language translation (e.g. Japanese #982) while that overflow ships. This PR is the gate those merges are blocked on.

## Key decisions

  - Measure East Asian Width (full-width = 2 columns, else 1) and slice on grapheme boundaries, rather than naive char count.
  - Keep the existing middle-ellipsis behaviour in formatString; this is a drop-in, no call sites change.
  - The bug-reports cell is moved to CSS truncation, not the column heuristic - a deliberate signal that CSS is the correct long-term tool for HTML surfaces.
  - Explicitly scoped as a mitigation. The full CSS/measured-width fix is not attempted here.

## Changes

  - formatString: width-aware, grapheme-safe truncation. Provable no-op for ASCII (byte-identical to the old slice formula, asserted by test).
  - New stringWidth.ts: getStringWidth + sliceToWidth (East Asian Width table + grapheme segmentation).
  - bug-reports admin message cell: JS character cap → CSS truncate.
  - 14 unit tests (stringWidth.test.ts, formatters.test.ts).

 ## What this does NOT do (read this before relying on it)

  - It does not guarantee anything fits. The UI uses a proportional font (Inter / system-ui), so "columns" never map to pixels. CJK lands at roughly average Latin width with real variance both ways - narrow Latin (i / :) is narrower than CJK, wide Latin (m q, digits) is wider. A tightly-sized box can still overflow.
  - CJK and Latin truncations do not render at equal width, and no character/column count can make them - two ASCII strings of equal column count already render at different widths.
  - It is the wrong tool for the HTML surfaces (filter chips, table cells, dropdowns). The only reliable bound there is CSS (max-width + truncate) or measuring rendered text. This PR does neither.
  - It carries cost: an East-Asian-Width range table and grapheme segmentation that become largely throwaway if/when the HTML surfaces move to CSS.
  - Its only durable value is the surfaces CSS can't reach - SVG (Sankey node labels) and the email report.

##  Additional notes

  - Net effect: overflow goes from "catastrophic" to "possible." Enough to gate CJK translations behind some handling, not enough to call the content-truncation debt solved. 
  - I still believe changing to: "max-width truncate" and giving up on our mid sentence elipsis is the real fix.