### PR TITLE
Fixed filter values matching case-sensitively on hourly MV-backed cards

### DIFF
--- a/dashboard/src/lib/ba-hourly-query.test.ts
+++ b/dashboard/src/lib/ba-hourly-query.test.ts
@@ -31,10 +31,10 @@ describe('hourly MV filters bare wildcard semantics', () => {
     expect(sql).toBe(`city = ''`);
   });
 
-  it('keeps plain values on the IN path', () => {
+  it('routes plain values through the ILIKE path', () => {
     const sql = buildGeoSql([makeFilter('country_code', '=', ['DK'])]);
 
-    expect(sql).toContain('country_code IN');
+    expect(sql).toMatch(/arrayExists\(pattern -> country_code ILIKE pattern/);
   });
 
   it('keeps partial wildcard patterns on the ILIKE path', () => {
@@ -75,5 +75,26 @@ describe('hourly MV filters bare wildcard semantics', () => {
 
     expect(fastSql).toBe(`city != ''`);
     expect(slow.taggedSql).toContain(`city != ''`);
+  });
+});
+
+describe('hourly MV filters case-insensitive matching', () => {
+  it('keeps != plain values on the arrayAll NOT ILIKE path', () => {
+    const sql = buildGeoSql([makeFilter('country_code', '!=', ['DK'])]);
+
+    expect(sql).toMatch(/arrayAll\(pattern -> country_code NOT ILIKE pattern/);
+  });
+
+  it('passes plain values through untransformed so ILIKE does the case folding', () => {
+    const [part] = BAHourlyQuery.getGeoHourlyFilters([makeFilter('country_code', '=', ['us'])]);
+
+    expect(part.taggedSql).toMatch(/arrayExists\(pattern -> country_code ILIKE pattern/);
+    expect(part.taggedParams).toEqual({ hourly_mv_filter_0: ['us'] });
+  });
+
+  it('still maps * to % in mixed value lists', () => {
+    const [part] = BAHourlyQuery.getGeoHourlyFilters([makeFilter('city', '=', ['Copen*', 'Aarhus'])]);
+
+    expect(part.taggedParams).toEqual({ hourly_mv_filter_0: ['Copen%', 'Aarhus'] });
   });
 });

--- a/dashboard/src/lib/ba-hourly-query.ts
+++ b/dashboard/src/lib/ba-hourly-query.ts
@@ -71,13 +71,6 @@ function buildHourlyMvFilters(
       return presenceCheck;
     }
 
-    const hasWildcard = filter.values.some((v) => v.includes('*'));
-
-    if (!hasWildcard) {
-      const values = SQL.StringArray({ [`hourly_mv_filter_${i}`]: filter.values });
-      return filter.operator === '=' ? safeSql`${col} IN ${values}` : safeSql`${col} NOT IN ${values}`;
-    }
-
     const patterns = SQL.StringArray({
       [`hourly_mv_filter_${i}`]: filter.values.map((v) => v.replaceAll('*', '%')),
     });


### PR DESCRIPTION
The hourly MV fast path compared non-wildcard filter values with a plain IN, which is case-sensitive in ClickHouse, while the events path matches with ILIKE. A lowercase value like country "us" showed zeros on MV-backed cards (geography map, device/browser/OS breakdowns) while events-path cards kept showing data. The IN branch is removed so every non-presence filter takes the same arrayExists ILIKE shape as the events path, making the two paths match by construction.

Closes betterlytics/betterlytics-internal#120

Deviation from spec: the issue preferred keeping IN with lowercased comparison. No lowercase-based IN reproduces ILIKE's folding exactly (ClickHouse lowerUTF8 applies the contextual Greek final-sigma rule, ILIKE does not), so the issue's listed ILIKE alternative was implemented instead. Measured cost is ~1-5ms at realistic MV row counts (15ms vs 63ms on a deliberately extreme synthetic 500k-row site-month).

Reviewer note: the issue names "overview summary numbers" as affected, but only the device/browser/OS breakdowns and geography cards are MV-backed; the summary card was never wrong. Wildcard and presence filter behavior is unchanged and covered by the existing tests.
