### PR TITLE
Fixed active filter pills overflowing the viewport on long filter values

### DIFF
--- a/dashboard/src/components/dashboard/DashboardFilters.tsx
+++ b/dashboard/src/components/dashboard/DashboardFilters.tsx
@@ -20,7 +20,7 @@ export default function DashboardFilters({
   const isMobile = useIsMobile();
 
   return (
-    <div className='space-y-2'>
+    <div className='min-w-0 space-y-2'>
       <div className='flex flex-col justify-end gap-x-8 gap-y-2 sm:flex-row'>
         {!isMobile && <div className='flex gap-4'>{children}</div>}
         {showQueryFilters && <QueryFiltersSelector />}

--- a/dashboard/src/components/filters/ActiveQueryFilters.tsx
+++ b/dashboard/src/components/filters/ActiveQueryFilters.tsx
@@ -29,11 +29,15 @@ export function ActiveQueryFilters() {
             key={filter.id}
             variant='outline'
             className={cn(
-              'border-input bg-muted/50 hover:bg-muted/70 dark:bg-secondary dark:hover:bg-secondary/90 gap-1.5 p-1 px-1.5',
+              'border-input bg-muted/50 hover:bg-muted/70 dark:bg-secondary dark:hover:bg-secondary/90 max-w-full gap-1.5 p-1 px-1.5',
               status.disabled && 'opacity-50',
             )}
           >
-            <DisabledTooltip disabled={status.disabled} message={disabledMessage} wrapperClassName='inline-flex'>
+            <DisabledTooltip
+              disabled={status.disabled}
+              message={disabledMessage}
+              wrapperClassName='inline-flex min-w-0'
+            >
               {() => <FilterDescription filter={filter} />}
             </DisabledTooltip>
             <Tooltip>

--- a/dashboard/src/components/filters/FilterDescription.tsx
+++ b/dashboard/src/components/filters/FilterDescription.tsx
@@ -17,15 +17,10 @@ export function FilterDescription({ filter, className }: FilterDescriptionProps)
   const values = filter.values.map((v) => strategy.formatValue(v, locale)).join(', ');
 
   return (
-    <span
-      className={cn(
-        'inline-flex items-center gap-1 [&_svg]:size-3',
-        className,
-      )}
-    >
-      <FilterColumnLabel column={filter.column} />
+    <span className={cn('inline-flex min-w-0 items-center gap-1 [&_svg]:size-3', className)}>
+      <FilterColumnLabel column={filter.column} className='shrink-0' />
       <span className='text-muted-foreground/80'>{operator}</span>
-      <span>{values}</span>
+      <span className='truncate'>{values}</span>
     </span>
   );
 }


### PR DESCRIPTION
Long filter values made active filter pills wider than the screen, on mobile via the badge's unbounded `w-fit whitespace-nowrap` sizing and on desktop via the `lg:` header flex row stretching to the pill's unwrapped max-content width. Pills are now capped at their container width and the values text truncates with an ellipsis, with `min-w-0` at each nested flex level so the truncation actually engages.

Closes betterlytics/betterlytics#885
Closes betterlytics/betterlytics-internal#13

**Reviewer notes:** `FilterDescription` is shared with the funnel bar tooltip, where very long values now stay on one line instead of wrapping (column labels already behaved this way there).

**Verification:** reproduced the issue's filter (long URL value lists) against a live worktree at 390px and 1440px: no horizontal overflow at either width, and the column label, ellipsized values, and remove button all stay visible.
