### PR TITLE
Self-hosting update procedure requires git pull first

### DIFF
--- a/docs/src/content/installation/self-hosting.mdx
+++ b/docs/src/content/installation/self-hosting.mdx
@@ -204,18 +204,16 @@ When `GEOLOCATION_MODE=full` is set (alongside `ENABLE_GEOLOCATION=true`), both 
 
 ## Updating
 
-Updates are delivered through the `betterlytics-selfhost` repository — the compose file pins the image version that matches its configuration. To update your self-hosted instance:
+Updates are delivered through the `betterlytics-selfhost` repository — the compose file pins the image version that matches its configuration. To update your self-hosted instance, run the update script from the repository root:
 
 ```bash
-git pull
-docker compose pull
-docker compose up -d
+./update.sh
 ```
 
 <Callout type="warning">
-Always run `git pull` first. New images can require configuration that only
-exists in updated repository files, and pulling images alone will not update
-your instance.
+If you update manually instead, always run `git pull` before pulling images.
+New images can require configuration that only exists in updated repository
+files, and pulling images alone will not update your instance.
 </Callout>
 
 <Callout type="info">

--- a/docs/src/content/installation/self-hosting.mdx
+++ b/docs/src/content/installation/self-hosting.mdx
@@ -110,6 +110,7 @@ Then point your reverse proxy to that port.
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header X-Forwarded-Port 443;
         }
     }
     ```
@@ -203,12 +204,26 @@ When `GEOLOCATION_MODE=full` is set (alongside `ENABLE_GEOLOCATION=true`), both 
 
 ## Updating
 
-To update your self-hosted instance to the latest version:
+Updates are delivered through the `betterlytics-selfhost` repository — the compose file pins the image version that matches its configuration. To update your self-hosted instance:
 
 ```bash
+git pull
 docker compose pull
 docker compose up -d
 ```
+
+<Callout type="warning">
+Always run `git pull` first. New images can require configuration that only
+exists in updated repository files, and pulling images alone will not update
+your instance.
+</Callout>
+
+<Callout type="info">
+Major updates may run one-time database migrations on first boot. For large
+installations: back up your Docker volumes first, ensure sufficient free disk
+space (see the release notes for specifics), and do not interrupt the container
+while migrations are running.
+</Callout>
 
 You can follow new releases on [GitHub](https://github.com/betterlytics/betterlytics/releases).
 


### PR DESCRIPTION
Fixes the self-hosting docs' Updating section, which currently instructs the exact command sequence that will break existing installs once the next selfhost image ships.

## Description of why
- The selfhost image and the config files in the `betterlytics-selfhost` repo move in lockstep, and the compose file will pin the image version going forward — so updates are delivered through the repository, and `docker compose pull` alone (the current documented procedure) either does nothing or, on old checkouts pulling `:latest`, fetches an image the mounted config cannot boot.

## Changes
- Rewrite the Updating section: point at the new `update.sh` script in `betterlytics-selfhost`, plus a git-pull-first warning for manual updates and a one-time-migrations/backup callout.
- Add `X-Forwarded-Port` to the reverse-proxy nginx example (matches the updated selfhost proxy template).

## Additional Notes
- Must be deployed to betterlytics.io **before** the next selfhost release is published. Related: #990 and the fail-fast PR.
Closes betterlytics/betterlytics-internal#34
