### PR TITLE
Override zod to 4.3.2 for docs builds

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -32,5 +32,10 @@
     "pagefind": "^1.3.0",
     "tailwindcss": "^4",
     "typescript": "^5"
+  },
+  "pnpm": {
+    "overrides": {
+      "zod": "4.3.2"
+    }
   }
 }


### PR DESCRIPTION
Unblocks cold docs image builds, which currently fail on a zod 4.4.x regression.

## Description of why
- `docs/Dockerfile` builds from the `docs/` context, which contains no lockfile — every image build freshly resolves dependency ranges. Freshly-resolved zod 4.4.3 (within nextra's declared `^4.1.12`) regresses nextra 4.6.1's MDX component prop validation: prerendering `/dashboard/user-journey` fails with `Invalid input` on an ordinary `<Callout>`. The workspace lockfile resolves zod 4.3.2, which works.

## Changes
- `pnpm.overrides: { "zod": "4.3.2" }` in `docs/package.json` (mirrors the workspace lockfile).

## Additional Notes
- Tactical fix — the structural follow-up is making the docs image build lockfile-aware (repo-root context + workspace-filtered install), after which this override can be dropped. Worth reporting upstream to nextra/zod.
- Cold builds also need #990 to get past `pnpm install` at all.