### PR TITLE
Fixed monitor check intervals above 1h failing to save

### DIFF
--- a/backend/src/monitor/backoff.rs
+++ b/backend/src/monitor/backoff.rs
@@ -9,8 +9,6 @@ const DEFAULT_MAX_EFFECTIVE_SECS: u64 = 86_400;
 const DEFAULT_FAILURE_THRESHOLD: u16 = 25;
 const DEFAULT_SUCCESS_THRESHOLD: u16 = 2;
 
-/// Escalation is defined relative to the monitor's own base interval (base × multiplier^level,
-/// capped), so the policy is independent of whichever interval values the dashboard offers.
 #[derive(Clone, Copy, Debug)]
 pub struct BackoffPolicy {
     pub multiplier: u64,

--- a/backend/src/monitor/backoff.rs
+++ b/backend/src/monitor/backoff.rs
@@ -3,15 +3,18 @@ use std::time::Duration as StdDuration;
 
 use crate::monitor::{BackoffReason, BackoffSnapshot, MonitorCheck, ProbeOutcome};
 
-const DEFAULT_ALLOWED_INTERVALS_SECS: &[u64] =
-    &[60, 120, 180, 240, 300, 600, 900, 1800, 3600, 7200, 10_800, 21_600];
+const DEFAULT_MULTIPLIER: u64 = 2;
+const DEFAULT_MAX_EFFECTIVE_SECS: u64 = 86_400;
 
 const DEFAULT_FAILURE_THRESHOLD: u16 = 25;
 const DEFAULT_SUCCESS_THRESHOLD: u16 = 2;
 
+/// Escalation is defined relative to the monitor's own base interval (base × multiplier^level,
+/// capped), so the policy is independent of whichever interval values the dashboard offers.
 #[derive(Clone, Copy, Debug)]
 pub struct BackoffPolicy {
-    pub allowed_intervals_secs: &'static [u64],
+    pub multiplier: u64,
+    pub max_effective_secs: u64,
     pub failure_threshold: u16,
     pub success_threshold: u16,
 }
@@ -19,7 +22,8 @@ pub struct BackoffPolicy {
 impl Default for BackoffPolicy {
     fn default() -> Self {
         Self {
-            allowed_intervals_secs: DEFAULT_ALLOWED_INTERVALS_SECS,
+            multiplier: DEFAULT_MULTIPLIER,
+            max_effective_secs: DEFAULT_MAX_EFFECTIVE_SECS,
             failure_threshold: DEFAULT_FAILURE_THRESHOLD,
             success_threshold: DEFAULT_SUCCESS_THRESHOLD,
         }
@@ -145,22 +149,156 @@ impl BackoffController {
 }
 
 impl BackoffPolicy {
+    /// Level 0 is exactly the base interval; each level multiplies it, capped at
+    /// `max_effective_secs` (a base already above the cap is left untouched).
     pub fn interval_for_level(&self, base: StdDuration, level: u8) -> StdDuration {
-        let base_idx = self.base_index(base);
-        let target_idx = (base_idx + level as usize).min(self.allowed_intervals_secs.len() - 1);
-        StdDuration::from_secs(self.allowed_intervals_secs[target_idx])
+        let secs = base
+            .as_secs()
+            .saturating_mul(self.multiplier.saturating_pow(level as u32));
+        StdDuration::from_secs(secs.min(self.cap_for(base)))
     }
 
+    /// The lowest level at which the effective interval reaches the cap; escalating
+    /// beyond it would not change anything.
     pub fn max_level(&self, base: StdDuration) -> u8 {
-        let base_idx = self.base_index(base);
-        (self.allowed_intervals_secs.len() - 1 - base_idx) as u8
+        if self.multiplier < 2 {
+            return 0;
+        }
+        let cap = self.cap_for(base);
+        let mut secs = base.as_secs().max(1);
+        let mut level = 0u8;
+        while secs < cap && level < u8::MAX {
+            secs = secs.saturating_mul(self.multiplier);
+            level += 1;
+        }
+        level
     }
 
-    fn base_index(&self, base: StdDuration) -> usize {
-        let base_secs = base.as_secs();
-        self.allowed_intervals_secs
-            .iter()
-            .position(|&v| v >= base_secs)
-            .unwrap_or(self.allowed_intervals_secs.len() - 1)
+    fn cap_for(&self, base: StdDuration) -> u64 {
+        self.max_effective_secs.max(base.as_secs())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::monitor::{AlertConfig, HttpMethod, MonitorCheck, ReasonCode};
+    use std::net::{IpAddr, Ipv4Addr};
+
+    fn policy() -> BackoffPolicy {
+        BackoffPolicy::default()
+    }
+
+    fn check(interval_secs: u64) -> MonitorCheck {
+        MonitorCheck {
+            id: "check-1".to_string(),
+            dashboard_id: "dash-1".to_string(),
+            site_id: "site-1".to_string(),
+            name: None,
+            url: url::Url::parse("https://example.com").unwrap(),
+            interval: StdDuration::from_secs(interval_secs),
+            timeout: StdDuration::from_secs(5),
+            updated_at: chrono::Utc::now(),
+            http_method: HttpMethod::Head,
+            request_headers: Vec::new(),
+            accepted_status_codes: Vec::new(),
+            expected_keyword: None,
+            check_ssl_errors: false,
+            alert: AlertConfig::default(),
+        }
+    }
+
+    fn success() -> ProbeOutcome {
+        ProbeOutcome::success(
+            StdDuration::from_millis(50),
+            Some(200),
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+        )
+    }
+
+    fn failure() -> ProbeOutcome {
+        ProbeOutcome::failure(StdDuration::from_millis(50), Some(503), ReasonCode::Http5xx)
+    }
+
+    #[test]
+    fn level_zero_is_exactly_the_base_interval() {
+        // 44 minutes is not a "round" value; it must not be snapped to anything else.
+        let base = StdDuration::from_secs(44 * 60);
+        assert_eq!(policy().interval_for_level(base, 0), base);
+    }
+
+    #[test]
+    fn levels_multiply_the_base_until_the_cap() {
+        let p = policy();
+        let base = StdDuration::from_secs(44 * 60);
+        assert_eq!(p.interval_for_level(base, 1), StdDuration::from_secs(88 * 60));
+        assert_eq!(p.interval_for_level(base, 2), StdDuration::from_secs(176 * 60));
+        assert_eq!(
+            p.interval_for_level(base, 6),
+            StdDuration::from_secs(DEFAULT_MAX_EFFECTIVE_SECS)
+        );
+    }
+
+    #[test]
+    fn base_at_or_above_the_cap_never_escalates() {
+        let p = policy();
+        let day = StdDuration::from_secs(86_400);
+        assert_eq!(p.max_level(day), 0);
+        assert_eq!(p.interval_for_level(day, 5), day);
+
+        let above_cap = StdDuration::from_secs(100_000);
+        assert_eq!(p.max_level(above_cap), 0);
+        assert_eq!(p.interval_for_level(above_cap, 5), above_cap);
+    }
+
+    #[test]
+    fn max_level_reaches_the_cap_exactly_once() {
+        let p = policy();
+        let base = StdDuration::from_secs(60);
+        let max = p.max_level(base);
+        assert_eq!(max, 11); // 60 * 2^11 = 122880 >= 86400
+        assert_eq!(
+            p.interval_for_level(base, max),
+            StdDuration::from_secs(DEFAULT_MAX_EFFECTIVE_SECS)
+        );
+        assert!(p.interval_for_level(base, max - 1) < StdDuration::from_secs(DEFAULT_MAX_EFFECTIVE_SECS));
+    }
+
+    #[test]
+    fn controller_escalates_after_failure_threshold_and_recovers() {
+        let p = policy();
+        let mut controller = BackoffController::new(p);
+        let check = check(300);
+
+        for _ in 0..p.failure_threshold - 1 {
+            let snapshot = controller.apply_outcome(&check, &failure());
+            assert_eq!(snapshot.backoff_level, 0);
+            assert_eq!(snapshot.effective_interval, check.interval);
+        }
+        let snapshot = controller.apply_outcome(&check, &failure());
+        assert_eq!(snapshot.backoff_level, 1);
+        assert_eq!(snapshot.effective_interval, StdDuration::from_secs(600));
+
+        let snapshot = controller.apply_outcome(&check, &success());
+        assert_eq!(snapshot.backoff_level, 1);
+        let snapshot = controller.apply_outcome(&check, &success());
+        assert_eq!(snapshot.backoff_level, 0);
+        assert_eq!(snapshot.effective_interval, check.interval);
+    }
+
+    #[test]
+    fn base_interval_change_reclamps_the_level() {
+        let p = policy();
+        let mut controller = BackoffController::new(p);
+        let slow = check(86_400);
+
+        // Escalate a 5m monitor one level, then simulate the user changing it to 24h.
+        let fast = check(300);
+        for _ in 0..p.failure_threshold {
+            controller.apply_outcome(&fast, &failure());
+        }
+        let snapshot = controller.current_snapshot(&slow);
+        assert_eq!(snapshot.backoff_level, 0);
+        assert_eq!(snapshot.effective_interval, slow.interval);
     }
 }

--- a/backend/src/monitor/models.rs
+++ b/backend/src/monitor/models.rs
@@ -238,10 +238,10 @@ impl BackoffSnapshot {
         }
     }
 
-    pub fn effective_interval_seconds(&self) -> u16 {
+    pub fn effective_interval_seconds(&self) -> u32 {
         self.effective_interval
             .as_secs()
-            .min(u16::MAX as u64) as u16
+            .min(u32::MAX as u64) as u32
     }
 }
 
@@ -311,7 +311,7 @@ pub struct MonitorResultRow {
     pub port: Option<u16>,
     #[serde(with = "clickhouse::serde::chrono::datetime64::millis::option")]
     pub tls_not_after: Option<DateTime<Utc>>,
-    pub effective_interval_seconds: u16,
+    pub effective_interval_seconds: u32,
     pub backoff_level: u8,
     pub consecutive_failures: u16,
     pub consecutive_successes: u16,

--- a/backend/src/monitor/repository.rs
+++ b/backend/src/monitor/repository.rs
@@ -42,6 +42,10 @@ AND mc."deletedAt" IS NULL
 
 const ORDER_BY_UPDATED_AT: &str = r#" ORDER BY mc."updatedAt" ASC"#;
 
+/// Infra backstop against corrupt rows hammering a target — deliberately below the
+/// product minimums, which are enforced by the dashboard's schema and plan capabilities.
+const MIN_INTERVAL_SECS: i32 = 30;
+
 #[derive(Debug, Error)]
 pub enum MonitorRepositoryError {
     #[error(transparent)]
@@ -140,7 +144,7 @@ impl TryFrom<MonitorCheckRecord> for MonitorCheck {
             site_id: record.site_id,
             name: record.name,
             url,
-            interval: Duration::from_secs(record.interval_seconds.max(1) as u64),
+            interval: Duration::from_secs(record.interval_seconds.max(MIN_INTERVAL_SECS) as u64),
             timeout: Duration::from_millis(record.timeout_ms.max(1) as u64),
             updated_at: record.updated_at,
             http_method,

--- a/backend/src/monitor/repository.rs
+++ b/backend/src/monitor/repository.rs
@@ -42,8 +42,6 @@ AND mc."deletedAt" IS NULL
 
 const ORDER_BY_UPDATED_AT: &str = r#" ORDER BY mc."updatedAt" ASC"#;
 
-/// Infra backstop against corrupt rows hammering a target — deliberately below the
-/// product minimums, which are enforced by the dashboard's schema and plan capabilities.
 const MIN_INTERVAL_SECS: i32 = 30;
 
 #[derive(Debug, Error)]

--- a/dashboard/messages/da.json
+++ b/dashboard/messages/da.json
@@ -1822,6 +1822,7 @@
       "noData": "Ingen data endnu",
       "intervalMinutes": "{value} min",
       "intervalSeconds": "{value}s",
+      "intervalHours": "{value}t",
       "backoffTooltip": "Overvågning midlertidigt reduceret til {value}, fordi denne monitor har været nede gentagne gange. Normal frekvens genoptages automatisk, når tjenesten er oppe igen.",
       "emptyTitle": "Ingen overvågninger endnu",
       "emptyDescription": "Opret din første overvågning for at begynde at spore oppetid.",

--- a/dashboard/messages/en.json
+++ b/dashboard/messages/en.json
@@ -1822,6 +1822,7 @@
       "noData": "No data yet",
       "intervalMinutes": "{value} min",
       "intervalSeconds": "{value}s",
+      "intervalHours": "{value}h",
       "backoffTooltip": "Monitoring temporarily reduced to {value} because this monitor has been down repeatedly. Normal frequency resumes automatically once the service is healthy.",
       "emptyTitle": "No monitors yet",
       "emptyDescription": "Create your first monitor to start tracking uptime.",

--- a/dashboard/messages/it.json
+++ b/dashboard/messages/it.json
@@ -1822,6 +1822,7 @@
       "noData": "Nessun dato ancora",
       "intervalMinutes": "{value} min",
       "intervalSeconds": "{value}s",
+      "intervalHours": "{value}h",
       "backoffTooltip": "Monitoraggio temporaneamente ridotto a {value} perché questo monitor è stato offline ripetutamente. La frequenza normale riprenderà automaticamente quando il servizio torna online.",
       "emptyTitle": "Nessun monitor ancora",
       "emptyDescription": "Crea il tuo primo monitor per iniziare a tracciare l'uptime.",

--- a/dashboard/messages/nb.json
+++ b/dashboard/messages/nb.json
@@ -1822,6 +1822,7 @@
       "noData": "Ingen data ennå",
       "intervalMinutes": "{value} min.",
       "intervalSeconds": "{value} s",
+      "intervalHours": "{value} t",
       "backoffTooltip": "Overvåking er midlertidig redusert til {value} fordi denne overvåkingen har vært nede gjentatte ganger. Normal frekvens gjenopptas automatisk når tjenesten er frisk.",
       "emptyTitle": "Ingen overvåkere ennå",
       "emptyDescription": "Opprett din første overvåker for å begynne å spore oppetid.",

--- a/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/monitoring/shared/utils/sliderConstants.ts
+++ b/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/monitoring/shared/utils/sliderConstants.ts
@@ -1,22 +1,32 @@
 import { type SliderMark } from '@/components/inputs/LabeledSlider';
-import { MONITOR_DEFAULTS } from '@/entities/analytics/monitoring.entities';
+import { MONITOR_DEFAULTS, MONITOR_LIMITS } from '@/entities/analytics/monitoring.entities';
 
+// Minute steps up to 1h, then hour steps up to the schema maximum, so every
+// selectable mark is guaranteed to pass MonitorCheckBaseSchema validation.
 export const MONITOR_INTERVAL_MARKS = [
-  ...Array.from({ length: 59 }, (_, i) => (i + 1) * 60),
-  ...Array.from({ length: 24 }, (_, i) => (i + 1) * 3600),
+  ...Array.from(
+    { length: 60 - MONITOR_LIMITS.INTERVAL_MIN_SECONDS / 60 },
+    (_, i) => MONITOR_LIMITS.INTERVAL_MIN_SECONDS + i * 60,
+  ),
+  ...Array.from({ length: MONITOR_LIMITS.INTERVAL_MAX_SECONDS / 3600 }, (_, i) => (i + 1) * 3600),
 ];
 
 export const REQUEST_TIMEOUT_MARKS = Array.from({ length: 30 }, (_, i) => (i + 1) * 1000);
 
+const intervalMark = (seconds: number, label: string): SliderMark => ({
+  idx: MONITOR_INTERVAL_MARKS.indexOf(seconds),
+  label,
+});
+
 export const INTERVAL_DISPLAY_MARKS: SliderMark[] = [
-  { idx: 0, label: '1m' },
-  { idx: 4, label: '5m' },
-  { idx: 14, label: '15m' },
-  { idx: 29, label: '30m' },
-  { idx: 59, label: '1h' },
-  { idx: 64, label: '6h' },
-  { idx: 70, label: '12h' },
-  { idx: 82, label: '24h' },
+  intervalMark(60, '1m'),
+  intervalMark(300, '5m'),
+  intervalMark(900, '15m'),
+  intervalMark(1800, '30m'),
+  intervalMark(3600, '1h'),
+  intervalMark(21_600, '6h'),
+  intervalMark(43_200, '12h'),
+  intervalMark(86_400, '24h'),
 ];
 
 export const TIMEOUT_DISPLAY_MARKS: SliderMark[] = [

--- a/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/monitoring/utils.ts
+++ b/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/monitoring/utils.ts
@@ -4,6 +4,10 @@ type MonitoringPageTranslation = ReturnType<typeof useTranslations<'monitoringPa
 
 export function formatIntervalLabel(t: MonitoringPageTranslation, intervalSeconds?: number | null): string {
   if (intervalSeconds == null || Number.isNaN(intervalSeconds)) return '—';
+  if (intervalSeconds % 3600 === 0) {
+    const hours = intervalSeconds / 3600;
+    return t('list.intervalHours', { value: hours });
+  }
   if (intervalSeconds % 60 === 0) {
     const mins = intervalSeconds / 60;
     return t('list.intervalMinutes', { value: mins });

--- a/dashboard/src/entities/analytics/monitoring.entities.ts
+++ b/dashboard/src/entities/analytics/monitoring.entities.ts
@@ -26,8 +26,6 @@ export const MONITOR_LIMITS = {
   ALERT_EMAILS_MAX: 5,
   ACCEPTED_STATUS_CODES_MAX: 5,
   EXPECTED_KEYWORD_MAX: 256,
-  // Single source of truth for the check interval range: the schema below and the
-  // interval slider marks both derive from these so they cannot drift apart.
   INTERVAL_MIN_SECONDS: 60,
   INTERVAL_MAX_SECONDS: 86_400,
 } as const;

--- a/dashboard/src/entities/analytics/monitoring.entities.ts
+++ b/dashboard/src/entities/analytics/monitoring.entities.ts
@@ -26,6 +26,10 @@ export const MONITOR_LIMITS = {
   ALERT_EMAILS_MAX: 5,
   ACCEPTED_STATUS_CODES_MAX: 5,
   EXPECTED_KEYWORD_MAX: 256,
+  // Single source of truth for the check interval range: the schema below and the
+  // interval slider marks both derive from these so they cannot drift apart.
+  INTERVAL_MIN_SECONDS: 60,
+  INTERVAL_MAX_SECONDS: 86_400,
 } as const;
 
 export const MONITOR_DEFAULTS = {
@@ -57,7 +61,12 @@ export const StatusCodeValueSchema = z.union([
 
 export const MonitorCheckBaseSchema = z.object({
   name: z.string().trim().max(MONITOR_LIMITS.NAME_MAX).optional().nullable(),
-  intervalSeconds: z.number().int().min(60).max(3600).default(MONITOR_DEFAULTS.intervalSeconds),
+  intervalSeconds: z
+    .number()
+    .int()
+    .min(MONITOR_LIMITS.INTERVAL_MIN_SECONDS)
+    .max(MONITOR_LIMITS.INTERVAL_MAX_SECONDS)
+    .default(MONITOR_DEFAULTS.intervalSeconds),
   timeoutMs: z.number().int().min(500).max(120_000).default(MONITOR_DEFAULTS.timeoutMs),
   isEnabled: z.boolean().default(MONITOR_DEFAULTS.isEnabled),
   checkSslErrors: z.boolean().default(MONITOR_DEFAULTS.checkSslErrors),

--- a/dashboard/src/lib/billing/capabilities.ts
+++ b/dashboard/src/lib/billing/capabilities.ts
@@ -69,7 +69,7 @@ export const PLAN_CAPABILITIES: Record<TierName, PlanCapabilities> = {
     dashboards: { maxDashboards: 9999, maxMembers: 9999 },
     monitoring: {
       maxMonitors: 9999,
-      minIntervalSeconds: 30,
+      minIntervalSeconds: 60,
       httpMethodConfigurable: true,
       customStatusCodes: true,
       customHeaders: true,

--- a/migrations/36_widen_monitor_effective_interval.sql
+++ b/migrations/36_widen_monitor_effective_interval.sql
@@ -1,3 +1,5 @@
 -- Check intervals can now be up to 24h (86400s), which overflows UInt16 (max 65535).
+-- The column is a per-probe measurement the backend always writes; drop the legacy
+-- DEFAULT 30 for 0 ("unknown"), matching the other backoff columns.
 ALTER TABLE analytics.monitor_results
-    MODIFY COLUMN effective_interval_seconds UInt32 DEFAULT 30;
+    MODIFY COLUMN effective_interval_seconds UInt32 DEFAULT 0;

--- a/migrations/36_widen_monitor_effective_interval.sql
+++ b/migrations/36_widen_monitor_effective_interval.sql
@@ -1,0 +1,3 @@
+-- Check intervals can now be up to 24h (86400s), which overflows UInt16 (max 65535).
+ALTER TABLE analytics.monitor_results
+    MODIFY COLUMN effective_interval_seconds UInt32 DEFAULT 30;


### PR DESCRIPTION
The monitor form offered check intervals up to 24h while the schema capped them at 1h, so any multi-hour selection failed with a generic error. The interval range (60s to 24h) now lives in `MONITOR_LIMITS`, and both the Zod schema and the slider marks derive from it so they cannot drift apart again. Backend backoff no longer snaps base intervals to a hardcoded ladder that mirrored the dashboard's values: the effective interval is now base x 2^level capped at 24h, meaning a 44m monitor actually probes every 44m (the ladder silently rounded it to 1h), and future slider changes need no backend edit.

Closes betterlytics/betterlytics-internal#4

**Reviewer notes**

- Migration 36 widens `monitor_results.effective_interval_seconds` to UInt32 (24h overflows UInt16). The usual initializer-before-backend deploy order covers it, but an old backend writing into the widened column errors, so deploy both together.
- Also bumps the enterprise plan minimum interval from 30s to 60s: the schema floor was always 60, so 30s was dead config that could never be selected or saved.
- First unit tests in `backend/src/monitor` cover the new backoff policy.

**Verification**

On a live worktree: monitors at 60s/3m/5m/30m/24h all saved, first probes recorded the exact configured interval, and observed cadence matched within the 10% scheduling jitter (60s monitor: 58s/58s/64s gaps; 3m monitor: 195s). Hourly uptime charts show "no data" for hours a multi-hour monitor does not check in; that is inherent to infrequent checking, not a regression.
