### PR TITLE
Added referrer domain click filtering to Traffic Sources

### DIFF
--- a/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/(overview)/CustomEventsSection.tsx
+++ b/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/(overview)/CustomEventsSection.tsx
@@ -1,20 +1,19 @@
 'use client';
 
-import MultiProgressTable from '@/components/MultiProgressTable';
+import MultiProgressTable, { type ProgressBarData } from '@/components/MultiProgressTable';
 import { useTranslations } from 'next-intl';
 import { FilterPreservingLink } from '@/components/ui/FilterPreservingLink';
 import { ArrowRight } from 'lucide-react';
-import { useFilterClick } from '@/hooks/use-filter-click';
+import { useProgressTableFilterClick } from '@/hooks/use-progress-table-filter-click';
 import { useState } from 'react';
 import { useBAQueryParams } from '@/trpc/hooks';
 import { trpc } from '@/trpc/client';
 import { useQueryState } from '@/hooks/use-query-state';
-import { isFilterColumn } from '@/entities/analytics/filter.entities';
 
 export default function CustomEventsSection() {
   const [activeTab, setActiveTab] = useState('events');
   const { input, options } = useBAQueryParams();
-  const { applyFilter } = useFilterClick({ behavior: 'replace-same-column' });
+  const { onItemClick, isItemInteractive } = useProgressTableFilterClick();
   const t = useTranslations('dashboard');
 
   const eventsQuery = trpc.events.customEventsOverview.useQuery(input, {
@@ -30,22 +29,6 @@ export default function CustomEventsSection() {
   const propertiesState = useQueryState(propertiesQuery, activeTab === 'properties');
   const activeState = { events: eventsState, properties: propertiesState }[activeTab as 'events' | 'properties'];
 
-  const onItemClick = (
-    tabKey: string,
-    item: { label: string; key?: string; children?: unknown[]; filterValue?: string; filterColumn?: string },
-  ) => {
-    if (tabKey === 'events') {
-      return applyFilter('custom_event_name', item.label);
-    }
-
-    if (tabKey === 'properties' && item.filterColumn) {
-      const filterColumn = item.filterColumn;
-      if (isFilterColumn(filterColumn)) {
-        return applyFilter(filterColumn, item.filterValue ?? '*');
-      }
-    }
-  };
-
   return (
     <MultiProgressTable
       title={t('sections.events')}
@@ -53,24 +36,28 @@ export default function CustomEventsSection() {
       defaultTab='events'
       onTabChange={setActiveTab}
       onItemClick={onItemClick}
+      isItemInteractive={isItemInteractive}
       tabs={[
         {
           key: 'events',
           label: t('tabs.events'),
           loading: eventsState.loading,
-          data: (eventsQuery.data ?? []).map((event) => ({
-            label: event.event_name,
-            value: event.current.count,
-            trendPercentage: event.change?.count,
-            comparisonValue: event.compare?.count,
-          })),
+          data: (eventsQuery.data ?? []).map(
+            (event): ProgressBarData => ({
+              label: event.event_name,
+              value: event.current.count,
+              trendPercentage: event.change?.count,
+              comparisonValue: event.compare?.count,
+              filterColumn: 'custom_event_name',
+            }),
+          ),
         },
         {
           key: 'properties',
           label: t('tabs.topProperties'),
           loading: propertiesState.loading,
-          data: (propertiesQuery.data ?? []).map((prop) => {
-            const filterKey = `gp.${prop.property_key}`;
+          data: (propertiesQuery.data ?? []).map((prop): ProgressBarData => {
+            const filterKey = `gp.${prop.property_key}` as const;
             return {
               key: filterKey,
               label: prop.property_key,
@@ -78,14 +65,16 @@ export default function CustomEventsSection() {
               trendPercentage: prop.change?.percentage,
               comparisonValue: prop.compare?.visitors,
               filterColumn: filterKey,
-              children: prop.children.map((v) => ({
-                filterValue: v.value,
-                filterColumn: filterKey,
-                label: v.value,
-                value: v.current.visitors,
-                trendPercentage: v.change?.percentage,
-                comparisonValue: v.compare?.visitors,
-              })),
+              filterValue: '*',
+              children: prop.children.map(
+                (v): ProgressBarData => ({
+                  filterColumn: filterKey,
+                  label: v.value,
+                  value: v.current.visitors,
+                  trendPercentage: v.change?.percentage,
+                  comparisonValue: v.compare?.visitors,
+                }),
+              ),
             };
           }),
         },

--- a/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/(overview)/DevicesSection.tsx
+++ b/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/(overview)/DevicesSection.tsx
@@ -1,12 +1,12 @@
 'use client';
-import MultiProgressTable from '@/components/MultiProgressTable';
+import MultiProgressTable, { type ProgressBarData } from '@/components/MultiProgressTable';
 import { BrowserIcon } from '@/components/icons/BrowserIcon';
 import { DeviceIcon } from '@/components/icons/DeviceIcon';
 import { OSIcon } from '@/components/icons/OSIcon';
 import { useTranslations } from 'next-intl';
 import { FilterPreservingLink } from '@/components/ui/FilterPreservingLink';
 import { ArrowRight } from 'lucide-react';
-import { useFilterClick } from '@/hooks/use-filter-click';
+import { useProgressTableFilterClick } from '@/hooks/use-progress-table-filter-click';
 import { useState } from 'react';
 import { useBAQueryParams } from '@/trpc/hooks';
 import { trpc } from '@/trpc/client';
@@ -15,7 +15,7 @@ import { useQueryState } from '@/hooks/use-query-state';
 export default function DevicesSection() {
   const [activeTab, setActiveTab] = useState('browsers');
   const t = useTranslations('dashboard');
-  const { makeFilterClick } = useFilterClick({ behavior: 'replace-same-column' });
+  const { onItemClick, isItemInteractive } = useProgressTableFilterClick();
   const { input, options } = useBAQueryParams();
 
   const browsersQuery = trpc.devices.browserRollup.useQuery(input, {
@@ -32,13 +32,6 @@ export default function DevicesSection() {
     activeTab as 'browsers' | 'os' | 'devices'
   ];
 
-  const onItemClick = (tabKey: string, item: { label: string; key?: string; filterValue?: string }) => {
-    const filterValue = item.filterValue ?? item.label;
-    if (tabKey === 'browsers') return makeFilterClick('browser')(filterValue);
-    if (tabKey === 'devices') return makeFilterClick('device_type')(filterValue);
-    if (tabKey === 'os') return makeFilterClick('os')(filterValue);
-  };
-
   return (
     <MultiProgressTable
       title={t('sections.devicesBreakdown')}
@@ -46,60 +39,74 @@ export default function DevicesSection() {
       defaultTab='browsers'
       onTabChange={setActiveTab}
       onItemClick={onItemClick}
+      isItemInteractive={isItemInteractive}
       tabs={[
         {
           key: 'browsers',
           label: t('tabs.browsers'),
           loading: browsersState.loading,
-          data: (browsersQuery.data ?? []).map((item) => ({
-            label: item.browser,
-            value: item.current.visitors,
-            trendPercentage: item.change?.visitors,
-            comparisonValue: item.compare?.visitors,
-            filterValue: item.browser,
-            icon: <BrowserIcon name={item.browser} className='h-4 w-4' />,
-            children: item.children?.map((v) => ({
-              filterValue: item.browser,
+          data: (browsersQuery.data ?? []).map(
+            (item): ProgressBarData => ({
+              label: item.browser,
+              value: item.current.visitors,
+              trendPercentage: item.change?.visitors,
+              comparisonValue: item.compare?.visitors,
+              filterColumn: 'browser',
               icon: <BrowserIcon name={item.browser} className='h-4 w-4' />,
-              label: `${item.browser} ${v.version}`,
-              value: v.current.visitors,
-              comparisonValue: v.compare?.visitors,
-              trendPercentage: v.change?.visitors,
-            })),
-          })),
+              children: item.children?.map(
+                (v): ProgressBarData => ({
+                  filterColumn: 'browser',
+                  filterValue: item.browser,
+                  icon: <BrowserIcon name={item.browser} className='h-4 w-4' />,
+                  label: `${item.browser} ${v.version}`,
+                  value: v.current.visitors,
+                  comparisonValue: v.compare?.visitors,
+                  trendPercentage: v.change?.visitors,
+                }),
+              ),
+            }),
+          ),
         },
         {
           key: 'os',
           label: t('tabs.operatingSystems'),
           loading: osState.loading,
-          data: (osQuery.data ?? []).map((item) => ({
-            label: item.os,
-            value: item.current.visitors,
-            trendPercentage: item.change?.visitors,
-            comparisonValue: item.compare?.visitors,
-            filterValue: item.os,
-            icon: <OSIcon name={item.os} className='h-4 w-4' />,
-            children: item.children?.map((v) => ({
-              filterValue: item.os,
+          data: (osQuery.data ?? []).map(
+            (item): ProgressBarData => ({
+              label: item.os,
+              value: item.current.visitors,
+              trendPercentage: item.change?.visitors,
+              comparisonValue: item.compare?.visitors,
+              filterColumn: 'os',
               icon: <OSIcon name={item.os} className='h-4 w-4' />,
-              label: `${item.os} ${v.version}`,
-              value: v.current.visitors,
-              comparisonValue: v.compare?.visitors,
-              trendPercentage: v.change?.visitors,
-            })),
-          })),
+              children: item.children?.map(
+                (v): ProgressBarData => ({
+                  filterColumn: 'os',
+                  filterValue: item.os,
+                  icon: <OSIcon name={item.os} className='h-4 w-4' />,
+                  label: `${item.os} ${v.version}`,
+                  value: v.current.visitors,
+                  comparisonValue: v.compare?.visitors,
+                  trendPercentage: v.change?.visitors,
+                }),
+              ),
+            }),
+          ),
         },
         {
           key: 'devices',
           label: t('tabs.devices'),
           loading: devicesState.loading,
-          data: (devicesQuery.data ?? []).map((item) => ({
-            label: item.device_type,
-            value: item.current.visitors,
-            trendPercentage: item.change?.visitors,
-            comparisonValue: item.compare?.visitors,
-            icon: <DeviceIcon type={item.device_type} className='h-4 w-4' />,
-          })),
+          data: (devicesQuery.data ?? []).map(
+            (item): ProgressBarData => ({
+              label: item.device_type,
+              value: item.current.visitors,
+              trendPercentage: item.change?.visitors,
+              comparisonValue: item.compare?.visitors,
+              filterColumn: 'device_type',
+              icon: <DeviceIcon type={item.device_type} className='h-4 w-4' />,
+            }),
+          ),
         },
       ]}
       footer={

--- a/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/(overview)/GeographySection.tsx
+++ b/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/(overview)/GeographySection.tsx
@@ -1,5 +1,5 @@
 'use client';
-import MultiProgressTable from '@/components/MultiProgressTable';
+import MultiProgressTable, { type ProgressBarData } from '@/components/MultiProgressTable';
 import { getCountryName } from '@/utils/countryCodes';
 import { getSubdivisionName } from '@/utils/subdivisionCodes';
 import { useState } from 'react';
@@ -7,9 +7,8 @@ import { FlagIcon, FlagIconProps } from '@/components/icons';
 import { FilterPreservingLink } from '@/components/ui/FilterPreservingLink';
 import { ArrowRight } from 'lucide-react';
 import { useLocale, useTranslations } from 'next-intl';
-import { useFilterClick } from '@/hooks/use-filter-click';
+import { useProgressTableFilterClick } from '@/hooks/use-progress-table-filter-click';
 import { type GeoLevel } from '@/entities/analytics/geography.entities';
-import type { FilterColumn } from '@/entities/analytics/filter.entities';
 import type { SupportedLanguages } from '@/constants/i18n';
 import dynamic from 'next/dynamic';
 import { useBAQueryParams } from '@/trpc/hooks';
@@ -48,7 +47,7 @@ export default function GeographySection({ enabledLevels }: GeographySectionProp
 
   const t = useTranslations('dashboard');
   const locale = useLocale();
-  const { makeFilterClick } = useFilterClick({ behavior: 'replace-same-column' });
+  const { onItemClick, isItemInteractive } = useProgressTableFilterClick();
 
   const geoLevelTabLabels = {
     country_code: t('tabs.countries'),
@@ -72,19 +71,23 @@ export default function GeographySection({ enabledLevels }: GeographySectionProp
       key: level,
       label: geoLevelTabLabels[level],
       loading: stateForLevel.loading,
-      data: (data ?? []).map((item) => ({
-        label: GEO_LABEL_FORMATTERS[level](item[level], locale),
-        key: item[level],
-        value: item.current.visitors,
-        trendPercentage: item.change?.visitors,
-        comparisonValue: item.compare?.visitors,
-        icon: (
-          <FlagIcon
-            countryCode={item.current.country_code as FlagIconProps['countryCode']}
-            countryName={getCountryName(item.current.country_code, locale)}
-          />
-        ),
-      })),
+      data: (data ?? []).map(
+        (item): ProgressBarData => ({
+          label: GEO_LABEL_FORMATTERS[level](item[level], locale),
+          key: item[level],
+          value: item.current.visitors,
+          trendPercentage: item.change?.visitors,
+          comparisonValue: item.compare?.visitors,
+          filterColumn: item[level] ? level : undefined,
+          filterValue: item[level],
+          icon: (
+            <FlagIcon
+              countryCode={item.current.country_code as FlagIconProps['countryCode']}
+              countryName={getCountryName(item.current.country_code, locale)}
+            />
+          ),
+        }),
+      ),
     };
   });
 
@@ -96,10 +99,6 @@ export default function GeographySection({ enabledLevels }: GeographySectionProp
     worldmap: worldMapState,
   }[activeTab as 'country_code' | 'subdivision_code' | 'city' | 'worldmap'];
 
-  const onItemClick = (tabKey: string, item: { key?: string }) => {
-    if (item.key) makeFilterClick(tabKey as FilterColumn)(item.key);
-  };
-
   return (
     <MultiProgressTable
       title={t('sections.geography')}
@@ -107,6 +106,7 @@ export default function GeographySection({ enabledLevels }: GeographySectionProp
       defaultTab={activeTab}
       onTabChange={setActiveTab}
       onItemClick={onItemClick}
+      isItemInteractive={isItemInteractive}
       tabs={[
         ...geoLevelTabs,
         {

--- a/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/(overview)/PagesAnalyticsSection.tsx
+++ b/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/(overview)/PagesAnalyticsSection.tsx
@@ -1,9 +1,9 @@
 'use client';
-import MultiProgressTable from '@/components/MultiProgressTable';
+import MultiProgressTable, { type ProgressBarData } from '@/components/MultiProgressTable';
 import { useTranslations } from 'next-intl';
 import { FilterPreservingLink } from '@/components/ui/FilterPreservingLink';
 import { ArrowRight } from 'lucide-react';
-import { useFilterClick } from '@/hooks/use-filter-click';
+import { useProgressTableFilterClick } from '@/hooks/use-progress-table-filter-click';
 import { useState } from 'react';
 import { useBAQueryParams } from '@/trpc/hooks';
 import { trpc } from '@/trpc/client';
@@ -12,7 +12,7 @@ import { useQueryState } from '@/hooks/use-query-state';
 export default function PagesAnalyticsSection() {
   const [activeTab, setActiveTab] = useState('pages');
   const t = useTranslations('dashboard');
-  const { makeFilterClick } = useFilterClick({ behavior: 'replace-same-column' });
+  const { onItemClick, isItemInteractive } = useProgressTableFilterClick();
   const { input, options } = useBAQueryParams();
 
   const pagesQuery = trpc.overview.topPages.useQuery(input, { ...options, enabled: activeTab === 'pages' });
@@ -24,20 +24,17 @@ export default function PagesAnalyticsSection() {
   const exitState = useQueryState(exitQuery, activeTab === 'exit');
   const activeState = { pages: pagesState, entry: entryState, exit: exitState }[activeTab as 'pages' | 'entry' | 'exit'];
 
-  const onItemClick = (_tabKey: string, item: { label: string }) => {
-    return makeFilterClick('url')(item.label);
-  };
-
   const mapPage = (page: {
     url: string;
     current: { visitors: number };
     change?: { visitors: number };
     compare?: { visitors: number };
-  }) => ({
+  }): ProgressBarData => ({
     label: page.url,
     value: page.current.visitors,
     trendPercentage: page.change?.visitors,
     comparisonValue: page.compare?.visitors,
+    filterColumn: 'url',
   });
 
   return (
@@ -47,6 +44,7 @@ export default function PagesAnalyticsSection() {
       defaultTab='pages'
       onTabChange={setActiveTab}
       onItemClick={onItemClick}
+      isItemInteractive={isItemInteractive}
       tabs={[
         {
           key: 'pages',

--- a/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/(overview)/TrafficSourcesSection.tsx
+++ b/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/(overview)/TrafficSourcesSection.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import MultiProgressTable from '@/components/MultiProgressTable';
+import MultiProgressTable, { type ProgressBarData } from '@/components/MultiProgressTable';
 import { useTranslations } from 'next-intl';
 import { FilterPreservingLink } from '@/components/ui/FilterPreservingLink';
 import { ArrowRight } from 'lucide-react';
-import { useFilterClick } from '@/hooks/use-filter-click';
+import { useProgressTableFilterClick } from '@/hooks/use-progress-table-filter-click';
 import { useState } from 'react';
 import { useBAQueryParams } from '@/trpc/hooks';
 import { trpc } from '@/trpc/client';
@@ -13,7 +13,7 @@ import { useQueryState } from '@/hooks/use-query-state';
 export default function TrafficSourcesSection() {
   const [activeTab, setActiveTab] = useState('referrers');
   const t = useTranslations('dashboard');
-  const { makeFilterClick } = useFilterClick({ behavior: 'replace-same-column' });
+  const { onItemClick, isItemInteractive } = useProgressTableFilterClick();
   const { input, options } = useBAQueryParams();
 
   const referrersQuery = trpc.referrers.referrerUrlRollup.useQuery(input, {
@@ -31,16 +31,6 @@ export default function TrafficSourcesSection() {
     activeTab as 'referrers' | 'channels'
   ];
 
-  const onItemClick = (tabKey: string, item: { label: string; children?: unknown[] }) => {
-    if (tabKey === 'referrers') {
-      if (item.children) return;
-      return makeFilterClick('referrer_url')(item.label);
-    }
-    if (tabKey === 'channels') return makeFilterClick('referrer_source')(item.label);
-  };
-
-  const isItemInteractive = (tabKey: string) => tabKey === 'referrers' || tabKey === 'channels';
-
   return (
     <MultiProgressTable
       title={t('sections.trafficSources')}
@@ -48,35 +38,44 @@ export default function TrafficSourcesSection() {
       defaultTab='referrers'
       onTabChange={setActiveTab}
       onItemClick={onItemClick}
-      isItemInteractive={(tabKey) => isItemInteractive(tabKey)}
+      isItemInteractive={isItemInteractive}
       tabs={[
         {
           key: 'referrers',
           label: t('tabs.referrers'),
           loading: referrersState.loading,
-          data: (referrersQuery.data ?? []).map((item) => ({
-            label: item.source_name,
-            value: item.current.visitors,
-            trendPercentage: item.change?.visitors,
-            comparisonValue: item.compare?.visitors,
-            children: item.children?.map((child) => ({
-              label: child.referrer_url,
-              value: child.current.visitors,
-              trendPercentage: child.change?.visitors,
-              comparisonValue: child.compare?.visitors,
-            })),
-          })),
+          data: (referrersQuery.data ?? []).map(
+            (item): ProgressBarData => ({
+              label: item.source_name,
+              value: item.current.visitors,
+              trendPercentage: item.change?.visitors,
+              comparisonValue: item.compare?.visitors,
+              filterColumn: 'referrer_source_name',
+              children: item.children?.map(
+                (child): ProgressBarData => ({
+                  label: child.referrer_url,
+                  value: child.current.visitors,
+                  trendPercentage: child.change?.visitors,
+                  comparisonValue: child.compare?.visitors,
+                  filterColumn: 'referrer_url',
+                }),
+              ),
+            }),
+          ),
         },
         {
           key: 'channels',
           label: t('tabs.channels'),
           loading: channelsState.loading,
-          data: (channelsQuery.data ?? []).map((item) => ({
-            label: item.channel,
-            value: item.current.visits,
-            trendPercentage: item.change?.visits,
-            comparisonValue: item.compare?.visits,
-          })),
+          data: (channelsQuery.data ?? []).map(
+            (item): ProgressBarData => ({
+              label: item.channel,
+              value: item.current.visits,
+              trendPercentage: item.change?.visits,
+              comparisonValue: item.compare?.visits,
+              filterColumn: 'referrer_source',
+            }),
+          ),
         },
       ]}
       footer={

--- a/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/(overview)/TrafficSourcesSection.tsx
+++ b/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/(overview)/TrafficSourcesSection.tsx
@@ -50,7 +50,8 @@ export default function TrafficSourcesSection() {
               value: item.current.visitors,
               trendPercentage: item.change?.visitors,
               comparisonValue: item.compare?.visitors,
-              filterColumn: 'referrer_source_name',
+              filterColumn: item.stored_source_name ? 'referrer_source_name' : undefined,
+              filterValue: item.stored_source_name ?? undefined,
               children: item.children?.map(
                 (child): ProgressBarData => ({
                   label: child.referrer_url,

--- a/dashboard/src/components/MultiProgressTable.tsx
+++ b/dashboard/src/components/MultiProgressTable.tsx
@@ -12,14 +12,17 @@ import { Button } from '@/components/ui/button';
 import { Spinner } from '@/components/ui/spinner';
 import MultiProgressTableRowSkeleton from '@/components/skeleton/MultiProgressTableSkeleton';
 import { cn } from '@/lib/utils';
+import type { FilterColumn } from '@/entities/analytics/filter.entities';
 
-interface ProgressBarData {
+export interface ProgressBarData {
   label: string;
   value: number;
   key?: string;
   trendPercentage?: number;
   comparisonValue?: number;
   icon?: React.ReactElement;
+  filterColumn?: FilterColumn;
+  filterValue?: string;
   children?: ProgressBarData[];
 }
 

--- a/dashboard/src/entities/analytics/referrers.entities.ts
+++ b/dashboard/src/entities/analytics/referrers.entities.ts
@@ -51,6 +51,7 @@ export const ReferrerUrlRollupRowSchema = z.object({
   source_name: z.string(),
   referrer_url: z.string().nullable(),
   visitors: z.number(),
+  stored_source_name: z.string().nullable(),
   is_rollup: z.preprocess(rollupToBoolean, z.boolean()),
 });
 

--- a/dashboard/src/hooks/use-progress-table-filter-click.ts
+++ b/dashboard/src/hooks/use-progress-table-filter-click.ts
@@ -5,6 +5,11 @@ import { useFilterClick } from '@/hooks/use-filter-click';
 import { isFilterColumn } from '@/entities/analytics/filter.entities';
 import type { ProgressBarData } from '@/components/MultiProgressTable';
 
+/**
+ * Data-driven click handling for MultiProgressTable rows: a row is interactive
+ * iff it declares a `filterColumn`, and clicking it applies `filterValue ?? label`
+ * to that column.
+ */
 export function useProgressTableFilterClick() {
   const { applyFilter } = useFilterClick({ behavior: 'replace-same-column' });
 

--- a/dashboard/src/hooks/use-progress-table-filter-click.ts
+++ b/dashboard/src/hooks/use-progress-table-filter-click.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useFilterClick } from '@/hooks/use-filter-click';
+import { isFilterColumn } from '@/entities/analytics/filter.entities';
+import type { ProgressBarData } from '@/components/MultiProgressTable';
+
+export function useProgressTableFilterClick() {
+  const { applyFilter } = useFilterClick({ behavior: 'replace-same-column' });
+
+  const onItemClick = useCallback(
+    (_tabKey: string, item: ProgressBarData) => {
+      if (!item.filterColumn || !isFilterColumn(item.filterColumn)) return;
+      applyFilter(item.filterColumn, item.filterValue ?? item.label);
+    },
+    [applyFilter],
+  );
+
+  const isItemInteractive = useCallback(
+    (_tabKey: string, item: ProgressBarData) => Boolean(item.filterColumn),
+    [],
+  );
+
+  return { onItemClick, isItemInteractive };
+}

--- a/dashboard/src/repositories/clickhouse/referrers.repository.ts
+++ b/dashboard/src/repositories/clickhouse/referrers.repository.ts
@@ -176,6 +176,7 @@ export async function getReferrerUrlRollup(
       SELECT
         cutToFirstSignificantSubdomain(concat('http://', referrer_url)) as source_name,
         referrer_url,
+        referrer_source_name,
         session_id,
         _sample_factor
       FROM analytics.events ${sample}
@@ -198,6 +199,7 @@ export async function getReferrerUrlRollup(
       source_name,
       referrer_url,
       uniq(session_id) * any(_sample_factor) as visitors,
+      any(nullIf(referrer_source_name, '')) as stored_source_name,
       grouping(referrer_url) as is_rollup
     FROM enriched
     WHERE source_name IN (SELECT source_name FROM top_parents)

--- a/dashboard/src/repositories/clickhouse/referrers.repository.ts
+++ b/dashboard/src/repositories/clickhouse/referrers.repository.ts
@@ -199,7 +199,8 @@ export async function getReferrerUrlRollup(
       source_name,
       referrer_url,
       uniq(session_id) * any(_sample_factor) as visitors,
-      any(nullIf(referrer_source_name, '')) as stored_source_name,
+      /* pre-#813 events store legacy parser names here, not root domains; topK picks the majority */
+      arrayElement(topK(1)(nullIf(referrer_source_name, '')), 1) as stored_source_name,
       grouping(referrer_url) as is_rollup
     FROM enriched
     WHERE source_name IN (SELECT source_name FROM top_parents)

--- a/dashboard/src/trpc/routers/referrers.ts
+++ b/dashboard/src/trpc/routers/referrers.ts
@@ -23,12 +23,16 @@ export const referrersRouter = createRouter({
       getReferrerUrlRollupForSite(main, TOP_REFERRERS_LIMIT),
       compare && getReferrerUrlRollupForSite(compare, TOP_REFERRERS_LIMIT),
     ]);
-    return toHierarchicalDataTable({
+    const rollup = toHierarchicalDataTable({
       data,
       compare: compareData || undefined,
       parentKey: 'source_name',
       childKey: 'referrer_url',
     });
+    const storedSourceNames = new Map(
+      data.filter((row) => row.is_rollup).map((row) => [row.source_name, row.stored_source_name]),
+    );
+    return rollup.map((row) => ({ ...row, stored_source_name: storedSourceNames.get(row.source_name) ?? null }));
   }),
 
   topChannels: analyticsProcedure.query(async ({ ctx }) => {

--- a/simulate-events.js
+++ b/simulate-events.js
@@ -14,6 +14,7 @@ const DEFAULT_ARGS = {
   OUTBOUND_LINK_FREQUENCY: 0.05,
   CAMPAIGN_FREQUENCY: 0.3,
   NUM_CAMPAIGNS: 6,
+  REFERRER_FREQUENCY: 0.6,
 }
 
 
@@ -37,6 +38,7 @@ if (!args[0] || args[0].startsWith("--")) {
     | '--outbound-freq'| Fraction (0–1) of events that are outbound link clicks     | ${formatNumber(DEFAULT_ARGS.OUTBOUND_LINK_FREQUENCY)} |
     | '--campaign-freq'| Fraction (0–1) of events that have campaign UTM tags       | ${formatNumber(DEFAULT_ARGS.CAMPAIGN_FREQUENCY)} |
     | '--campaigns'    | Number of unique campaigns to generate                     | ${formatNumber(DEFAULT_ARGS.NUM_CAMPAIGNS)} |
+    | '--referrer-freq'| Fraction (0–1) of users arriving via an external referrer  | ${formatNumber(DEFAULT_ARGS.REFERRER_FREQUENCY)} |
     ------------------------------------------------------------------------------------------------
 
     Example:
@@ -48,7 +50,8 @@ if (!args[0] || args[0].startsWith("--")) {
       --event-freq=${DEFAULT_ARGS.CUSTOM_EVENT_FREQUENCY} \\
       --outbound-freq=${DEFAULT_ARGS.OUTBOUND_LINK_FREQUENCY} \\
       --campaign-freq=${DEFAULT_ARGS.CAMPAIGN_FREQUENCY} \\
-      --campaigns=${DEFAULT_ARGS.NUM_CAMPAIGNS}
+      --campaigns=${DEFAULT_ARGS.NUM_CAMPAIGNS} \\
+      --referrer-freq=${DEFAULT_ARGS.REFERRER_FREQUENCY}
   `);
   process.exit(1);
 }
@@ -71,6 +74,7 @@ const CUSTOM_EVENT_FREQUENCY = getFlag("event-freq", DEFAULT_ARGS.CUSTOM_EVENT_F
 const OUTBOUND_LINK_FREQUENCY = getFlag("outbound-freq", DEFAULT_ARGS.OUTBOUND_LINK_FREQUENCY);
 const CAMPAIGN_FREQUENCY = getFlag("campaign-freq", DEFAULT_ARGS.CAMPAIGN_FREQUENCY);
 const NUM_CAMPAIGNS = getFlag("campaigns", DEFAULT_ARGS.NUM_CAMPAIGNS);
+const REFERRER_FREQUENCY = getFlag("referrer-freq", DEFAULT_ARGS.REFERRER_FREQUENCY);
 
 const CUSTOM_EVENTS = [
   {
@@ -89,6 +93,22 @@ const OUTBOUND_LINK_URLS = [
   "https://linkedin.com",
   "https://youtube.com",
   "https://partner.com",
+];
+
+const REFERRER_URLS = [
+  "https://duckduckgo.com/",
+  "https://www.bing.com/search",
+  "https://www.google.com/",
+  "https://www.google.com/search",
+  "https://news.google.com/",
+  "https://www.reddit.com/r/selfhosted/",
+  "https://old.reddit.com/r/webdev/",
+  "https://news.ycombinator.com/",
+  "https://news.ycombinator.com/item?id=39538522",
+  "https://github.com/betterlytics/betterlytics",
+  "https://t.co/9fKzXqLm",
+  "https://www.linkedin.com/feed/",
+  "https://www.facebook.com/",
 ];
 const SCREEN_SIZES = ["1920x1080", "900x400", "500x300"];
 
@@ -251,6 +271,8 @@ const users = new Array(NUMBER_OF_USERS).fill(0).map(() => ({
   visitor_id: uuidv4(),
   ip: getRandomPublicIp(),
   globalProperties: getRandomElement(GLOBAL_PROPERTIES_POOL),
+  referrer:
+    Math.random() < REFERRER_FREQUENCY ? getRandomElement(REFERRER_URLS) : null,
 }));
 
 // Generate unique campaign IDs (short UUIDs)
@@ -309,10 +331,12 @@ const events = new Array(NUMBER_OF_EVENTS)
   .sort((a, b) => a.timestamp - b.timestamp)
   .map((payload) => getExtraPayload(payload))
   .map((payload) => {
-    const gp = usersByVisitorId.get(payload.visitor_id)?.globalProperties ?? {};
+    const user = usersByVisitorId.get(payload.visitor_id);
+    const gp = user?.globalProperties ?? {};
     return {
       ...BASE_PAYLOAD,
       ...payload,
+      referrer: user?.referrer ?? null,
       ...(Object.keys(gp).length > 0 ? { global_properties: gp } : {}),
     };
   });


### PR DESCRIPTION
makes Traffic Sources referrer parent rows clickable to filter, matching Devices and Global Properties, via a shared row-annotation pattern across all overview sections.

## Description of why
- Parent referrer rows showed a pointer cursor and a 'Filter by ...' tooltip but silently did nothing; child URLs and every other overview section already apply filters on click
- No schema change needed: ingest already stores `referrer_source_name` as the referrer's root domain - exactly the value the rollup displays as the group label

## Key decisions
- All five overview sections converge on one pattern: rows declare `filterColumn`/`filterValue` and the new `useProgressTableFilterClick` hook derives click handling + interactivity from the annotation, so a row can no longer look clickable while doing nothing
- Rollup SQL deliberately untouched: on date ranges reaching before March 2026 (PR #813 changed what `referrer_source_name` stores) the filter undercounts older events - the same accepted limitation the Referrers page already has; a backfill was considered, but I rejected as too risky for little benefit
- Known limitation: on ranges spanning the #813 deploy, parent rows mix legacy parser names and root domains in `referrer_source_name`; the click filters on the topK-majority value, so it can partially match the row's own traffic - superseded by #1005 (dedicated `referrer_domain` column)

## Changes
- `ProgressBarData` gains optional `filterColumn`/`filterValue`; new shared `useProgressTableFilterClick` hook
- Traffic Sources: referrer parents filter `referrer_source_name`, children keep `referrer_url`, channels keep `referrer_source`
- Devices, Events/Global Properties, Geography and Pages migrated to row annotations; five bespoke `onItemClick` switch handlers deleted
- Update our simulate-events script, so it actually add traffic sources

## Demo
<img width="747" height="487" alt="msedge_yUjH5SMh7Y" src="https://github.com/user-attachments/assets/435af2f8-32cb-409d-afb5-3d9508564f41" />