### PR TITLE
Templates for public repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,64 @@
+name: Bug report
+description: Something in Betterlytics isn't working as expected.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please search
+        [existing issues](https://github.com/betterlytics/betterlytics/issues?q=is%3Aissue) first -
+        if your bug is already reported, a 👍 on it helps us prioritize.
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment
+      description: Where are you running Betterlytics?
+      options:
+        - Betterlytics Cloud (betterlytics.io)
+        - Self-hosted
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: For self-hosted - the version/tag or commit you're running. Leave empty for Cloud.
+      placeholder: e.g. v1.4.4
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+      placeholder: Filtering the pages report by country should update the chart to match the table...
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happens instead? Include error messages if any.
+      placeholder: The chart shows no data even though the table has rows...
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: If you can't reproduce it reliably, describe when it happens instead (how often, after what kind of action).
+      placeholder: |
+        1. Go to...
+        2. Click on...
+        3. See error
+    validations:
+      required: true
+  - type: input
+    id: browser
+    attributes:
+      label: Browser and device
+      description: If the issue is visual or dashboard-related - browser + version, OS, and device type.
+      placeholder: e.g. Chrome 138 on Windows 11, desktop
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or screenshots
+      description: Console errors, server logs, or screenshots. Please redact anything sensitive.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & help
+    url: https://discord.gg/vwqSvPn6sP
+    about: Get help, ask questions, and chat with the community on Discord.
+  - name: Security vulnerability
+    url: https://github.com/betterlytics/betterlytics/security/advisories/new
+    about: Please report security vulnerabilities privately - never in a public issue.
+  - name: Documentation
+    url: https://betterlytics.io/docs
+    about: Setup guides, self-hosting instructions, and feature documentation.

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,22 @@
+name: Documentation issue
+description: Something in the docs is wrong, unclear, or missing.
+labels: ["documentation"]
+body:
+  - type: input
+    id: page
+    attributes:
+      label: Page
+      description: Optional - the docs page this is about, or where you looked and didn't find it.
+      placeholder: https://betterlytics.io/docs/...
+  - type: textarea
+    id: issue
+    attributes:
+      label: What's wrong or missing?
+      description: Quote the confusing part if applicable, and say what you expected to find.
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested improvement
+      description: Optional - how would you phrase or structure it instead?

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: Feature request
+description: Suggest an idea or improvement for Betterlytics.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please search [existing issues](https://github.com/betterlytics/betterlytics/issues?q=is%3Aissue+label%3Aenhancement) first -
+        if the idea already exists, a 👍 and a comment on it helps us prioritize.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the situation or need behind the request - this matters more to us than the specific solution.
+      placeholder: I want to compare traffic between two campaigns, but currently I can only view one filter at a time...
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: What would you like to see?
+      description: Optional - if you have an idea for how Betterlytics could solve it. The problem above matters more.
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Current workaround
+      description: Optional - how do you handle this today? (Or how another tool you've used handles it.)
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: How do you use Betterlytics?
+      options:
+        - Betterlytics Cloud (betterlytics.io)
+        - Self-hosted
+        - Not a user yet

--- a/.github/ISSUE_TEMPLATE/self_hosting.yml
+++ b/.github/ISSUE_TEMPLATE/self_hosting.yml
@@ -1,0 +1,45 @@
+name: Self-hosting problem
+description: Trouble deploying, upgrading, or operating a self-hosted Betterlytics instance.
+labels: ["Self-Hosted"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For setup questions, the [self-hosting docs](https://betterlytics.io/docs/installation/self-hosting)
+        and [Discord](https://discord.gg/vwqSvPn6sP) are often faster. Use this template when something
+        seems broken in the self-hosted deployment itself.
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      placeholder: e.g. v1.4.4, or a commit SHA
+    validations:
+      required: true
+  - type: dropdown
+    id: method
+    attributes:
+      label: Deployment method
+      options:
+        - Docker Compose
+        - Kubernetes
+        - Manual / other
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What's the problem?
+      description: What did you do, what did you expect, and what happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Relevant container/server logs. Please redact secrets and personal data.
+      render: shell
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, architecture, reverse proxy, anything non-default in your setup or .env (redacted).


### PR DESCRIPTION
Public-facing issue templates, making it simpler and faster for users to report bugs, request features, get help with self-hosting, or flag documentation problems.

Four issue forms, each auto-applying the right label:
- Bug report (bug): deployment + version, expected vs actual behavior, reproduction steps
- Feature request (enhancement): problem-first, proposed solution optional
- Self-hosting problem (Self-Hosted): version, deployment method, logs
- Documentation issue (documentation): what's wrong or missing, where

Required fields are limited to what reporters actually know, so nobody is forced to type filler

Blank issues are disabled; contact links route questions to Discord, security reports to private vulnerability reporting, and setup help to the docs