### PR TITLE
Fixed filter value dropdown flashing its post-pick state during the close animation

### DIFF
--- a/dashboard/src/components/MultiSelect.tsx
+++ b/dashboard/src/components/MultiSelect.tsx
@@ -457,63 +457,6 @@ export const MultiSelect = ({
     return undefined;
   }, [creatable, commandProps?.filter]);
 
-  const listContent = isLoading ? (
-    <>{loadingIndicator}</>
-  ) : (
-    <>
-      {EmptyItem()}
-      {!selectFirstItem && <CommandItem value='-' className='hidden' />}
-      {Object.entries(selectables).map(([key, dropdowns]) => (
-        <CommandGroup key={key} heading={key} className='h-full overflow-auto'>
-          <>
-            {dropdowns.map((option) => {
-              return (
-                <CommandItem
-                  key={option.value}
-                  value={option.value}
-                  disabled={option.disable}
-                  onMouseDown={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                  }}
-                  onSelect={() => {
-                    if (selected.length >= maxSelected) {
-                      onMaxSelected?.(selected.length);
-
-                      return;
-                    }
-
-                    handleInputChange('');
-                    const newOptions = [...selected, option];
-
-                    setSelected(newOptions);
-                    onChange?.(newOptions);
-                    setOpen(false);
-                  }}
-                  className={cn(
-                    'cursor-pointer',
-                    option.disable && 'pointer-events-none cursor-not-allowed opacity-50',
-                  )}
-                >
-                  {option.label}
-                </CommandItem>
-              );
-            })}
-          </>
-        </CommandGroup>
-      ))}
-      {CreatableItem()}
-    </>
-  );
-
-  // Radix keeps the content mounted through the exit animation; keep painting the last-open list
-  const lastOpenListRef = React.useRef<React.ReactNode>(null);
-  useEffect(() => {
-    if (open) {
-      lastOpenListRef.current = listContent;
-    }
-  });
-
   return (
     <PopoverPrimitive.Root open={open} modal={false}>
       <Command
@@ -658,7 +601,7 @@ export const MultiSelect = ({
             onOpenAutoFocus={(e) => e.preventDefault()}
             className={cn(
               'border-input z-50 w-[var(--radix-popover-trigger-width)] overflow-hidden rounded-md border',
-              'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+              'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
             )}
             onMouseDown={(e) => {
               // Prevent blur when clicking inside dropdown
@@ -679,7 +622,54 @@ export const MultiSelect = ({
               onWheel={(e) => e.stopPropagation()}
               onTouchMove={(e) => e.stopPropagation()}
             >
-              {open ? listContent : lastOpenListRef.current}
+              {isLoading ? (
+                <>{loadingIndicator}</>
+              ) : (
+                <>
+                  {EmptyItem()}
+                  {!selectFirstItem && <CommandItem value='-' className='hidden' />}
+                  {Object.entries(selectables).map(([key, dropdowns]) => (
+                    <CommandGroup key={key} heading={key} className='h-full overflow-auto'>
+                      <>
+                        {dropdowns.map((option) => {
+                          return (
+                            <CommandItem
+                              key={option.value}
+                              value={option.value}
+                              disabled={option.disable}
+                              onMouseDown={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                              }}
+                              onSelect={() => {
+                                if (selected.length >= maxSelected) {
+                                  onMaxSelected?.(selected.length);
+
+                                  return;
+                                }
+
+                                handleInputChange('');
+                                const newOptions = [...selected, option];
+
+                                setSelected(newOptions);
+                                onChange?.(newOptions);
+                                setOpen(false);
+                              }}
+                              className={cn(
+                                'cursor-pointer',
+                                option.disable && 'pointer-events-none cursor-not-allowed opacity-50',
+                              )}
+                            >
+                              {option.label}
+                            </CommandItem>
+                          );
+                        })}
+                      </>
+                    </CommandGroup>
+                  ))}
+                  {CreatableItem()}
+                </>
+              )}
             </CommandList>
           </PopoverPrimitive.Content>
         </PopoverPrimitive.Portal>

--- a/dashboard/src/components/MultiSelect.tsx
+++ b/dashboard/src/components/MultiSelect.tsx
@@ -457,6 +457,63 @@ export const MultiSelect = ({
     return undefined;
   }, [creatable, commandProps?.filter]);
 
+  const listContent = isLoading ? (
+    <>{loadingIndicator}</>
+  ) : (
+    <>
+      {EmptyItem()}
+      {!selectFirstItem && <CommandItem value='-' className='hidden' />}
+      {Object.entries(selectables).map(([key, dropdowns]) => (
+        <CommandGroup key={key} heading={key} className='h-full overflow-auto'>
+          <>
+            {dropdowns.map((option) => {
+              return (
+                <CommandItem
+                  key={option.value}
+                  value={option.value}
+                  disabled={option.disable}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                  }}
+                  onSelect={() => {
+                    if (selected.length >= maxSelected) {
+                      onMaxSelected?.(selected.length);
+
+                      return;
+                    }
+
+                    handleInputChange('');
+                    const newOptions = [...selected, option];
+
+                    setSelected(newOptions);
+                    onChange?.(newOptions);
+                    setOpen(false);
+                  }}
+                  className={cn(
+                    'cursor-pointer',
+                    option.disable && 'pointer-events-none cursor-not-allowed opacity-50',
+                  )}
+                >
+                  {option.label}
+                </CommandItem>
+              );
+            })}
+          </>
+        </CommandGroup>
+      ))}
+      {CreatableItem()}
+    </>
+  );
+
+  // Radix keeps the content mounted through the exit animation; keep painting the last-open list
+  const lastOpenListRef = React.useRef<React.ReactNode>(null);
+  useEffect(() => {
+    if (open) {
+      lastOpenListRef.current = listContent;
+    }
+  });
+
   return (
     <PopoverPrimitive.Root open={open} modal={false}>
       <Command
@@ -622,54 +679,7 @@ export const MultiSelect = ({
               onWheel={(e) => e.stopPropagation()}
               onTouchMove={(e) => e.stopPropagation()}
             >
-              {isLoading ? (
-                <>{loadingIndicator}</>
-              ) : (
-                <>
-                  {EmptyItem()}
-                  {!selectFirstItem && <CommandItem value='-' className='hidden' />}
-                  {Object.entries(selectables).map(([key, dropdowns]) => (
-                    <CommandGroup key={key} heading={key} className='h-full overflow-auto'>
-                      <>
-                        {dropdowns.map((option) => {
-                          return (
-                            <CommandItem
-                              key={option.value}
-                              value={option.value}
-                              disabled={option.disable}
-                              onMouseDown={(e) => {
-                                e.preventDefault();
-                                e.stopPropagation();
-                              }}
-                              onSelect={() => {
-                                if (selected.length >= maxSelected) {
-                                  onMaxSelected?.(selected.length);
-
-                                  return;
-                                }
-
-                                handleInputChange('');
-                                const newOptions = [...selected, option];
-
-                                setSelected(newOptions);
-                                onChange?.(newOptions);
-                                setOpen(false);
-                              }}
-                              className={cn(
-                                'cursor-pointer',
-                                option.disable && 'pointer-events-none cursor-not-allowed opacity-50',
-                              )}
-                            >
-                              {option.label}
-                            </CommandItem>
-                          );
-                        })}
-                      </>
-                    </CommandGroup>
-                  ))}
-                  {CreatableItem()}
-                </>
-              )}
+              {open ? listContent : lastOpenListRef.current}
             </CommandList>
           </PopoverPrimitive.Content>
         </PopoverPrimitive.Portal>


### PR DESCRIPTION
Picking a value in the filter value multi-select briefly flashed a different list state (highlight jump, scroll snap, reordering) while Radix played the popover's exit animation. Closing without picking was always smooth - the flash only appeared on close paths that also mutate state.

Resolves betterlytics/betterlytics-internal#84

## Key decisions
- Neither #945 pattern fits. Reset-on-open leaves stale search text in the always-visible anchor input, and deferring resets to animation-end (`useOverlayReset`) can't stop the selection-driven list changes, which must apply at click time.
- Freezing the rendered list during the exit was tried and reverted: cmdk holds its own external store, and the cleared input triggers select-first + `scrollIntoView` inside the still-mounted list - per-item store subscriptions bypass any React-level snapshot.
- Final fix: drop the closed-state animation classes on this popover so Radix unmounts it synchronously. Picking closes instantly, leaving no window to paint into; the open animation is kept.

## Changes
- `MultiSelect.tsx`: removed `data-[state=closed]` animation classes from the popover content (one line vs main).

## Demo
### Before
<img width="1883" height="654" alt="msedge_3uWzoOB6KG" src="https://github.com/user-attachments/assets/9279ec74-2ff8-42e1-a821-ad5df09e9c66" />

### After
<img width="1915" height="655" alt="msedge_OBkQlsNBZB" src="https://github.com/user-attachments/assets/737fa8ee-73c7-42ce-874f-d149f8ee6f3c" />
