### PR TITLE
Added SECURITY.md and a served .well-known/security.txt

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security issues privately via [GitHub's private vulnerability reporting](https://github.com/betterlytics/betterlytics/security/advisories/new)
+(Security tab -> "Report a vulnerability"). Never report security problems through public
+issues, discussions, or pull requests.
+
+We will respond as quickly as we can and are grateful for every report, big or small.
+We do not run a bug bounty program, so there is no monetary reward, but if you'd like,
+we are happy to credit you in the release notes of the fix.
+
+## Scope
+
+- Betterlytics Cloud ([betterlytics.io](https://betterlytics.io))
+- Self-hosted Betterlytics deployments
+- The tracking and session replay scripts served to end users
+
+## Supported versions
+
+Security fixes land in the latest release only; we do not backport. If you self-host,
+stay on the most recent version to receive security patches.
+
+## Safe harbor
+
+We will not take legal action against anyone who reports a vulnerability in good faith.
+Please keep testing non-disruptive, do not access more data than needed to demonstrate
+the issue, and give us reasonable time to fix it before any public disclosure.

--- a/dashboard/public/.well-known/security.txt
+++ b/dashboard/public/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: https://github.com/betterlytics/betterlytics/security/advisories/new
+Policy: https://github.com/betterlytics/betterlytics/blob/main/SECURITY.md
+Canonical: https://betterlytics.io/.well-known/security.txt
+Preferred-Languages: en
+Expires: 2027-07-26T00:00:00.000Z


### PR DESCRIPTION
Adds a security policy (SECURITY.md) covering private vulnerability reporting via GitHub security advisories, scope (Cloud, self-host, tracking and replay scripts), a latest-release-only support statement, and safe harbor. The dashboard also now serves an RFC 9116 `security.txt` at `/.well-known/security.txt` pointing at that policy.

Reviewer note: the `security.txt` `Expires` field is set to 2027-07-26 (one year out), so it needs a yearly refresh.
