### PR TITLE
Fail fast when an outdated selfhost checkout drives a newer image

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,9 +27,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository_owner }}/betterlytics-selfhost
-          # Do not move :latest — the selfhost compose file pins a version tag,
-          # and legacy checkouts pulling :latest must not receive images their
-          # mounted config cannot boot.
+          # Never move :latest - legacy checkouts pull it but can't boot newer images
           flavor: |
             latest=false
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,11 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository_owner }}/betterlytics-selfhost
+          # Do not move :latest — the selfhost compose file pins a version tag,
+          # and legacy checkouts pulling :latest must not receive images their
+          # mounted config cannot boot.
+          flavor: |
+            latest=false
 
       - name: Building selfhost image
         uses: docker/build-push-action@v6

--- a/scripts/post_migrate_monitoring_ro.js
+++ b/scripts/post_migrate_monitoring_ro.js
@@ -1,0 +1,7 @@
+// Stub for a removed script: old betterlytics-selfhost checkouts still call
+// this by name. Role provisioning moved to provision_roles.js.
+console.error(
+  "Your betterlytics-selfhost checkout is outdated for this image.\n" +
+    "Run 'git pull' in your betterlytics-selfhost directory, then 'docker compose up -d' again."
+);
+process.exit(1);

--- a/scripts/post_migrate_monitoring_ro.js
+++ b/scripts/post_migrate_monitoring_ro.js
@@ -1,5 +1,4 @@
-// Stub for a removed script: old betterlytics-selfhost checkouts still call
-// this by name. Role provisioning moved to provision_roles.js.
+// Stub kept for old selfhost checkouts; role provisioning moved to provision_roles.js
 console.error(
   "Your betterlytics-selfhost checkout is outdated for this image.\n" +
     "Run 'git pull' in your betterlytics-selfhost directory, then 'docker compose up -d' again."

--- a/scripts/post_migrate_siteconfig_ro.js
+++ b/scripts/post_migrate_siteconfig_ro.js
@@ -1,0 +1,7 @@
+// Stub for a removed script: old betterlytics-selfhost checkouts still call
+// this by name. Role provisioning moved to provision_roles.js.
+console.error(
+  "Your betterlytics-selfhost checkout is outdated for this image.\n" +
+    "Run 'git pull' in your betterlytics-selfhost directory, then 'docker compose up -d' again."
+);
+process.exit(1);

--- a/scripts/post_migrate_siteconfig_ro.js
+++ b/scripts/post_migrate_siteconfig_ro.js
@@ -1,5 +1,4 @@
-// Stub for a removed script: old betterlytics-selfhost checkouts still call
-// this by name. Role provisioning moved to provision_roles.js.
+// Stub kept for old selfhost checkouts; role provisioning moved to provision_roles.js
 console.error(
   "Your betterlytics-selfhost checkout is outdated for this image.\n" +
     "Run 'git pull' in your betterlytics-selfhost directory, then 'docker compose up -d' again."

--- a/scripts/run-migration.js
+++ b/scripts/run-migration.js
@@ -1,7 +1,5 @@
 if (process.env.SECRET_BASE && !process.env.SALTS_DATABASE_URL) {
-  // SECRET_BASE only exists on selfhost deployments; SALTS_DATABASE_URL is
-  // derived by an up-to-date selfhost entrypoint. This combination means an
-  // outdated betterlytics-selfhost checkout is driving a newer image.
+  // SECRET_BASE without SALTS_DATABASE_URL means an outdated selfhost checkout is driving a newer image
   console.error(
     "Your betterlytics-selfhost checkout is outdated for this image.\n" +
       "Run 'git pull' in your betterlytics-selfhost directory, then 'docker compose up -d' again.\n" +

--- a/scripts/run-migration.js
+++ b/scripts/run-migration.js
@@ -1,3 +1,15 @@
+if (process.env.SECRET_BASE && !process.env.SALTS_DATABASE_URL) {
+  // SECRET_BASE only exists on selfhost deployments; SALTS_DATABASE_URL is
+  // derived by an up-to-date selfhost entrypoint. This combination means an
+  // outdated betterlytics-selfhost checkout is driving a newer image.
+  console.error(
+    "Your betterlytics-selfhost checkout is outdated for this image.\n" +
+      "Run 'git pull' in your betterlytics-selfhost directory, then 'docker compose up -d' again.\n" +
+      "No migrations have been run."
+  );
+  process.exit(1);
+}
+
 if (process.env.NODE_ENV !== "production") {
   require("dotenv").config();
 }


### PR DESCRIPTION
Makes the selfhost upgrade path fail safely and stops `:latest` from delivering images that outdated checkouts cannot boot.

## Description of why
- Since v1.3.5, three contract changes (deleted post-migrate scripts, required `INTEGRATION_ENCRYPTION_KEY`, required `SALTS_DATABASE_URL`) mean an old `betterlytics-selfhost` checkout driving a newer image crash-loops — and the old entrypoint runs **all database migrations first**, so the user discovers the problem only after their ClickHouse events table has been rewritten, with no rollback to the old version and a cryptic module-not-found error.
- The selfhost compose file pins a version tag going forward, so `:latest` no longer has a job — freezing it means legacy `docker compose pull` becomes a harmless no-op instead of a breaking upgrade.

## Changes
- `publish.yml`: stop applying the `latest` tag to selfhost images (`flavor: latest=false`).
- `scripts/run-migration.js`: preflight — `SECRET_BASE` set (selfhost-only signal) with `SALTS_DATABASE_URL` missing (only derived by an updated selfhost entrypoint) → print a clear "run git pull" message and exit **before any migration runs**.
- Re-add the two deleted post-migrate script names as error stubs with the same message.

## Additional Notes
- Verified end-to-end: built this image and ran it against a genuine v1.3.5 selfhost checkout — clean actionable error, zero migrations executed, databases untouched.
- Cloud and dev are unaffected: neither sets `SECRET_BASE`, so the preflight never fires there. The stubs are dead code except for legacy selfhost entrypoints.