### PR TITLE
Pin pnpm in image builds

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -82,6 +82,7 @@ MAILER_SEND_API_TOKEN=''
 
 # Totp settings
 TOTP_SECRET_ENCRYPTION_KEY=your-32-character-encryption-key
+INTEGRATION_ENCRYPTION_KEY=your-32-character-encryption-key
 
 # OAuth
 GITHUB_ID=

--- a/Dockerfile.selfhost
+++ b/Dockerfile.selfhost
@@ -33,7 +33,7 @@ RUN echo "Building dashboard..."
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable
+RUN corepack enable && corepack prepare pnpm@10.9.0 --activate
 
 RUN apt-get update -y && apt-get install -y openssl && rm -rf /var/lib/apt/lists/*
 
@@ -61,7 +61,7 @@ FROM node:24-slim AS initializer-builder
 RUN echo "Building initializer..."
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable
+RUN corepack enable && corepack prepare pnpm@10.9.0 --activate
 
 WORKDIR /app
 

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -6,7 +6,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 # Setup pnpm
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable
+RUN corepack enable && corepack prepare pnpm@10.9.0 --activate
 
 RUN apt-get update -y && apt-get install -y openssl wget
 

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -4,7 +4,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable
+RUN corepack enable && corepack prepare pnpm@10.9.0 --activate
 
 # --------------------------
 

--- a/initializer/Dockerfile
+++ b/initializer/Dockerfile
@@ -2,7 +2,7 @@ FROM node:20-slim
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable
+RUN corepack enable && corepack prepare pnpm@10.9.0 --activate
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends openssl
 


### PR DESCRIPTION
Cold rebuilds of every deploy-image Dockerfile currently fail — existing layer caches are the only thing keeping them green. This pins pnpm and fixes the selfhost publish build env.

## Description of why
- The corepack setup runs before any `package.json` exists in the build context, so `pnpm` resolves to **latest** (11.x) whenever those layers re-execute (`--no-cache`, fresh machine, CI cache eviction, edits above the layer). On the `node:20-slim` images (dashboard, initializer, docs) pnpm 11 cannot run at all — `ERR_UNKNOWN_BUILTIN_MODULE: node:sqlite`, it requires Node >= 22.13. On `node:24-slim` (`Dockerfile.selfhost`) it runs, but `pnpm install -g` fails because pnpm 11 moved its global bin dir off the image's `PATH`. Both modes reproduced cold on two machines.
- Separately: `.env.production.example` (used by `publish.yml` as the selfhost image build env) is missing `INTEGRATION_ENCRYPTION_KEY`, which the dashboard env schema now requires (32 chars) — `next build` fails during page data collection. Any published Release hits this today.

## Changes
- `corepack prepare pnpm@10.9.0 --activate` (matches root `packageManager`) in `Dockerfile.selfhost`, `dashboard/Dockerfile`, `initializer/Dockerfile`, `docs/Dockerfile`.
- Add `INTEGRATION_ENCRYPTION_KEY` placeholder to `.env.production.example`.

## Additional Notes
- Verified: selfhost image builds and a full selfhost stack boots, migrates, and ingests events; dashboard image full build; pinned corepack + global prisma install on `node:20-slim` (initializer base); docs `pnpm install` restored.
- `docs/Dockerfile` has a **second, independent** cold-build failure this PR does not fix: its build context has no lockfile, and freshly-resolved zod 4.4.x (within nextra 4.6.1's `^4.1.12` range) breaks MDX prerendering of `/dashboard/user-journey`. Verified fix ready (override zod to the lockfile's 4.3.2) as a follow-up until the docs image build is lockfile-aware.
- The pnpm version literal intentionally mirrors root `package.json` `packageManager` — bump both together.

## Verification evidence
Without the pin, corepack resolves pnpm 11, which requires the `node:sqlite` builtin (Node >= 22.5) and cannot run at all on the `node:20-slim` images - `pnpm install` fails immediately with `ERR_UNKNOWN_BUILTIN_MODULE` on any cache-busted build of dashboard/initializer/docs.

Verified per file:
- `Dockerfile.selfhost`: full image build + full selfhost stack boot, migrations, event ingestion.
- `dashboard/Dockerfile`: full image build.
- `initializer/Dockerfile`: pinned corepack + global prisma install verified on `node:20-slim` (full build requires the deploy pipeline's assembled context).
- `docs/Dockerfile`: pin restores `pnpm install`; the subsequent prerender failure of `/dashboard/user-journey` is a separate pre-existing issue - the docs build context has no lockfile, so fresh resolution (react 19.2.7) breaks one page, while the same commit builds fine via `pnpm --filter ./docs run build` against the workspace lockfile. Suggest a follow-up making the docs image build lockfile-aware.