### PR TITLE
Bare wildcard (*) filter values now mean value present or absent

### DIFF
--- a/dashboard/src/lib/ba-hourly-query.test.ts
+++ b/dashboard/src/lib/ba-hourly-query.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { BAHourlyQuery } from './ba-hourly-query';
+import { BASessionQuery } from './ba-session-query';
+import type { QueryFilter } from '@/entities/analytics/filter.entities';
+
+function makeFilter(
+  column: QueryFilter['column'],
+  operator: QueryFilter['operator'],
+  values: string[],
+  id = 'filter-1',
+): QueryFilter {
+  return { id, column, operator, values };
+}
+
+function buildGeoSql(filters: QueryFilter[]) {
+  return BAHourlyQuery.getGeoHourlyFilters(filters)
+    .map((part) => part.taggedSql)
+    .join(' AND ');
+}
+
+describe('hourly MV filters bare wildcard semantics', () => {
+  it('treats = * as "value present"', () => {
+    const sql = buildGeoSql([makeFilter('city', '=', ['*'])]);
+
+    expect(sql).toBe(`city != ''`);
+  });
+
+  it('treats != * as "value absent"', () => {
+    const sql = buildGeoSql([makeFilter('city', '!=', ['*'])]);
+
+    expect(sql).toBe(`city = ''`);
+  });
+
+  it('keeps plain values on the IN path', () => {
+    const sql = buildGeoSql([makeFilter('country_code', '=', ['DK'])]);
+
+    expect(sql).toContain('country_code IN');
+  });
+
+  it('keeps partial wildcard patterns on the ILIKE path', () => {
+    const sql = buildGeoSql([makeFilter('city', '=', ['Copen*'])]);
+
+    expect(sql).toMatch(/arrayExists\(pattern -> city ILIKE pattern/);
+  });
+
+  it('does not special-case a wildcard mixed with other values', () => {
+    const sql = buildGeoSql([makeFilter('city', '!=', ['Copenhagen', '*'])]);
+
+    expect(sql).toMatch(/arrayAll\(pattern -> city NOT ILIKE pattern/);
+  });
+
+  it('treats a lone literal % the same as *, matching the transforming builders', () => {
+    const sql = buildGeoSql([makeFilter('city', '=', ['%'])]);
+
+    expect(sql).toBe(`city != ''`);
+  });
+
+  it('applies wildcard semantics to overview filters too', () => {
+    const sql = BAHourlyQuery.getOverviewHourlyFilters([makeFilter('browser', '!=', ['*'])])
+      .map((part) => part.taggedSql)
+      .join(' AND ');
+
+    expect(sql).toBe(`browser = ''`);
+  });
+
+  it('emits the same presence predicate as the sessions slow path', () => {
+    const fastSql = buildGeoSql([makeFilter('city', '=', ['*'])]);
+    const slow = BASessionQuery.getSessionTableSubQuery(
+      ['visitor_id'],
+      [makeFilter('city', '=', ['*'])],
+      'test-site',
+      '2026-01-01 00:00:00',
+      '2026-01-31 23:59:59',
+    );
+
+    expect(fastSql).toBe(`city != ''`);
+    expect(slow.taggedSql).toContain(`city != ''`);
+  });
+});

--- a/dashboard/src/lib/ba-hourly-query.ts
+++ b/dashboard/src/lib/ba-hourly-query.ts
@@ -3,6 +3,7 @@ import 'server-only';
 import { QueryFilter } from '@/entities/analytics/filter.entities';
 import { GranularityRangeValues } from '@/utils/granularityRanges';
 import { safeSql, SQL } from './safe-sql';
+import { matchAnyValueFilterSql } from './filter-sql';
 import { BASiteQuery } from '@/entities/analytics/analyticsQuery.entities';
 
 const HOUR_MS = 3_600_000;
@@ -65,10 +66,9 @@ function buildHourlyMvFilters(
 
   return applicable.map((filter, i) => {
     const col = SQL.Unsafe(filter.column);
-    // a lone literal % is indistinguishable from * in the builders that transform before checking
-    const isMatchAnyValue = filter.values.length === 1 && (filter.values[0] === '*' || filter.values[0] === '%');
-    if (isMatchAnyValue) {
-      return filter.operator === '=' ? safeSql`${col} != ''` : safeSql`${col} = ''`;
+    const presenceCheck = matchAnyValueFilterSql(filter.values, filter.operator, col);
+    if (presenceCheck) {
+      return presenceCheck;
     }
 
     const hasWildcard = filter.values.some((v) => v.includes('*'));

--- a/dashboard/src/lib/ba-hourly-query.ts
+++ b/dashboard/src/lib/ba-hourly-query.ts
@@ -65,6 +65,12 @@ function buildHourlyMvFilters(
 
   return applicable.map((filter, i) => {
     const col = SQL.Unsafe(filter.column);
+    // a lone literal % is indistinguishable from * in the builders that transform before checking
+    const isMatchAnyValue = filter.values.length === 1 && (filter.values[0] === '*' || filter.values[0] === '%');
+    if (isMatchAnyValue) {
+      return filter.operator === '=' ? safeSql`${col} != ''` : safeSql`${col} = ''`;
+    }
+
     const hasWildcard = filter.values.some((v) => v.includes('*'));
 
     if (!hasWildcard) {

--- a/dashboard/src/lib/ba-query.test.ts
+++ b/dashboard/src/lib/ba-query.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/lib/env', () => ({
+  env: {
+    SAMPLING_TRAFFIC_THRESHOLD: 100_000,
+    SAMPLING_FACTOR: 0.25,
+    HIGH_TRAFFIC_CONCURRENCY_LIMIT: 20,
+  },
+}));
+
+vi.mock('@/repositories/clickhouse/usage.repository', () => ({
+  isHighTrafficSite: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock('@/observability/clickhouse-concurrency', () => ({
+  setSiteConcurrencyLimit: vi.fn(),
+}));
+
+import { BAQuery } from './ba-query';
+import type { QueryFilter } from '@/entities/analytics/filter.entities';
+
+function makeFilter(
+  column: QueryFilter['column'],
+  operator: QueryFilter['operator'],
+  values: string[],
+  id = 'filter-1',
+): QueryFilter {
+  return { id, column, operator, values };
+}
+
+function buildSql(filters: QueryFilter[]) {
+  const parts = BAQuery.getFilterQuery(filters);
+  return parts.map((part) => part.taggedSql).join(' AND ');
+}
+
+describe('getFilterQuery bare wildcard semantics', () => {
+  it('treats = * as "value present"', () => {
+    const sql = buildSql([makeFilter('custom_event_name', '=', ['*'])]);
+
+    expect(sql).toBe(`custom_event_name != ''`);
+  });
+
+  it('treats != * as "value absent"', () => {
+    const sql = buildSql([makeFilter('utm_source', '!=', ['*'])]);
+
+    expect(sql).toBe(`utm_source = ''`);
+  });
+
+  it('keeps the ILIKE path for event_type since Enum8 cannot compare to empty string', () => {
+    const sql = buildSql([makeFilter('event_type', '=', ['*'])]);
+
+    expect(sql).toContain('event_type ILIKE pattern');
+    expect(sql).not.toContain(`event_type != ''`);
+  });
+
+  it('keeps the NOT ILIKE path for event_type != *', () => {
+    const sql = buildSql([makeFilter('event_type', '!=', ['*'])]);
+
+    expect(sql).toContain('event_type NOT ILIKE pattern');
+    expect(sql).not.toContain(`event_type = ''`);
+  });
+
+  it('does not special-case a wildcard mixed with other values', () => {
+    const sql = buildSql([makeFilter('custom_event_name', '=', ['signup', '*'])]);
+
+    expect(sql).toContain('custom_event_name ILIKE pattern');
+  });
+
+  it('does not special-case partial wildcard patterns', () => {
+    const sql = buildSql([makeFilter('url', '=', ['/docs/*'])]);
+
+    expect(sql).toContain('url ILIKE pattern');
+  });
+
+  it('applies the referrer_source column override to presence checks', () => {
+    const sql = buildSql([makeFilter('referrer_source', '=', ['*'])]);
+
+    expect(sql).toBe(`referrer_source_effective != ''`);
+  });
+});
+
+describe('getFilterQuery regressions', () => {
+  it('keeps = as arrayExists ILIKE for plain values', () => {
+    const sql = buildSql([makeFilter('custom_event_name', '=', ['signup'])]);
+
+    expect(sql).toMatch(/arrayExists\(pattern -> custom_event_name ILIKE pattern/);
+  });
+
+  it('keeps != as arrayAll NOT ILIKE for plain values', () => {
+    const sql = buildSql([makeFilter('custom_event_name', '!=', ['signup'])]);
+
+    expect(sql).toMatch(/arrayAll\(pattern -> custom_event_name NOT ILIKE pattern/);
+  });
+
+  it('keeps gp bare wildcard as key existence', () => {
+    const equals = buildSql([makeFilter('gp.plan', '=', ['*'])]);
+    const notEquals = buildSql([makeFilter('gp.plan', '!=', ['*'])]);
+
+    expect(equals).toContain('has(global_properties_keys');
+    expect(notEquals).toContain('NOT has(global_properties_keys');
+  });
+});

--- a/dashboard/src/lib/ba-query.ts
+++ b/dashboard/src/lib/ba-query.ts
@@ -52,12 +52,12 @@ function getFilterQuery(queryFilters: QueryFilter[]) {
 function buildFilterQuery(filter: z.infer<typeof TransformQueryFilterSchema>, filterIndex: number) {
   const parsed = parseFilterColumn(filter.column);
   const values = SQL.StringArray({ [`query_filter_${filterIndex}`]: filter.values });
+  const isMatchAnyValue = filter.values.length === 1 && filter.values[0] === '%';
 
   switch (parsed.kind) {
     case 'gp': {
       const key = SQL.String({ [`gp_key_${filterIndex}`]: parsed.key });
-      const isWildcard = filter.values.length === 1 && filter.values[0] === '%';
-      if (isWildcard) {
+      if (isMatchAnyValue) {
         const hasKey = safeSql`has(global_properties_keys, ${key})`;
         return filter.rawOperator === '=' ? hasKey : safeSql`NOT ${hasKey}`;
       }
@@ -66,6 +66,10 @@ function buildFilterQuery(filter: z.infer<typeof TransformQueryFilterSchema>, fi
     }
     default: {
       const column = filterColumnSql(parsed.col);
+      // event_type is an Enum8 - comparing it to '' throws, and it is never unset anyway
+      if (isMatchAnyValue && parsed.col !== 'event_type') {
+        return filter.rawOperator === '=' ? safeSql`${column} != ''` : safeSql`${column} = ''`;
+      }
       return safeSql`${filter.operator.quantifier}(pattern -> ${column} ${filter.operator.operater} pattern, ${values})`;
     }
   }

--- a/dashboard/src/lib/ba-query.ts
+++ b/dashboard/src/lib/ba-query.ts
@@ -9,7 +9,7 @@ import {
 import { GranularityRangeValues } from '@/utils/granularityRanges';
 import { z } from 'zod';
 import { safeSql, SQL } from './safe-sql';
-import { filterColumnSql } from './filter-sql';
+import { filterColumnSql, isMatchAnyValueFilter, matchAnyValueFilterSql } from './filter-sql';
 import { DateTimeString } from '@/types/dates';
 import { isHighTrafficSite } from '@/repositories/clickhouse/usage.repository';
 import { setSiteConcurrencyLimit } from '@/observability/clickhouse-concurrency';
@@ -52,12 +52,11 @@ function getFilterQuery(queryFilters: QueryFilter[]) {
 function buildFilterQuery(filter: z.infer<typeof TransformQueryFilterSchema>, filterIndex: number) {
   const parsed = parseFilterColumn(filter.column);
   const values = SQL.StringArray({ [`query_filter_${filterIndex}`]: filter.values });
-  const isMatchAnyValue = filter.values.length === 1 && filter.values[0] === '%';
 
   switch (parsed.kind) {
     case 'gp': {
       const key = SQL.String({ [`gp_key_${filterIndex}`]: parsed.key });
-      if (isMatchAnyValue) {
+      if (isMatchAnyValueFilter(filter.values)) {
         const hasKey = safeSql`has(global_properties_keys, ${key})`;
         return filter.rawOperator === '=' ? hasKey : safeSql`NOT ${hasKey}`;
       }
@@ -66,11 +65,10 @@ function buildFilterQuery(filter: z.infer<typeof TransformQueryFilterSchema>, fi
     }
     default: {
       const column = filterColumnSql(parsed.col);
-      // event_type is an Enum8 - comparing it to '' throws, and it is never unset anyway
-      if (isMatchAnyValue && parsed.col !== 'event_type') {
-        return filter.rawOperator === '=' ? safeSql`${column} != ''` : safeSql`${column} = ''`;
-      }
-      return safeSql`${filter.operator.quantifier}(pattern -> ${column} ${filter.operator.operater} pattern, ${values})`;
+      return (
+        matchAnyValueFilterSql(filter.values, filter.rawOperator, column, parsed.col) ??
+        safeSql`${filter.operator.quantifier}(pattern -> ${column} ${filter.operator.operater} pattern, ${values})`
+      );
     }
   }
 }

--- a/dashboard/src/lib/ba-session-query.test.ts
+++ b/dashboard/src/lib/ba-session-query.test.ts
@@ -76,6 +76,62 @@ describe('getSessionTableSubQuery event-column filters', () => {
     expect(taggedSql).toMatch(/custom_event_name ILIKE pattern.*\) OR \(.*outbound_link_url ILIKE pattern/);
   });
 
+  it('guards the = bridge by event type for primary key pruning', () => {
+    const { taggedSql } = buildSubQuery([makeFilter('custom_event_name', '=', ['signup'])]);
+
+    expect(taggedSql).toMatch(/event_type = 'custom' AND arrayExists\(pattern -> custom_event_name ILIKE pattern/);
+  });
+
+  it('treats = * on the bridge as "session has such an event"', () => {
+    const { taggedSql, taggedParams } = buildSubQuery([makeFilter('custom_event_name', '=', ['*'])]);
+
+    expect(taggedSql).toContain('session_id IN ( SELECT session_id FROM analytics.events');
+    expect(taggedSql).toContain(`event_type = 'custom' AND arrayExists`);
+    expect(Object.values(taggedParams)).toContainEqual(['%']);
+  });
+
+  it('treats = * on session-native columns as "value present"', () => {
+    const { taggedSql } = buildSubQuery([makeFilter('utm_source', '=', ['*'])]);
+
+    expect(taggedSql).toContain(`utm_source.2 != ''`);
+    expect(taggedSql).not.toContain('analytics.events');
+  });
+
+  it('treats != * on session-native columns as "value absent"', () => {
+    const { taggedSql } = buildSubQuery([makeFilter('utm_source', '!=', ['*'])]);
+
+    expect(taggedSql).toContain(`utm_source.2 = ''`);
+  });
+
+  it('splits = filters on different event types into separate IN bridges', () => {
+    const { taggedSql } = buildSubQuery([
+      makeFilter('custom_event_name', '=', ['signup'], 'filter-1'),
+      makeFilter('outbound_link_url', '=', ['https://example.com*'], 'filter-2'),
+    ]);
+
+    expect(taggedSql.match(/session_id IN \( SELECT/g)).toHaveLength(2);
+    expect(taggedSql).toMatch(/event_type = 'custom' AND arrayExists\(pattern -> custom_event_name/);
+    expect(taggedSql).toMatch(/event_type = 'outbound_link' AND arrayExists\(pattern -> outbound_link_url/);
+  });
+
+  it('keeps same-event conjunction for url combined with a guarded column', () => {
+    const { taggedSql } = buildSubQuery([
+      makeFilter('custom_event_name', '=', ['signup'], 'filter-1'),
+      makeFilter('url', '=', ['/pricing'], 'filter-2'),
+    ]);
+
+    expect(taggedSql.match(/session_id IN \( SELECT/g)).toHaveLength(1);
+    expect(taggedSql).toMatch(/custom_event_name ILIKE pattern.*AND.*arrayExists\(pattern -> url ILIKE pattern/);
+  });
+
+  it('keeps gp bare wildcard as session-level key existence', () => {
+    const equals = buildSubQuery([makeFilter('gp.plan', '=', ['*'])]);
+    const notEquals = buildSubQuery([makeFilter('gp.plan', '!=', ['*'])]);
+
+    expect(equals.taggedSql).toMatch(/arrayExists\(t -> t\.1 = \{gp_key_[0-9a-f]+:String\}, all_props\)/);
+    expect(notEquals.taggedSql).toMatch(/NOT arrayExists\(t -> t\.1 = \{gp_key_[0-9a-f]+:String\}, all_props\)/);
+  });
+
   it('keeps != on session-native columns as an inline per-session predicate', () => {
     const { taggedSql } = buildSubQuery([makeFilter('device_type', '!=', ['mobile'])]);
 

--- a/dashboard/src/lib/ba-session-query.ts
+++ b/dashboard/src/lib/ba-session-query.ts
@@ -10,7 +10,12 @@ import { GranularityRangeValues } from '@/utils/granularityRanges';
 import { z } from 'zod';
 import { safeSql, SQL, type SQLTaggedExpression } from './safe-sql';
 import { DateTimeString } from '@/types/dates';
-import { filterColumnSql, filterColumnSqlForSession } from './filter-sql';
+import {
+  filterColumnSql,
+  filterColumnSqlForSession,
+  isMatchAnyValueFilter,
+  matchAnyValueFilterSql,
+} from './filter-sql';
 
 // Filters
 const MAIN_TABLE_FILTERS: TableFilterColumn[] = [
@@ -287,8 +292,7 @@ function buildGlobalPropertyFilterQuery(filter: GpFilter) {
   const key = SQL.String({ [`gp_key_${filterHash}`]: filter.gpKey });
   const isEquals = filter.rawOperator === '=';
 
-  const isMatchAnyValue = filter.values.length === 1 && filter.values[0] === '%';
-  if (isMatchAnyValue) {
+  if (isMatchAnyValueFilter(filter.values)) {
     return isEquals
       ? safeSql`arrayExists(t -> t.1 = ${key}, all_props)`
       : safeSql`NOT arrayExists(t -> t.1 = ${key}, all_props)`;
@@ -301,17 +305,15 @@ function buildGlobalPropertyFilterQuery(filter: GpFilter) {
 
 function buildSessionFilterQuery(filter: StandardFilter) {
   const column = filterColumnSqlForSession(filter.col, SESSION_TUPLE_COLUMNS);
-  const isMatchAnyValue = filter.values.length === 1 && filter.values[0] === '%';
-  if (isMatchAnyValue) {
-    return filter.rawOperator === '=' ? safeSql`${column} != ''` : safeSql`${column} = ''`;
-  }
-
   const filterHash = hashFilterQuery(filter);
   const values = SQL.StringArray({ [`query_filter_${filterHash}`]: filter.values });
   const quantifier = filter.operator.quantifier;
   const operator = filter.operator.operater;
 
-  return safeSql`${quantifier}(pattern -> ${column} ${operator} pattern, ${values})`;
+  return (
+    matchAnyValueFilterSql(filter.values, filter.rawOperator, column, filter.col) ??
+    safeSql`${quantifier}(pattern -> ${column} ${operator} pattern, ${values})`
+  );
 }
 
 // Utility for granularity

--- a/dashboard/src/lib/ba-session-query.ts
+++ b/dashboard/src/lib/ba-session-query.ts
@@ -184,7 +184,7 @@ function getSessionFilterQuery(
 /**
  * Bridge event-scoped columns through analytics.events, since they don't exist
  * on session rows. `=` means "the session has a matching event"; `!=` must
- * exclude the whole session, so it becomes NOT IN over the positive match — a
+ * exclude the whole session, so it becomes NOT IN over the positive match - a
  * per-event NOT ILIKE inside IN would pass any session with at least one other event.
  */
 function buildEventsBridgeQueries(
@@ -196,31 +196,61 @@ function buildEventsBridgeQueries(
   const bridge = (predicate: SQLTaggedExpression) =>
     safeSql`( SELECT session_id FROM analytics.events WHERE site_id = ${SQL.String({ siteId })} AND timestamp BETWEEN ${SQL.DateTime({ startDate })} AND ${SQL.DateTime({ endDate })} AND ${predicate} )`;
 
-  const includes = eventsFilters
-    .filter((filter) => filter.rawOperator === '=')
-    .map((filter) => buildFilterQuery(filter));
+  const includes = eventsFilters.filter((filter) => filter.rawOperator === '=');
   const excludes = eventsFilters
     .filter((filter) => filter.rawOperator === '!=')
     .map((filter) => buildEventMatchQuery(filter));
 
+  const includeBridges = buildIncludePredicates(includes).map(
+    (predicate) => safeSql`session_id IN ${bridge(predicate)}`,
+  );
+
   return [
-    ...(includes.length > 0 ? [safeSql`session_id IN ${bridge(SQL.AND(includes))}`] : []),
+    ...includeBridges,
     ...(excludes.length > 0 ? [safeSql`session_id NOT IN ${bridge(safeSql`(${SQL.OR(excludes)})`)}`] : []),
   ];
 }
 
+/**
+ * One IN-bridge per event type: columns carried by different event types can
+ * never match on the same event row, so conjoining their guarded predicates
+ * per-event would be unsatisfiable. Unguarded columns (url, event_type) join
+ * every bridge, preserving same-event conjunction semantics within each type.
+ */
+function buildIncludePredicates(includes: StandardFilter[]) {
+  if (includes.length === 0) {
+    return [];
+  }
+
+  const guardOf = (filter: StandardFilter) => EVENT_MATCH_TYPE_GUARDS[filter.col];
+  const guards = [...new Set(includes.map(guardOf))].filter((guard) => guard !== undefined);
+  const unguarded = includes.filter((filter) => !guardOf(filter)).map((filter) => buildFilterQuery(filter));
+
+  if (guards.length === 0) {
+    return [SQL.AND(unguarded)];
+  }
+
+  return guards.map((guard) =>
+    SQL.AND([
+      ...includes.filter((filter) => guardOf(filter) === guard).map((filter) => buildFilterQuery(filter)),
+      ...unguarded,
+    ]),
+  );
+}
+
+/**
+ * Pins event-scoped columns to the only event type that carries them. This
+ * prunes both bridge subqueries on the (site_id, event_type, date) primary key
+ * and keeps all-wildcard patterns (`*` → `%`) from matching events where the
+ * column is unset - so `custom_event_name != *` reads "sessions with no custom
+ * events" and `custom_event_name = *` reads "sessions with at least one".
+ */
 const EVENT_MATCH_TYPE_GUARDS: Partial<Record<TableFilterColumn, SQLTaggedExpression>> = {
   custom_event_name: safeSql`event_type = 'custom'`,
   outbound_link_url: safeSql`event_type = 'outbound_link'`,
 };
 
-/**
- * Positive per-event match used by the NOT IN bridge. The event_type guard pins
- * columns to the only event type that carries them, which both prunes on the
- * (site_id, event_type, date) primary key and keeps all-wildcard patterns
- * (`*` → `%`) from matching events where the column is unset — so
- * `custom_event_name != *` reads "sessions with no custom events".
- */
+// Positive per-event match for filters negated at the session level via NOT IN
 function buildEventMatchQuery(filter: StandardFilter) {
   const filterHash = hashFilterQuery(filter);
   const values = SQL.StringArray({ [`query_filter_${filterHash}`]: filter.values });
@@ -243,7 +273,9 @@ function buildFilterQuery(filter: StandardFilter) {
   const filterHash = hashFilterQuery(filter);
   const values = SQL.StringArray({ [`query_filter_${filterHash}`]: filter.values });
   const column = filterColumnSql(filter.col);
-  return safeSql`${filter.operator.quantifier}(pattern -> ${column} ${filter.operator.operater} pattern, ${values})`;
+  const match = safeSql`${filter.operator.quantifier}(pattern -> ${column} ${filter.operator.operater} pattern, ${values})`;
+  const guard = EVENT_MATCH_TYPE_GUARDS[filter.col];
+  return guard ? safeSql`(${guard} AND ${match})` : match;
 }
 
 // Global-property filter against the unioned all_props on analytics.sessions.
@@ -269,6 +301,11 @@ function buildGlobalPropertyFilterQuery(filter: GpFilter) {
 
 function buildSessionFilterQuery(filter: StandardFilter) {
   const column = filterColumnSqlForSession(filter.col, SESSION_TUPLE_COLUMNS);
+  const isMatchAnyValue = filter.values.length === 1 && filter.values[0] === '%';
+  if (isMatchAnyValue) {
+    return filter.rawOperator === '=' ? safeSql`${column} != ''` : safeSql`${column} = ''`;
+  }
+
   const filterHash = hashFilterQuery(filter);
   const values = SQL.StringArray({ [`query_filter_${filterHash}`]: filter.values });
   const quantifier = filter.operator.quantifier;

--- a/dashboard/src/lib/filter-sql.ts
+++ b/dashboard/src/lib/filter-sql.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { FILTER_COLUMNS, type TableFilterColumn } from '@/entities/analytics/filter.entities';
-import { SQL, safeSql } from './safe-sql';
+import { SQL, safeSql, type SQLTaggedExpression } from './safe-sql';
 
 const TABLE_COLUMN_SCHEMA = z.enum(FILTER_COLUMNS);
 
@@ -29,4 +29,32 @@ export function filterColumnSqlForSession(col: TableFilterColumn, tupleColumns: 
   const isTuple = !FILTER_COLUMN_SQL_OVERRIDES[parsed] && tupleColumns.includes(parsed);
 
   return isTuple ? safeSql`${sql}.2` : sql;
+}
+
+/**
+ * A lone bare wildcard (`*`, or `%` in builders that transform patterns before
+ * checking) means "match any value". ClickHouse evaluates `'' ILIKE '%'` as
+ * true, so pattern matching would also match rows where the column is unset -
+ * builders special-case such filters into a presence check instead.
+ */
+export function isMatchAnyValueFilter(values: string[]) {
+  return values.length === 1 && (values[0] === '*' || values[0] === '%');
+}
+
+/**
+ * Presence check for a bare wildcard filter: `= *` keeps rows where the value
+ * is set, `!= *` keeps rows where it is absent. Returns null when the filter
+ * is not a bare wildcard, or for `event_type` - it is an Enum8, so comparing
+ * it to '' throws, and it is never unset anyway.
+ */
+export function matchAnyValueFilterSql(
+  values: string[],
+  operator: '=' | '!=',
+  column: SQLTaggedExpression,
+  col?: TableFilterColumn,
+): SQLTaggedExpression | null {
+  if (!isMatchAnyValueFilter(values) || col === 'event_type') {
+    return null;
+  }
+  return operator === '=' ? safeSql`${column} != ''` : safeSql`${column} = ''`;
 }

--- a/docs/src/content/dashboard/filtering.mdx
+++ b/docs/src/content/dashboard/filtering.mdx
@@ -132,12 +132,19 @@ Use the asterisk (`*`) character for flexible pattern matching:
 - `*example` - Matches anything **ending** with "example"
 - `example*` - Matches anything **starting** with "example"
 - `*example*` - Matches anything **containing** "example"
+- `*` on its own - Matches any **non-empty** value
 
 **Real-world examples:**
 - **URL is `/blog/*`** - All blog pages and subpages
 - **Browser is `*Chrome*`** - All Chrome variants (Chrome, Chrome Mobile, etc.)
 - **UTM source is `*google*`** - All Google traffic sources (google, google-ads, google-organic)
 - **Event is `*click*`** - All click-related events (button-click, link-click, etc.)
+
+**Checking presence or absence:**
+
+A bare `*` works as a presence check, since it only matches values that are actually set:
+- **UTM source is `*`** - Only traffic that arrived with a UTM source
+- **Event is not `*`** - Sessions that never fired a custom event
 
 ## Working with multiple filters
 


### PR DESCRIPTION
## Bare wildcard (*) filter values now mean value present or absent

Filtering with a bare `*` now does something useful: `column = *` keeps only rows where the column has a value, and `column != *` keeps only rows where it does not.

## Description of why

Closes #984. Until now a bare `*` was a silent no-op on columns that can be empty, because an empty string happily matches `ILIKE '%'`. Filters like `custom_event_name = *` or `utm_source != *` looked like they worked but changed nothing. Global-property filters already treat `gp.key = *` as "key exists", so this brings regular columns in line with them.

The change lands in all three query builders - event grain, session grain, and the hourly materialized-view fast paths - so a page gives the same answer no matter which path serves it.

## Changes

- A filter whose only value is `*` (or a literal `%`, which is indistinguishable after the wildcard transform) now compiles to `col != ''` or `col = ''` instead of an ILIKE pattern. `event_type` is exempt because it is an Enum8, and comparing an Enum8 to an empty string throws.
- On session pages, equals filters on event columns now get the same event-type guards the not-equals side got in #985, letting ClickHouse prune on the primary key. The bridge also builds one subquery per event type, so combining `Event = *` with `Outbound link = *` means "the session did both" rather than matching nothing.
- Added 24 unit tests across the three builders, including a fast/slow-path parity check.

## Additional Notes

- Stacked on #985 - the base branch is the 973 one; retarget to main once that merges.
- This deliberately changes what saved filters containing `*` return, so it deserves a line in the next release changelog.
- `referrer_source = *` and `!= *` still do nothing, since that column is never empty (it defaults to `direct`). Whether `!= *` should mean "direct traffic" is an open product question, left out of scope here.