### PR TITLE
Move docs zod override into the Dockerfile

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -13,6 +13,8 @@ FROM base as builder
 WORKDIR /app
 
 COPY package*.json .
+# zod >= 4.4 breaks nextra's MDX prerender.
+RUN npm pkg set pnpm.overrides.zod=4.3.2
 RUN pnpm install
 
 COPY . .

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /app
 
 COPY package*.json .
 # zod >= 4.4 breaks nextra's MDX prerender.
-RUN npm pkg set pnpm.overrides.zod=4.3.2
+RUN npm pkg set "pnpm.overrides[nextra>zod]=4.3.2" "pnpm.overrides[nextra-theme-docs>zod]=4.3.2"
 RUN pnpm install
 
 COPY . .

--- a/docs/package.json
+++ b/docs/package.json
@@ -32,10 +32,5 @@
     "pagefind": "^1.3.0",
     "tailwindcss": "^4",
     "typescript": "^5"
-  },
-  "pnpm": {
-    "overrides": {
-      "zod": "4.3.2"
-    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,8 @@ settings:
 
 overrides:
   qs@<6.14.1: '>=6.14.1'
+  nextra>zod: 4.3.2
+  nextra-theme-docs>zod: 4.3.2
 
 importers:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,5 @@ packages:
 
 overrides:
   qs@<6.14.1: '>=6.14.1'
+  nextra>zod: 4.3.2
+  nextra-theme-docs>zod: 4.3.2


### PR DESCRIPTION
#994 placed `pnpm.overrides` in `docs/package.json`, but pnpm ignores member-level overrides in a workspace and warns about it on every install. The override is only needed in the standalone docs image build (no lockfile in that context, so deps resolve fresh) — workspace installs pin zod 4.3.2 via the root lockfile.

## Changes
- Inject scoped `nextra>zod` / `nextra-theme-docs>zod` overrides in `docs/Dockerfile` (`npm pkg set` before `pnpm install`) and remove the override from `docs/package.json` — no more workspace warning, and docs' own direct zod stays on v3 in the image, matching dev.
- Add the same scoped overrides in `pnpm-workspace.yaml` so a future lockfile regeneration can't re-resolve nextra to a broken zod 4.4.x. Scoped on purpose: a plain `zod` override would force the dashboard from zod 3 to 4.

## Verification
- `pnpm install` in the workspace: warning gone; lockfile records the scoped overrides with no resolution changes (+2 lines).
- Cold `docker build` of `docs/`: passes, all pages prerender; inside the image docs' own zod resolves 3.25.x while nextra's is pinned 4.3.2.