### PR TITLE
Added MCP read tools for uptime monitoring and status pages

### DIFF
--- a/dashboard/src/entities/analytics/monitoring.entities.ts
+++ b/dashboard/src/entities/analytics/monitoring.entities.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 export const MonitorStatusSchema = z.enum(['ok', 'warn', 'failed']);
 export const IncidentStateSchema = z.enum(['ongoing', 'resolved']);
+export const IncidentSeveritySchema = z.enum(['info', 'warning', 'critical']);
 
 /**
  * Operational state represents the current state of a monitor from a user's perspective.
@@ -205,6 +206,23 @@ export type MonitorWithStatus = MonitorCheck & {
   currentStateSince: string | null;
 };
 
+// Current state plus uptime and latency aggregates over a requested range, without the per-bucket
+// series MonitorWithStatus carries. Used where a summary is wanted rather than a chart.
+export type MonitorRangeSummary = {
+  monitor: MonitorCheck;
+  operationalState: MonitorOperationalState;
+  currentStateSince: string | null;
+  lastCheckAt: string | null;
+  lastStatus: MonitorStatus | null;
+  effectiveIntervalSeconds: number | null;
+  backoffLevel: number | null;
+  uptimePercent: number | null;
+  uptimeSeconds: number;
+  totalSeconds: number;
+  latency: MonitorLatencyStats;
+  tls: MonitorTlsResult | null;
+};
+
 export type UptimeStats = z.infer<typeof UptimeStatsSchema>;
 export type MonitorUptimeBucket = z.infer<typeof MonitorUptimeBucketSchema>;
 export type MonitorLatencyStats = z.infer<typeof MonitorLatencyStatsSchema>;
@@ -217,6 +235,24 @@ export type MonitorResult = z.infer<typeof MonitorResultSchema>;
 export type MonitorTlsResult = z.infer<typeof MonitorTlsResultSchema>;
 export type MonitorIncidentSegment = z.infer<typeof MonitorIncidentSegmentSchema>;
 export type MonitorDailyUptime = z.infer<typeof MonitorDailyUptimeSchema>;
+
+/**
+ * A single detected incident with its identity and severity
+ */
+export const MonitorIncidentRecordSchema = z.object({
+  incidentId: z.string(),
+  monitorCheckId: z.string(),
+  state: IncidentStateSchema,
+  severity: IncidentSeveritySchema,
+  reason: z.string().nullable(),
+  startedAt: z.string(),
+  resolvedAt: z.string().nullable(),
+  durationMs: z.number().nullable(),
+});
+export type MonitorIncidentRecord = z.infer<typeof MonitorIncidentRecordSchema>;
+
+/** An incident paired with the monitor it belongs to, for listings that span several monitors. */
+export type MonitorIncidentWithMonitor = MonitorIncidentRecord & { monitor: MonitorCheck };
 
 export const DetectedOutageRowSchema = z.object({
   detectedIncidentId: z.string(),

--- a/dashboard/src/lib/monitorReasonCodes.ts
+++ b/dashboard/src/lib/monitorReasonCodes.ts
@@ -78,7 +78,7 @@ export function getReasonTranslationKey(reasonCode: string | null | undefined): 
     return 'unknown';
   }
 
-  if (reasonCode in reasonCodeFallbackMessages) {
+  if (Object.hasOwn(reasonCodeFallbackMessages, reasonCode)) {
     return reasonCode as ReasonCodeKey;
   }
 
@@ -107,7 +107,7 @@ const REASON_CODE_TO_PUBLIC_CAUSE: Partial<Record<ReasonCodeKey, PublicIncidentC
 };
 
 export function getPublicIncidentCause(reasonCode: string | null | undefined): PublicIncidentCause {
-  if (reasonCode && reasonCode in REASON_CODE_TO_PUBLIC_CAUSE) {
+  if (reasonCode && Object.hasOwn(REASON_CODE_TO_PUBLIC_CAUSE, reasonCode)) {
     return REASON_CODE_TO_PUBLIC_CAUSE[reasonCode as ReasonCodeKey] ?? 'disruption';
   }
   return 'disruption';

--- a/dashboard/src/mcp/server.ts
+++ b/dashboard/src/mcp/server.ts
@@ -1,21 +1,31 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { getSchemaDescription } from '@/mcp/tools/describe';
+import { getSchemaDescription, type ToolAvailability } from '@/mcp/tools/describe';
 import { executeQuery } from '@/mcp/tools/query';
 import { McpQueryInputBaseSchema } from '@/mcp/entities/mcp.entities';
 import { executeUserJourneys, McpUserJourneysInputBaseSchema } from '@/mcp/tools/userJourneys';
 import { executeFunnelPreview, McpFunnelPreviewInputBaseSchema } from '@/mcp/tools/funnelPreview';
 import { executeListFunnels, McpListFunnelsInputBaseSchema } from '@/mcp/tools/listFunnels';
-import {
-  executeListGlobalProperties,
-  McpListGlobalPropertiesInputBaseSchema,
-} from '@/mcp/tools/globalProperties';
+import { executeListGlobalProperties, McpListGlobalPropertiesInputBaseSchema } from '@/mcp/tools/globalProperties';
 import {
   executeListErrors,
   McpListErrorsInputBaseSchema,
   executeGetError,
   McpGetErrorInputBaseSchema,
 } from '@/mcp/tools/errors';
+import {
+  executeListMonitors,
+  McpListMonitorsInputBaseSchema,
+  executeListMonitorIncidents,
+  McpListMonitorIncidentsInputBaseSchema,
+} from '@/mcp/tools/monitoring';
+import {
+  executeListStatusPages,
+  McpListStatusPagesInputBaseSchema,
+  executeListIncidentSuggestions,
+  McpListIncidentSuggestionsInputBaseSchema,
+} from '@/mcp/tools/statusPages';
 import { mcpToolCallsTotal, mcpToolDurationSeconds } from '@/mcp/metrics';
+import { isFeatureEnabled } from '@/lib/feature-flags';
 
 export type McpContext = {
   siteId: string;
@@ -48,13 +58,18 @@ export function createMcpServer(context: McpContext): McpServer {
     version: '0.1.0',
   });
 
+  const available: ToolAvailability = {
+    uptimeMonitoring: isFeatureEnabled('enableUptimeMonitoring'),
+    publicStatusPages: isFeatureEnabled('enablePublicStatusPages'),
+  };
+
   server.registerTool(
     'describe',
     {
       description:
         'Returns available metrics, dimensions, filter columns, time ranges, and granularities. Call this first to understand what you can query.',
     },
-    () => runTool('describe', () => getSchemaDescription()),
+    () => runTool('describe', () => getSchemaDescription(available)),
   );
 
   server.registerTool(
@@ -127,5 +142,60 @@ export function createMcpServer(context: McpContext): McpServer {
     (params) => runTool('get_error', () => executeGetError(params, context.siteId)),
   );
 
+  if (available.uptimeMonitoring) {
+    registerMonitoringTools(server, context);
+  }
+  if (available.publicStatusPages) {
+    registerStatusPageTools(server, context);
+  }
+
   return server;
+}
+
+function registerMonitoringTools(server: McpServer, context: McpContext) {
+  server.registerTool(
+    'list_monitors',
+    {
+      description:
+        'List the uptime monitors configured for this dashboard with their current operational state (up, down, degraded, preparing, paused), plus uptime percentage and response time summary over the given time range. Use timeRange "24h" to answer "is my site up right now".',
+      inputSchema: McpListMonitorsInputBaseSchema.shape,
+    },
+    (params) => runTool('list_monitors', () => executeListMonitors(params, context.siteId, context.dashboardId)),
+  );
+
+  server.registerTool(
+    'list_monitor_incidents',
+    {
+      description:
+        "List detected downtime incidents (ongoing and resolved) for this dashboard's uptime monitors, newest first, with severity, duration, and failure reason. Filterable by monitor and incident state. SSL certificate incidents are not included; cert health is reported per monitor by list_monitors.",
+      inputSchema: McpListMonitorIncidentsInputBaseSchema.shape,
+    },
+    (params) =>
+      runTool('list_monitor_incidents', () =>
+        executeListMonitorIncidents(params, context.siteId, context.dashboardId),
+      ),
+  );
+}
+
+function registerStatusPageTools(server: McpServer, context: McpContext) {
+  server.registerTool(
+    'list_status_pages',
+    {
+      description:
+        "List this dashboard's public status pages exactly as visitors currently see them: published state, public URL, derived overall status, each attached monitor with its public name, status and uptime, and the incidents shown on the page with their full update timelines.",
+      inputSchema: McpListStatusPagesInputBaseSchema.shape,
+    },
+    (params) => runTool('list_status_pages', () => executeListStatusPages(params, context.dashboardId)),
+  );
+
+  server.registerTool(
+    'list_incident_suggestions',
+    {
+      description:
+        'List detected outages that are NOT covered by any incident posted on the status page. Use this to find out whether an ongoing outage is missing an incident, or whether a recent one was never documented. Each suggestion carries the detected incident id and the affected monitors. Every status page and every monitor attached to them is swept, so an empty result means nothing is uncovered. Only the last 90 days count, and a resolved outage stops being suggested 3 days after it recovered.',
+      inputSchema: McpListIncidentSuggestionsInputBaseSchema.shape,
+    },
+    (params) =>
+      runTool('list_incident_suggestions', () => executeListIncidentSuggestions(params, context.dashboardId)),
+  );
 }

--- a/dashboard/src/mcp/tools/describe.test.ts
+++ b/dashboard/src/mcp/tools/describe.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { getSchemaDescription } from '@/mcp/tools/describe';
+import { getSchemaDescription, type ToolAvailability } from '@/mcp/tools/describe';
+
+const ALL_ENABLED: ToolAvailability = { uptimeMonitoring: true, publicStatusPages: true };
 
 describe('getSchemaDescription', () => {
   it('returns all expected top-level keys', () => {
-    const result = getSchemaDescription();
+    const result = getSchemaDescription(ALL_ENABLED);
 
     expect(result).toHaveProperty('metrics');
     expect(result).toHaveProperty('dimensions');
@@ -15,7 +17,7 @@ describe('getSchemaDescription', () => {
   });
 
   it('returns metrics with key and description', () => {
-    const { metrics } = getSchemaDescription();
+    const { metrics } = getSchemaDescription(ALL_ENABLED);
 
     expect(metrics.length).toBeGreaterThan(0);
     for (const metric of metrics) {
@@ -27,23 +29,23 @@ describe('getSchemaDescription', () => {
   });
 
   it('includes the visitors metric', () => {
-    const { metrics } = getSchemaDescription();
+    const { metrics } = getSchemaDescription(ALL_ENABLED);
     expect(metrics.some((m) => m.key === 'visitors')).toBe(true);
   });
 
   it('includes the device_type dimension', () => {
-    const { dimensions } = getSchemaDescription();
+    const { dimensions } = getSchemaDescription(ALL_ENABLED);
     expect(dimensions.some((d) => d.key === 'device_type')).toBe(true);
   });
 
   it('includes referrer dimensions', () => {
-    const { dimensions } = getSchemaDescription();
+    const { dimensions } = getSchemaDescription(ALL_ENABLED);
     expect(dimensions.some((d) => d.key === 'referrer_source')).toBe(true);
     expect(dimensions.some((d) => d.key === 'referrer_source_name')).toBe(true);
   });
 
   it('returns filter columns with key and description', () => {
-    const { filterColumns } = getSchemaDescription();
+    const { filterColumns } = getSchemaDescription(ALL_ENABLED);
 
     expect(filterColumns.length).toBeGreaterThan(0);
     for (const col of filterColumns) {
@@ -55,26 +57,24 @@ describe('getSchemaDescription', () => {
   });
 
   it('documents global properties and points to the list_global_properties tool', () => {
-    const result = getSchemaDescription();
+    const result = getSchemaDescription(ALL_ENABLED);
     expect(result).toHaveProperty('globalProperties');
     expect(result.globalProperties.description).toContain('gp.');
     expect(result.globalProperties.description).toContain('list_global_properties');
   });
 
   it('includes list_global_properties in the tools section', () => {
-    const { tools } = getSchemaDescription();
-    expect(tools).toEqual(
-      expect.arrayContaining([expect.objectContaining({ name: 'list_global_properties' })]),
-    );
+    const { tools } = getSchemaDescription(ALL_ENABLED);
+    expect(tools).toEqual(expect.arrayContaining([expect.objectContaining({ name: 'list_global_properties' })]));
   });
 
   it('does not include custom in the timeRanges list', () => {
-    const { timeRanges } = getSchemaDescription();
+    const { timeRanges } = getSchemaDescription(ALL_ENABLED);
     expect(timeRanges).not.toContain('custom');
   });
 
   it('documents custom date range with example', () => {
-    const { customDateRange } = getSchemaDescription();
+    const { customDateRange } = getSchemaDescription(ALL_ENABLED);
     expect(customDateRange).toHaveProperty('description');
     expect(customDateRange).toHaveProperty('example');
     expect(customDateRange.example.timeRange).toBe('custom');
@@ -82,8 +82,49 @@ describe('getSchemaDescription', () => {
     expect(customDateRange.example.endDate).toBeDefined();
   });
 
+  it('includes the monitoring tools with their documented inputs', () => {
+    const { tools } = getSchemaDescription(ALL_ENABLED);
+
+    const monitors = tools.find((t) => t.name === 'list_monitors');
+    expect(monitors?.inputs.map((i) => i.name)).toEqual(['timeRange', 'timezone']);
+
+    const incidents = tools.find((t) => t.name === 'list_monitor_incidents');
+    expect(incidents?.inputs.map((i) => i.name)).toEqual(['timeRange', 'timezone', 'monitorId', 'state', 'limit']);
+  });
+
+  it('includes the status page tools with their documented inputs', () => {
+    const { tools } = getSchemaDescription(ALL_ENABLED);
+
+    const pages = tools.find((t) => t.name === 'list_status_pages');
+    expect(pages?.inputs.map((i) => i.name)).toEqual(['statusPageId']);
+
+    const suggestions = tools.find((t) => t.name === 'list_incident_suggestions');
+    expect(suggestions?.inputs.map((i) => i.name)).toEqual(['statusPageId']);
+  });
+
+  it('omits the optional tool groups when their deployment flags are off', () => {
+    const { tools } = getSchemaDescription({ uptimeMonitoring: false, publicStatusPages: false });
+    const names = tools.map((t) => t.name);
+
+    expect(names).not.toContain('list_monitors');
+    expect(names).not.toContain('list_monitor_incidents');
+    expect(names).not.toContain('list_status_pages');
+    expect(names).not.toContain('list_incident_suggestions');
+    // The always-on tools are untouched.
+    expect(names).toContain('query');
+    expect(names).toContain('list_errors');
+  });
+
+  it('can advertise monitoring without status pages', () => {
+    const { tools } = getSchemaDescription({ uptimeMonitoring: true, publicStatusPages: false });
+    const names = tools.map((t) => t.name);
+
+    expect(names).toContain('list_monitors');
+    expect(names).not.toContain('list_status_pages');
+  });
+
   it('includes tools section with user_journeys, funnel_preview, and list_funnels', () => {
-    const result = getSchemaDescription();
+    const result = getSchemaDescription(ALL_ENABLED);
     expect(result).toHaveProperty('tools');
     expect(result.tools).toEqual(
       expect.arrayContaining([

--- a/dashboard/src/mcp/tools/describe.ts
+++ b/dashboard/src/mcp/tools/describe.ts
@@ -6,6 +6,8 @@ import { TIME_RANGE_VALUES } from '@/utils/timeRanges';
 import { MCP_GRANULARITIES } from '@/mcp/entities/mcp.entities';
 
 type ToolInput = { name: string; type: string; required: boolean; description: string };
+type ToolDescription = { name: string; description: string; inputs: ToolInput[] };
+export type ToolAvailability = { uptimeMonitoring: boolean; publicStatusPages: boolean };
 
 type SchemaDescription = {
   metrics: { key: string; description: string }[];
@@ -23,7 +25,7 @@ type SchemaDescription = {
   tools: { name: string; description: string; inputs: ToolInput[] }[];
 };
 
-export function getSchemaDescription(): SchemaDescription {
+export function getSchemaDescription(available: ToolAvailability): SchemaDescription {
   return {
     metrics: METRICS.map((m) => ({ key: m.key, description: m.description })),
     dimensions: DIMENSIONS.map((d) => ({ key: d.key, description: d.description })),
@@ -205,7 +207,7 @@ export function getSchemaDescription(): SchemaDescription {
       {
         name: 'list_global_properties',
         description:
-          'Discover the custom event (global) properties recorded for this dashboard. Without a key, lists the property keys (each as a gp.<key> filter column); with a key, lists that property\'s example values.',
+          "Discover the custom event (global) properties recorded for this dashboard. Without a key, lists the property keys (each as a gp.<key> filter column); with a key, lists that property's example values.",
         inputs: [
           {
             name: 'timeRange',
@@ -246,7 +248,8 @@ export function getSchemaDescription(): SchemaDescription {
             name: 'fingerprint',
             type: 'string',
             required: false,
-            description: 'Look up a specific error by its fingerprint ID. Use a fingerprint from a previous list_errors call, or ask the user to retrieve it from the error details page in the Betterlytics dashboard.',
+            description:
+              'Look up a specific error by its fingerprint ID. Use a fingerprint from a previous list_errors call, or ask the user to retrieve it from the error details page in the Betterlytics dashboard.',
           },
           {
             name: 'filters',
@@ -271,7 +274,8 @@ export function getSchemaDescription(): SchemaDescription {
             name: 'fingerprint',
             type: 'string',
             required: true,
-            description: 'The error fingerprint identifier. Use list_errors to find it, or ask the user to retrieve it from the error details page in the Betterlytics dashboard.',
+            description:
+              'The error fingerprint identifier. Use list_errors to find it, or ask the user to retrieve it from the error details page in the Betterlytics dashboard.',
           },
           {
             name: 'occurrenceOffset',
@@ -288,6 +292,88 @@ export function getSchemaDescription(): SchemaDescription {
           },
         ],
       },
+      ...(available.uptimeMonitoring ? MONITORING_TOOLS : []),
+      ...(available.publicStatusPages ? STATUS_PAGE_TOOLS : []),
     ],
   };
 }
+
+const MONITORING_TOOLS: ToolDescription[] = [
+  {
+    name: 'list_monitors',
+    description:
+      'List uptime monitors with their current operational state (up, down, degraded, preparing, paused), uptime percentage, response time summary, and SSL certificate status. Use timeRange "24h" for a current-state check.',
+    inputs: [
+      {
+        name: 'timeRange',
+        type: 'string',
+        required: true,
+        description:
+          'Time range the uptime and response time summary covers. Valid values are listed in the timeRanges field of this schema. Operational state is always current, regardless of this range.',
+      },
+      { name: 'timezone', type: 'string', required: false, description: 'IANA time zone. Defaults to UTC.' },
+    ],
+  },
+  {
+    name: 'list_monitor_incidents',
+    description:
+      'List detected downtime incidents (ongoing and resolved) for the uptime monitors, newest first, with severity, duration, and failure reason. SSL certificate incidents are excluded; see the ssl field of list_monitors for cert health.',
+    inputs: [
+      {
+        name: 'timeRange',
+        type: 'string',
+        required: true,
+        description:
+          'Time range to search. Incidents overlapping the range are returned, including ones that started before it. Valid values are listed in the timeRanges field of this schema.',
+      },
+      { name: 'timezone', type: 'string', required: false, description: 'IANA time zone. Defaults to UTC.' },
+      {
+        name: 'monitorId',
+        type: 'string',
+        required: false,
+        description: 'Only return incidents for this monitor. Use an id from list_monitors.',
+      },
+      {
+        name: 'state',
+        type: 'string',
+        required: false,
+        description: '"ongoing" (still down) or "resolved". Omit for both.',
+      },
+      {
+        name: 'limit',
+        type: 'number',
+        required: false,
+        description: 'Max incidents to return (1-100). Defaults to 20.',
+      },
+    ],
+  },
+];
+
+const STATUS_PAGE_TOOLS: ToolDescription[] = [
+  {
+    name: 'list_status_pages',
+    description:
+      "The dashboard's public status pages as visitors currently see them: published state, public URL, derived overall status, attached monitors with their public names and uptime, and the incidents shown on the page with their update timelines. Takes no time range; it always reflects right now.",
+    inputs: [
+      {
+        name: 'statusPageId',
+        type: 'string',
+        required: false,
+        description: 'Only look at this status page. Use an id from list_status_pages. Omit for all of them.',
+      },
+    ],
+  },
+  {
+    name: 'list_incident_suggestions',
+    description:
+      'Detected outages that no posted status page incident covers, grouped per status page. Use this to tell whether an ongoing outage is missing an incident. Each suggestion includes its detected incident id and the affected monitors. Sweeps every status page and every monitor attached to them, so an empty result means nothing is uncovered. Scope caveats: only the last 90 days are considered, a resolved outage stops being suggested 3 days after it recovered, outages starting within 10 minutes of each other are folded into one suggestion, and at most 20 suggestions are returned per page.',
+    inputs: [
+      {
+        name: 'statusPageId',
+        type: 'string',
+        required: false,
+        description: 'Only look at this status page. Use an id from list_status_pages. Omit for all of them.',
+      },
+    ],
+  },
+];

--- a/dashboard/src/mcp/tools/monitoring.test.ts
+++ b/dashboard/src/mcp/tools/monitoring.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/services/analytics/monitoring.service', () => ({
+  getMonitorSummariesForRange: vi.fn(),
+  getMonitorIncidentsForRange: vi.fn(),
+}));
+
+vi.mock('@/lib/feature-flags', () => ({
+  isFeatureEnabled: vi.fn(() => true),
+}));
+
+import { getMonitorIncidentsForRange, getMonitorSummariesForRange } from '@/services/analytics/monitoring.service';
+import type { MonitorIncidentWithMonitor, MonitorRangeSummary } from '@/entities/analytics/monitoring.entities';
+import { isFeatureEnabled } from '@/lib/feature-flags';
+import {
+  McpListMonitorsInputSchema,
+  McpListMonitorIncidentsInputSchema,
+  executeListMonitors,
+  executeListMonitorIncidents,
+} from '@/mcp/tools/monitoring';
+
+const getSummaries = vi.mocked(getMonitorSummariesForRange);
+const getIncidents = vi.mocked(getMonitorIncidentsForRange);
+const featureEnabled = vi.mocked(isFeatureEnabled);
+
+const monitor = {
+  id: 'mon-1',
+  dashboardId: 'dash-1',
+  name: 'API health',
+  url: 'https://example.com/health',
+  isEnabled: true,
+  intervalSeconds: 300,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+} as MonitorRangeSummary['monitor'];
+
+const summary: MonitorRangeSummary = {
+  monitor,
+  operationalState: 'up',
+  currentStateSince: '2026-01-05T00:00:00.000Z',
+  lastCheckAt: '2026-02-01T10:00:00.000Z',
+  lastStatus: 'ok',
+  effectiveIntervalSeconds: 900,
+  backoffLevel: 2,
+  uptimePercent: 99.98765,
+  uptimeSeconds: 86391,
+  totalSeconds: 86400,
+  latency: { avgMs: 120.456, minMs: 90.1, maxMs: 800.99 },
+  tls: { ts: '2026-02-01T10:00:00.000Z', status: 'ok', reasonCode: null, tlsNotAfter: '2026-06-01T00:00:00.000Z' },
+};
+
+const incident: MonitorIncidentWithMonitor = {
+  incidentId: 'inc-1',
+  monitorCheckId: 'mon-1',
+  monitor,
+  state: 'resolved',
+  severity: 'critical',
+  reason: 'http_5xx',
+  startedAt: '2026-01-30T12:00:00.000Z',
+  resolvedAt: '2026-01-30T12:15:00.000Z',
+  durationMs: 900_000,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  featureEnabled.mockReturnValue(true);
+});
+
+describe('McpListMonitorsInputSchema', () => {
+  it('accepts valid input with just a time range', () => {
+    expect(McpListMonitorsInputSchema.safeParse({ timeRange: '24h' }).success).toBe(true);
+  });
+
+  it('rejects custom time range without dates', () => {
+    expect(McpListMonitorsInputSchema.safeParse({ timeRange: 'custom' }).success).toBe(false);
+  });
+});
+
+describe('executeListMonitors', () => {
+  it('returns monitors with operational state, uptime, and response times', async () => {
+    getSummaries.mockResolvedValue([summary]);
+
+    const result = await executeListMonitors({ timeRange: '24h' }, 'site-1', 'dash-1');
+
+    expect(getSummaries).toHaveBeenCalledOnce();
+    expect(result.total).toBe(1);
+    expect(result.monitors[0]).toMatchObject({
+      id: 'mon-1',
+      name: 'API health',
+      operational_state: 'up',
+      last_status: 'ok',
+      uptime: { percent: 99.988, up_seconds: 86391, measured_seconds: 86400 },
+      response_time_ms: { avg: 120.5, min: 90.1, max: 801 },
+    });
+  });
+
+  it('exposes cert staleness and the backed-off interval, not just the configured one', async () => {
+    getSummaries.mockResolvedValue([summary]);
+
+    const result = await executeListMonitors({ timeRange: '24h' }, 'site-1', 'dash-1');
+
+    expect(result.monitors[0]).toMatchObject({
+      check_interval_seconds: 300,
+      effective_check_interval_seconds: 900,
+      backoff_level: 2,
+      ssl: {
+        status: 'ok',
+        expires_at: '2026-06-01T00:00:00.000Z',
+        // The TLS read is unbounded in time, so the caller needs to see how old this result is.
+        checked_at: '2026-02-01T10:00:00.000Z',
+      },
+    });
+  });
+
+  it('returns every monitor rather than capping at a guessed ceiling', async () => {
+    const many = Array.from({ length: 120 }, (_, i) => ({
+      ...summary,
+      monitor: { ...monitor, id: `mon-${i}` },
+    }));
+    getSummaries.mockResolvedValue(many);
+
+    const result = await executeListMonitors({ timeRange: '24h' }, 'site-1', 'dash-1');
+
+    // A cap without an offset would strand the rest: nothing here can select a specific monitor.
+    expect(result.monitors).toHaveLength(120);
+    expect(result.total).toBe(120);
+  });
+
+  it('reports null uptime when nothing was measured', async () => {
+    getSummaries.mockResolvedValue([{ ...summary, uptimePercent: null, uptimeSeconds: 0, totalSeconds: 0 }]);
+
+    const result = await executeListMonitors({ timeRange: '24h' }, 'site-1', 'dash-1');
+
+    expect(result.monitors[0].uptime.percent).toBeNull();
+  });
+
+  it('errors instead of returning data when uptime monitoring is disabled', async () => {
+    featureEnabled.mockReturnValue(false);
+
+    await expect(executeListMonitors({ timeRange: '24h' }, 'site-1', 'dash-1')).rejects.toThrow(
+      'Uptime monitoring is not enabled',
+    );
+    expect(getSummaries).not.toHaveBeenCalled();
+  });
+});
+
+describe('McpListMonitorIncidentsInputSchema', () => {
+  it('accepts a monitor and state filter', () => {
+    expect(
+      McpListMonitorIncidentsInputSchema.safeParse({ timeRange: '7d', monitorId: 'mon-1', state: 'ongoing' })
+        .success,
+    ).toBe(true);
+  });
+
+  it('rejects an unknown incident state', () => {
+    expect(McpListMonitorIncidentsInputSchema.safeParse({ timeRange: '7d', state: 'flapping' }).success).toBe(
+      false,
+    );
+  });
+
+  it('rejects startDate after endDate', () => {
+    expect(
+      McpListMonitorIncidentsInputSchema.safeParse({
+        timeRange: 'custom',
+        startDate: '2026-02-01',
+        endDate: '2026-01-01',
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe('executeListMonitorIncidents', () => {
+  it('returns incidents with the monitor, duration, and a readable reason', async () => {
+    getIncidents.mockResolvedValue([incident]);
+
+    const result = await executeListMonitorIncidents({ timeRange: '7d' }, 'site-1', 'dash-1');
+
+    expect(result.count).toBe(1);
+    expect(result.truncated).toBe(false);
+    expect(result.incidents[0]).toMatchObject({
+      id: 'inc-1',
+      monitor_id: 'mon-1',
+      monitor_name: 'API health',
+      state: 'resolved',
+      severity: 'critical',
+      reason: 'http_5xx',
+      reason_description: 'Server returned a server error',
+      duration_ms: 900_000,
+    });
+  });
+
+  it('passes the monitor, state, and limit filters through to the service', async () => {
+    getIncidents.mockResolvedValue([]);
+
+    await executeListMonitorIncidents(
+      { timeRange: '7d', monitorId: 'mon-1', state: 'ongoing', limit: 5 },
+      'site-1',
+      'dash-1',
+    );
+
+    expect(getIncidents.mock.calls[0][2]).toMatchObject({ monitorId: 'mon-1', state: 'ongoing', limit: 6 });
+  });
+
+  it('does not flag truncation when the result lands exactly on the limit', async () => {
+    getIncidents.mockResolvedValue([incident]);
+
+    const result = await executeListMonitorIncidents({ timeRange: '7d', limit: 1 }, 'site-1', 'dash-1');
+
+    // One row came back for a limit of 1, but the service was asked for 2, so there is no more.
+    expect(getIncidents.mock.calls[0][2]).toMatchObject({ limit: 2 });
+    expect(result.count).toBe(1);
+    expect(result.truncated).toBe(false);
+  });
+
+  it('flags truncation and trims the over-fetched row when more exist', async () => {
+    getIncidents.mockResolvedValue([incident, { ...incident, incidentId: 'inc-2' }]);
+
+    const result = await executeListMonitorIncidents({ timeRange: '7d', limit: 1 }, 'site-1', 'dash-1');
+
+    expect(result.incidents).toHaveLength(1);
+    expect(result.count).toBe(1);
+    expect(result.truncated).toBe(true);
+  });
+
+  it('describes an unmapped reason code as unknown rather than dropping it', async () => {
+    getIncidents.mockResolvedValue([{ ...incident, reason: null }]);
+
+    const result = await executeListMonitorIncidents({ timeRange: '7d' }, 'site-1', 'dash-1');
+
+    expect(result.incidents[0].reason).toBeNull();
+    expect(result.incidents[0].reason_description).toBe('Unknown error');
+  });
+
+  it('errors instead of returning data when uptime monitoring is disabled', async () => {
+    featureEnabled.mockReturnValue(false);
+
+    await expect(executeListMonitorIncidents({ timeRange: '7d' }, 'site-1', 'dash-1')).rejects.toThrow(
+      'Uptime monitoring is not enabled',
+    );
+    expect(getIncidents).not.toHaveBeenCalled();
+  });
+});

--- a/dashboard/src/mcp/tools/monitoring.ts
+++ b/dashboard/src/mcp/tools/monitoring.ts
@@ -1,0 +1,139 @@
+import { z } from 'zod';
+import { McpDateRangeSchema, customDateRangeRefinement, dateOrderRefinement } from '@/mcp/entities/mcp.entities';
+import { resolveTimeRange } from '@/mcp/utils/resolveTimeRange';
+import { round } from '@/mcp/utils/round';
+import {
+  IncidentStateSchema,
+  type MonitorIncidentWithMonitor,
+  type MonitorRangeSummary,
+} from '@/entities/analytics/monitoring.entities';
+import { isFeatureEnabled } from '@/lib/feature-flags';
+import { getReasonTranslationKey, reasonCodeFallbackMessages } from '@/lib/monitorReasonCodes';
+import { getMonitorIncidentsForRange, getMonitorSummariesForRange } from '@/services/analytics/monitoring.service';
+
+function assertMonitoringEnabled() {
+  if (!isFeatureEnabled('enableUptimeMonitoring')) {
+    throw new Error('Uptime monitoring is not enabled on this Betterlytics deployment.');
+  }
+}
+
+export const McpListMonitorsInputBaseSchema = McpDateRangeSchema;
+
+export const McpListMonitorsInputSchema = McpListMonitorsInputBaseSchema.refine(
+  customDateRangeRefinement.check,
+  customDateRangeRefinement,
+).refine(dateOrderRefinement.check, dateOrderRefinement);
+
+function formatMonitor(summary: MonitorRangeSummary) {
+  const { monitor, tls } = summary;
+
+  return {
+    id: monitor.id,
+    name: monitor.name,
+    url: monitor.url,
+    enabled: monitor.isEnabled,
+    operational_state: summary.operationalState,
+    state_since: summary.currentStateSince,
+    last_check_at: summary.lastCheckAt,
+    last_status: summary.lastStatus,
+    check_interval_seconds: monitor.intervalSeconds,
+    effective_check_interval_seconds: summary.effectiveIntervalSeconds,
+    backoff_level: summary.backoffLevel,
+    uptime: {
+      percent: round(summary.uptimePercent, 3),
+      up_seconds: summary.uptimeSeconds,
+      measured_seconds: summary.totalSeconds,
+    },
+    response_time_ms: {
+      avg: round(summary.latency.avgMs, 1),
+      min: round(summary.latency.minMs, 1),
+      max: round(summary.latency.maxMs, 1),
+    },
+    ssl: tls
+      ? {
+          status: tls.status,
+          expires_at: tls.tlsNotAfter,
+          reason: tls.reasonCode,
+          reason_description: reasonCodeFallbackMessages[getReasonTranslationKey(tls.reasonCode)],
+          checked_at: tls.ts,
+        }
+      : null,
+  };
+}
+
+export async function executeListMonitors(rawInput: unknown, siteId: string, dashboardId: string) {
+  assertMonitoringEnabled();
+
+  const input = McpListMonitorsInputSchema.parse(rawInput);
+  const { start, end } = resolveTimeRange(input);
+
+  const monitors = await getMonitorSummariesForRange(dashboardId, siteId, start, end);
+
+  return {
+    monitors: monitors.map(formatMonitor),
+    total: monitors.length,
+    time_range: { start: start.toISOString(), end: end.toISOString() },
+  };
+}
+
+export const McpListMonitorIncidentsInputBaseSchema = McpDateRangeSchema.extend({
+  monitorId: z
+    .string()
+    .optional()
+    .describe('Only return incidents for this monitor. Use an id from list_monitors.'),
+  state: IncidentStateSchema.optional().describe(
+    'Only return incidents in this state: "ongoing" (still down) or "resolved". Omit for both.',
+  ),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .default(20)
+    .describe('Max number of incidents to return (1-100). Defaults to 20.'),
+});
+
+export const McpListMonitorIncidentsInputSchema = McpListMonitorIncidentsInputBaseSchema.refine(
+  customDateRangeRefinement.check,
+  customDateRangeRefinement,
+).refine(dateOrderRefinement.check, dateOrderRefinement);
+
+function formatIncident(incident: MonitorIncidentWithMonitor) {
+  return {
+    id: incident.incidentId,
+    monitor_id: incident.monitor.id,
+    monitor_name: incident.monitor.name,
+    monitor_url: incident.monitor.url,
+    state: incident.state,
+    severity: incident.severity,
+    reason: incident.reason,
+    reason_description: reasonCodeFallbackMessages[getReasonTranslationKey(incident.reason)],
+    started_at: incident.startedAt,
+    resolved_at: incident.resolvedAt,
+    duration_ms: incident.durationMs,
+  };
+}
+
+export async function executeListMonitorIncidents(rawInput: unknown, siteId: string, dashboardId: string) {
+  assertMonitoringEnabled();
+
+  const input = McpListMonitorIncidentsInputSchema.parse(rawInput);
+  const { start, end } = resolveTimeRange(input);
+
+  const fetched = await getMonitorIncidentsForRange(dashboardId, siteId, {
+    start,
+    end,
+    monitorId: input.monitorId,
+    state: input.state,
+    limit: input.limit + 1,
+  });
+  const incidents = fetched.slice(0, input.limit);
+
+  return {
+    incidents: incidents.map(formatIncident),
+    count: incidents.length,
+    truncated: fetched.length > input.limit,
+    time_range: { start: start.toISOString(), end: end.toISOString() },
+  };
+}

--- a/dashboard/src/mcp/tools/statusPages.test.ts
+++ b/dashboard/src/mcp/tools/statusPages.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/services/analytics/statusPage.service', () => ({
+  getStatusPagesForDashboard: vi.fn(),
+}));
+
+vi.mock('@/services/analytics/publicStatusPage.service', () => ({
+  getStatusPageLivePreviewData: vi.fn(),
+}));
+
+vi.mock('@/services/analytics/statusPageIncident.service', () => ({
+  getIncidentSuggestions: vi.fn(),
+}));
+
+vi.mock('@/lib/feature-flags', () => ({
+  isFeatureEnabled: vi.fn(() => true),
+}));
+
+vi.mock('@/lib/env', () => ({
+  env: { PUBLIC_BASE_URL: 'https://betterlytics.io' },
+}));
+
+import { getStatusPagesForDashboard } from '@/services/analytics/statusPage.service';
+import { getStatusPageLivePreviewData } from '@/services/analytics/publicStatusPage.service';
+import { getIncidentSuggestions } from '@/services/analytics/statusPageIncident.service';
+import { isFeatureEnabled } from '@/lib/feature-flags';
+import type { StatusPageListItem } from '@/entities/analytics/statusPage/statusPage.entities';
+import type { StatusPagePreviewPayload } from '@/entities/analytics/statusPage/publicStatusPage.entities';
+import type { DetectedOutageSuggestion } from '@/entities/analytics/statusPage/statusPageIncident.entities';
+import { executeListStatusPages, executeListIncidentSuggestions } from '@/mcp/tools/statusPages';
+
+const listPages = vi.mocked(getStatusPagesForDashboard);
+const livePreview = vi.mocked(getStatusPageLivePreviewData);
+const suggestions = vi.mocked(getIncidentSuggestions);
+const featureEnabled = vi.mocked(isFeatureEnabled);
+
+const page = {
+  id: 'sp-1',
+  name: 'Betterlytics Status',
+  slug: 'betterlytics',
+  isPublished: true,
+  visibility: 'public',
+  customDomain: null,
+  showPastIncidents: true,
+  monitorCount: 1,
+  monitors: [{ monitorCheckId: 'mon-1', publicName: 'API' }],
+  activeIncidentCount: 1,
+} as StatusPageListItem;
+
+const payload = {
+  data: {
+    name: 'Betterlytics Status',
+    slug: 'betterlytics',
+    overallStatus: 'partial_outage',
+    overallUptime: 99.9876,
+    lastUpdatedAt: '2026-02-01T10:00:00.000Z',
+    monitors: [{ key: '0', publicName: 'API', status: 'down', uptime: 98.7654, days: [] }],
+    incidents: [
+      {
+        title: 'API is unreachable',
+        body: 'Investigating',
+        description: 'Customers cannot reach the API.',
+        impact: 'outage',
+        status: 'investigating',
+        monitorPublicNames: ['API'],
+        startedAt: '2026-02-01T09:00:00.000Z',
+        resolvedAt: null,
+        updates: [{ status: 'investigating', message: 'Investigating', createdAt: '2026-02-01T09:05:00.000Z' }],
+      },
+    ],
+  },
+  monitorCheckIds: ['mon-1'],
+  detectedStatuses: ['down'],
+  incidentMonitorCheckIds: [['mon-1']],
+} as unknown as StatusPagePreviewPayload;
+
+const suggestion: DetectedOutageSuggestion = {
+  detectedIncidentId: 'det-1',
+  monitors: [{ monitorCheckId: 'mon-1', monitorPublicName: 'API' }],
+  startedAt: '2026-02-01T09:00:00.000Z',
+  resolvedAt: null,
+  ongoing: true,
+  suggestedImpact: 'outage',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  featureEnabled.mockReturnValue(true);
+});
+
+describe('executeListStatusPages', () => {
+  it('returns what the page currently shows visitors, including open incidents', async () => {
+    listPages.mockResolvedValue([page]);
+    livePreview.mockResolvedValue(payload);
+
+    const result = await executeListStatusPages({}, 'dash-1');
+
+    expect(result.total).toBe(1);
+    expect(result.status_pages[0]).toMatchObject({
+      id: 'sp-1',
+      slug: 'betterlytics',
+      public_url: 'https://betterlytics.io/status/betterlytics',
+      published: true,
+      overall_status: 'partial_outage',
+      overall_uptime_percent: 99.988,
+      monitors: [{ monitor_id: 'mon-1', public_name: 'API', status: 'down', uptime_percent: 98.765 }],
+    });
+    expect(result.status_pages[0].incidents[0]).toMatchObject({
+      title: 'API is unreachable',
+      impact: 'outage',
+      status: 'investigating',
+      affected_monitors: ['API'],
+      resolved_at: null,
+      updates: [{ status: 'investigating', message: 'Investigating' }],
+    });
+  });
+
+  it('prefers the custom domain for the public URL', async () => {
+    listPages.mockResolvedValue([{ ...page, customDomain: 'status.example.com' }]);
+    livePreview.mockResolvedValue(payload);
+
+    const result = await executeListStatusPages({}, 'dash-1');
+
+    expect(result.status_pages[0].public_url).toBe('https://status.example.com');
+  });
+
+  it('scopes to a single status page', async () => {
+    listPages.mockResolvedValue([page, { ...page, id: 'sp-2' }]);
+    livePreview.mockResolvedValue(payload);
+
+    const result = await executeListStatusPages({ statusPageId: 'sp-2' }, 'dash-1');
+
+    expect(result.status_pages).toHaveLength(1);
+    // total counts what matched the request, not every page on the dashboard.
+    expect(result.total).toBe(1);
+    expect(livePreview).toHaveBeenCalledExactlyOnceWith('dash-1', 'sp-2');
+  });
+
+  it('returns every status page rather than capping at a guessed ceiling', async () => {
+    const pages = Array.from({ length: 12 }, (_, i) => ({ ...page, id: `sp-${i}` }));
+    listPages.mockResolvedValue(pages);
+    livePreview.mockResolvedValue(payload);
+
+    const result = await executeListStatusPages({}, 'dash-1');
+
+    // A cap without an offset would strand pages 11+ : their ids only come from this tool.
+    expect(livePreview).toHaveBeenCalledTimes(12);
+    expect(result.status_pages).toHaveLength(12);
+    expect(result.total).toBe(12);
+  });
+
+  it('rejects a status page id that does not belong to the dashboard', async () => {
+    listPages.mockResolvedValue([page]);
+
+    await expect(executeListStatusPages({ statusPageId: 'sp-other' }, 'dash-1')).rejects.toThrow(
+      'Status page not found',
+    );
+    expect(livePreview).not.toHaveBeenCalled();
+  });
+
+  it('still reports the page when its live data cannot be assembled', async () => {
+    listPages.mockResolvedValue([page]);
+    livePreview.mockResolvedValue(null);
+
+    const result = await executeListStatusPages({}, 'dash-1');
+
+    expect(result.status_pages[0]).toMatchObject({
+      id: 'sp-1',
+      overall_status: null,
+      monitors: [],
+      incidents: [],
+    });
+  });
+
+  it('errors instead of returning data when status pages are disabled', async () => {
+    featureEnabled.mockReturnValue(false);
+
+    await expect(executeListStatusPages({}, 'dash-1')).rejects.toThrow('Public status pages are not enabled');
+    expect(listPages).not.toHaveBeenCalled();
+  });
+});
+
+describe('executeListIncidentSuggestions', () => {
+  it('reports uncovered outages per status page with their detected incident ids', async () => {
+    listPages.mockResolvedValue([page]);
+    suggestions.mockResolvedValue([suggestion]);
+
+    const result = await executeListIncidentSuggestions({}, 'dash-1');
+
+    expect(result.total_suggestions).toBe(1);
+    expect(result.status_pages[0]).toMatchObject({
+      status_page_id: 'sp-1',
+      status_page_name: 'Betterlytics Status',
+      published: true,
+    });
+    expect(result.status_pages[0].suggestions[0]).toMatchObject({
+      detected_incident_id: 'det-1',
+      ongoing: true,
+      suggested_impact: 'outage',
+      monitors: [{ monitor_id: 'mon-1', public_name: 'API' }],
+    });
+  });
+
+  it('reports an empty suggestion list when every outage is already posted', async () => {
+    listPages.mockResolvedValue([page]);
+    suggestions.mockResolvedValue([]);
+
+    const result = await executeListIncidentSuggestions({}, 'dash-1');
+
+    expect(result.total_suggestions).toBe(0);
+    expect(result.status_pages[0].suggestions).toEqual([]);
+  });
+
+  it('totals suggestions across every status page', async () => {
+    listPages.mockResolvedValue([page, { ...page, id: 'sp-2' }]);
+    suggestions.mockResolvedValueOnce([suggestion]).mockResolvedValueOnce([suggestion, suggestion]);
+
+    const result = await executeListIncidentSuggestions({}, 'dash-1');
+
+    expect(result.total_suggestions).toBe(3);
+  });
+
+  it('sweeps every status page rather than capping the scan', async () => {
+    const pages = Array.from({ length: 12 }, (_, i) => ({ ...page, id: `sp-${i}` }));
+    listPages.mockResolvedValue(pages);
+    suggestions.mockResolvedValue([]);
+
+    const result = await executeListIncidentSuggestions({}, 'dash-1');
+
+    // An unchecked page would make an empty result read as a clean bill of health.
+    expect(suggestions).toHaveBeenCalledTimes(12);
+    expect(result.status_pages).toHaveLength(12);
+    expect(result.total_status_pages).toBe(12);
+  });
+
+  it('errors instead of returning data when status pages are disabled', async () => {
+    featureEnabled.mockReturnValue(false);
+
+    await expect(executeListIncidentSuggestions({}, 'dash-1')).rejects.toThrow(
+      'Public status pages are not enabled',
+    );
+    expect(suggestions).not.toHaveBeenCalled();
+  });
+});

--- a/dashboard/src/mcp/tools/statusPages.ts
+++ b/dashboard/src/mcp/tools/statusPages.ts
@@ -1,0 +1,138 @@
+import { z } from 'zod';
+import { env } from '@/lib/env';
+import { isFeatureEnabled } from '@/lib/feature-flags';
+import { round } from '@/mcp/utils/round';
+import { statusPagePublicUrl } from '@/entities/analytics/statusPage/statusPage.helpers';
+import type { StatusPageListItem } from '@/entities/analytics/statusPage/statusPage.entities';
+import type {
+  PublicStatusPageIncident,
+  StatusPagePreviewPayload,
+} from '@/entities/analytics/statusPage/publicStatusPage.entities';
+import type { DetectedOutageSuggestion } from '@/entities/analytics/statusPage/statusPageIncident.entities';
+import { getStatusPagesForDashboard } from '@/services/analytics/statusPage.service';
+import { getStatusPageLivePreviewData } from '@/services/analytics/publicStatusPage.service';
+import { getIncidentSuggestions } from '@/services/analytics/statusPageIncident.service';
+
+function assertStatusPagesEnabled() {
+  if (!isFeatureEnabled('enablePublicStatusPages')) {
+    throw new Error('Public status pages are not enabled on this Betterlytics deployment.');
+  }
+}
+
+/** Narrows the dashboard's status pages to the requested one, rejecting an id that isn't ours. */
+function scopeToStatusPage<T extends { id: string }>(pages: T[], statusPageId?: string): T[] {
+  if (!statusPageId) return pages;
+
+  const scoped = pages.filter((page) => page.id === statusPageId);
+  if (!scoped.length) throw new Error('Status page not found');
+  return scoped;
+}
+
+const statusPageIdInput = z
+  .string()
+  .optional()
+  .describe('Only look at this status page. Use an id from list_status_pages. Omit for all of them.');
+
+export const McpListStatusPagesInputBaseSchema = z.object({
+  statusPageId: statusPageIdInput,
+});
+
+function formatIncident(incident: PublicStatusPageIncident) {
+  return {
+    title: incident.title,
+    description: incident.description,
+    impact: incident.impact,
+    status: incident.status,
+    // Empty means the incident is shown as affecting the whole page.
+    affected_monitors: incident.monitorPublicNames,
+    started_at: incident.startedAt,
+    resolved_at: incident.resolvedAt,
+    updates: incident.updates.map((update) => ({
+      status: update.status,
+      message: update.message,
+      created_at: update.createdAt,
+    })),
+  };
+}
+
+function formatStatusPage(page: StatusPageListItem, payload: StatusPagePreviewPayload | null) {
+  const data = payload?.data;
+
+  return {
+    id: page.id,
+    name: page.name,
+    slug: page.slug,
+    public_url: statusPagePublicUrl(page, env.PUBLIC_BASE_URL),
+    published: page.isPublished,
+    visibility: page.visibility,
+    custom_domain: page.customDomain,
+    shows_past_incidents: page.showPastIncidents,
+    overall_status: data?.overallStatus ?? null,
+    overall_uptime_percent: round(data?.overallUptime, 3),
+    last_updated_at: data?.lastUpdatedAt ?? null,
+    monitors: (data?.monitors ?? []).map((monitor, index) => ({
+      monitor_id: payload?.monitorCheckIds[index] ?? null,
+      public_name: monitor.publicName,
+      status: monitor.status,
+      uptime_percent: round(monitor.uptime, 3),
+    })),
+    incidents: (data?.incidents ?? []).map(formatIncident),
+  };
+}
+
+export async function executeListStatusPages(rawInput: unknown, dashboardId: string) {
+  assertStatusPagesEnabled();
+
+  const input = McpListStatusPagesInputBaseSchema.parse(rawInput);
+  const pages = await getStatusPagesForDashboard(dashboardId);
+  const selected = scopeToStatusPage(pages, input.statusPageId);
+
+  const payloads = await Promise.all(selected.map((page) => getStatusPageLivePreviewData(dashboardId, page.id)));
+
+  return {
+    status_pages: selected.map((page, index) => formatStatusPage(page, payloads[index])),
+    total: selected.length,
+  };
+}
+
+export const McpListIncidentSuggestionsInputBaseSchema = z.object({
+  statusPageId: statusPageIdInput,
+});
+
+function formatSuggestion(suggestion: DetectedOutageSuggestion) {
+  return {
+    detected_incident_id: suggestion.detectedIncidentId,
+    monitors: suggestion.monitors.map((monitor) => ({
+      monitor_id: monitor.monitorCheckId,
+      public_name: monitor.monitorPublicName,
+    })),
+    started_at: suggestion.startedAt,
+    resolved_at: suggestion.resolvedAt,
+    ongoing: suggestion.ongoing,
+    suggested_impact: suggestion.suggestedImpact,
+  };
+}
+
+export async function executeListIncidentSuggestions(rawInput: unknown, dashboardId: string) {
+  assertStatusPagesEnabled();
+
+  const input = McpListIncidentSuggestionsInputBaseSchema.parse(rawInput);
+  const pages = await getStatusPagesForDashboard(dashboardId);
+  const selected = scopeToStatusPage(pages, input.statusPageId);
+
+  const suggestionsByPage = await Promise.all(
+    selected.map((page) => getIncidentSuggestions(dashboardId, page.id)),
+  );
+
+  return {
+    status_pages: selected.map((page, index) => ({
+      status_page_id: page.id,
+      status_page_name: page.name,
+      slug: page.slug,
+      published: page.isPublished,
+      suggestions: suggestionsByPage[index].map(formatSuggestion),
+    })),
+    total_suggestions: suggestionsByPage.reduce((sum, suggestions) => sum + suggestions.length, 0),
+    total_status_pages: selected.length,
+  };
+}

--- a/dashboard/src/mcp/utils/round.test.ts
+++ b/dashboard/src/mcp/utils/round.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { round } from '@/mcp/utils/round';
+
+describe('round', () => {
+  it('rounds to the requested number of decimals', () => {
+    expect(round(99.98765, 3)).toBe(99.988);
+    expect(round(120.456, 1)).toBe(120.5);
+    expect(round(800.99, 1)).toBe(801);
+  });
+
+  it('passes null and undefined straight through', () => {
+    expect(round(null, 2)).toBeNull();
+    expect(round(undefined, 2)).toBeNull();
+  });
+
+  it('keeps zero rather than treating it as absent', () => {
+    expect(round(0, 2)).toBe(0);
+  });
+
+  it('handles negatives and whole numbers', () => {
+    expect(round(-1.005, 2)).toBe(-1);
+    expect(round(42, 3)).toBe(42);
+  });
+});

--- a/dashboard/src/mcp/utils/round.ts
+++ b/dashboard/src/mcp/utils/round.ts
@@ -1,0 +1,9 @@
+/**
+ * Rounds a nullable metric for MCP responses. Raw ClickHouse averages carry far more precision than
+ * an agent can use, and the extra digits are pure token cost in the JSON payload.
+ */
+export function round(value: number | null | undefined, decimals: number): number | null {
+  if (value == null) return null;
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+}

--- a/dashboard/src/repositories/clickhouse/monitoring.repository.ts
+++ b/dashboard/src/repositories/clickhouse/monitoring.repository.ts
@@ -20,10 +20,13 @@ import {
   type MonitorLatencyPoint,
   MonitorIncidentSegmentSchema,
   type MonitorIncidentSegment,
+  MonitorIncidentRecordSchema,
+  type MonitorIncidentRecord,
+  type IncidentState,
   DetectedOutageRowSchema,
   type DetectedOutageRow,
 } from '@/entities/analytics/monitoring.entities';
-import { toIsoUtc } from '@/utils/dateHelpers';
+import { parseClickHouseDate, toIsoUtc } from '@/utils/dateHelpers';
 import { groupByKey } from '@/utils/collections';
 
 type UptimeBucketRow = { date: string; uptime_seconds: number | null; total_seconds: number };
@@ -50,7 +53,10 @@ function parseIncidentSegmentRow(row: IncidentSegmentRow): MonitorIncidentSegmen
     reason: row.reason_code,
     start: toIsoUtc(row.started_at) ?? row.started_at,
     end: row.resolved_at ? (toIsoUtc(row.resolved_at) ?? row.resolved_at) : null,
-    durationMs: row.started_at && end ? new Date(end).getTime() - new Date(row.started_at).getTime() : null,
+    durationMs:
+      row.started_at && end
+        ? parseClickHouseDate(end).getTime() - parseClickHouseDate(row.started_at).getTime()
+        : null,
   });
 }
 
@@ -557,6 +563,179 @@ export async function getIncidentSegmentsForMonitors(
   return groupByKey(rows, (row) => row.check_id, parseIncidentSegmentRow);
 }
 
+export async function getUptimeStatsForMonitors(
+  monitors: Array<{ checkId: string; createdAt: Date }>,
+  siteId: string,
+  rangeStart: string,
+  rangeEnd: string,
+): Promise<Map<string, UptimeStats>> {
+  if (!monitors.length) return new Map();
+
+  const checkIds = monitors.map((monitor) => monitor.checkId);
+  const createdAts = monitors.map((monitor) => toDateTimeString(monitor.createdAt));
+
+  const query = safeSql`
+    WITH
+      monitors AS (
+        SELECT
+          tupleElement(pair, 1) AS check_id,
+          tupleElement(pair, 2) AS created_at
+        FROM (
+          SELECT arrayJoin(arrayZip({check_ids:Array(String)}, {created_ats:Array(DateTime)})) AS pair
+        )
+      ),
+      downtime AS (
+        SELECT
+          check_id,
+          sum(
+            greatest(
+              0,
+              dateDiff(
+                'second',
+                greatest(started_at, ${SQL.DateTime({ rangeStart })}),
+                least(coalesce(resolved_at, now()), ${SQL.DateTime({ rangeEnd })})
+              )
+            )
+          ) AS downtime_seconds
+        FROM analytics.monitor_incidents FINAL
+        WHERE check_id IN ({check_ids:Array(String)})
+          AND site_id = {site_id:String}
+          AND kind != 'tls'
+          AND started_at < ${SQL.DateTime({ rangeEnd })}
+          AND (resolved_at IS NULL OR resolved_at > ${SQL.DateTime({ rangeStart })})
+        GROUP BY check_id
+      )
+    SELECT
+      m.check_id AS check_id,
+      greatest(0, dateDiff(
+        'second',
+        greatest(m.created_at, ${SQL.DateTime({ rangeStart })}),
+        least(now(), ${SQL.DateTime({ rangeEnd })})
+      )) AS total_seconds,
+      coalesce(d.downtime_seconds, 0) AS downtime_seconds
+    FROM monitors AS m
+    LEFT JOIN downtime AS d ON d.check_id = m.check_id
+  `;
+
+  const rows = (await clickhouse
+    .query(query.taggedSql, {
+      params: {
+        ...query.taggedParams,
+        check_ids: checkIds,
+        created_ats: createdAts,
+        site_id: siteId,
+      },
+    })
+    .toPromise()) as { check_id: string; total_seconds: number; downtime_seconds: number }[];
+
+  return new Map(
+    rows.map((row) => [
+      row.check_id,
+      UptimeStatsSchema.parse({
+        uptimeSeconds: Math.max(0, row.total_seconds - row.downtime_seconds),
+        totalSeconds: row.total_seconds,
+      }),
+    ]),
+  );
+}
+
+export async function getLatencyStatsForMonitors(
+  checkIds: string[],
+  siteId: string,
+  rangeStart: string,
+  rangeEnd: string,
+): Promise<Map<string, MonitorLatencyStats>> {
+  if (!checkIds.length) return new Map();
+
+  const query = safeSql`
+    SELECT
+      check_id,
+      avg(latency_ms) AS avg_ms,
+      min(latency_ms) AS min_ms,
+      max(latency_ms) AS max_ms
+    FROM analytics.monitor_results
+    WHERE check_id IN ({check_ids:Array(String)})
+      AND site_id = {site_id:String}
+      AND kind != 'tls'
+      AND ts >= ${SQL.DateTime({ rangeStart })}
+      AND ts < ${SQL.DateTime({ rangeEnd })}
+      AND latency_ms IS NOT NULL
+    GROUP BY check_id
+  `;
+
+  const rows = (await clickhouse
+    .query(query.taggedSql, {
+      params: { ...query.taggedParams, check_ids: checkIds, site_id: siteId },
+    })
+    .toPromise()) as {
+    check_id: string;
+    avg_ms: number | null;
+    min_ms: number | null;
+    max_ms: number | null;
+  }[];
+
+  return new Map(
+    rows.map((row) => [
+      row.check_id,
+      MonitorLatencyStatsSchema.parse({ avgMs: row.avg_ms, minMs: row.min_ms, maxMs: row.max_ms }),
+    ]),
+  );
+}
+
+export async function getMonitorIncidentsInRange(
+  checkIds: string[],
+  siteId: string,
+  rangeStart: string,
+  rangeEnd: string,
+  limit: number,
+  state?: IncidentState,
+): Promise<MonitorIncidentRecord[]> {
+  if (!checkIds.length) return [];
+
+  const stateCondition = state ? safeSql`state = ${SQL.String({ state })}` : safeSql`1=1`;
+
+  const query = safeSql`
+    SELECT
+      toString(incident_id) AS incident_id,
+      check_id,
+      state,
+      severity,
+      reason_code,
+      started_at,
+      resolved_at,
+      last_event_at
+    FROM analytics.monitor_incidents FINAL
+    WHERE check_id IN ({check_ids:Array(String)})
+      AND site_id = {site_id:String}
+      AND kind != 'tls'
+      AND started_at < ${SQL.DateTime({ rangeEnd })}
+      AND (resolved_at IS NULL OR resolved_at > ${SQL.DateTime({ rangeStart })})
+      AND ${stateCondition}
+    ORDER BY started_at DESC
+    LIMIT {limit:UInt32}
+  `;
+
+  const rows = (await clickhouse
+    .query(query.taggedSql, {
+      params: { ...query.taggedParams, check_ids: checkIds, site_id: siteId, limit },
+    })
+    .toPromise()) as (IncidentSegmentRow & { incident_id: string; check_id: string; severity: string })[];
+
+  return rows.map((row) => {
+    // An ongoing incident has no resolved_at, so its duration so far runs to the latest failing check.
+    const end = row.resolved_at ?? row.last_event_at;
+    return MonitorIncidentRecordSchema.parse({
+      incidentId: row.incident_id,
+      monitorCheckId: row.check_id,
+      state: row.state,
+      severity: row.severity,
+      reason: row.reason_code,
+      startedAt: toIsoUtc(row.started_at) ?? row.started_at,
+      resolvedAt: row.resolved_at ? (toIsoUtc(row.resolved_at) ?? row.resolved_at) : null,
+      durationMs: end ? parseClickHouseDate(end).getTime() - parseClickHouseDate(row.started_at).getTime() : null,
+    });
+  });
+}
 
 /**
  * Detected outages to suggest as incidents: ongoing ones, plus recently-recovered ones (within

--- a/dashboard/src/services/analytics/monitoring.service.ts
+++ b/dashboard/src/services/analytics/monitoring.service.ts
@@ -5,10 +5,13 @@ import { toDateTimeString } from '@/utils/dateFormatters';
 import {
   MonitorCheckCreate,
   MonitorCheckUpdate,
+  type IncidentState,
   type MonitorDailyUptime,
   type MonitorIncidentSegment,
+  type MonitorIncidentWithMonitor,
   type MonitorMetrics,
   type MonitorOperationalState,
+  type MonitorRangeSummary,
   type MonitorResult,
   type MonitorTlsResult,
   type MonitorUptimeBucket,
@@ -37,6 +40,9 @@ import {
   getLastResolvedIncidentForMonitors,
   getUptime24h,
   getUptimeBuckets24h,
+  getUptimeStatsForMonitors,
+  getLatencyStatsForMonitors,
+  getMonitorIncidentsInRange,
   getMonitorDailyUptime,
   getIncidentSegments24h,
 } from '@/repositories/clickhouse/monitoring.repository';
@@ -250,6 +256,91 @@ export async function fetchMonitorIncidentSegments(
   limit = 5,
 ): Promise<MonitorIncidentSegment[]> {
   return getMonitorIncidentSegments(monitorId, siteId, days, limit);
+}
+
+export async function getMonitorSummariesForRange(
+  dashboardId: string,
+  siteId: string,
+  start: Date,
+  end: Date,
+): Promise<MonitorRangeSummary[]> {
+  const checks = await listMonitorChecks(dashboardId);
+  if (!checks.length) return [];
+
+  const checkIds = checks.map((check) => check.id);
+  const rangeStart = toDateTimeString(start);
+  const rangeEnd = toDateTimeString(end);
+
+  const [openIncidents, lastResolvedIncidents, latestCheckInfo, uptimeStats, latencyStats, tlsResults] =
+    await Promise.all([
+      getOpenIncidentsForMonitors(checkIds, siteId),
+      getLastResolvedIncidentForMonitors(checkIds, siteId),
+      getLatestCheckInfoForMonitors(checkIds, siteId),
+      getUptimeStatsForMonitors(
+        checks.map((check) => ({ checkId: check.id, createdAt: check.createdAt })),
+        siteId,
+        rangeStart,
+        rangeEnd,
+      ),
+      getLatencyStatsForMonitors(checkIds, siteId, rangeStart, rangeEnd),
+      getLatestTlsResultsForMonitors(checkIds, siteId),
+    ]);
+
+  return checks.map((check) => {
+    const checkInfo = latestCheckInfo[check.id];
+    const openIncident = openIncidents.get(check.id);
+    const operationalState = deriveOperationalState(check.isEnabled, checkInfo?.ts != null, openIncident != null);
+    const uptime = uptimeStats.get(check.id) ?? { uptimeSeconds: 0, totalSeconds: 0 };
+
+    return {
+      monitor: check,
+      operationalState,
+      currentStateSince: deriveCurrentStateSince(operationalState, {
+        openIncident,
+        lastResolvedIncident: lastResolvedIncidents.get(check.id),
+        createdAt: check.createdAt,
+      }),
+      lastCheckAt: checkInfo?.ts ?? null,
+      lastStatus: checkInfo?.status ?? null,
+      effectiveIntervalSeconds: checkInfo?.effectiveIntervalSeconds ?? null,
+      backoffLevel: checkInfo?.backoffLevel ?? null,
+      uptimePercent: uptime.totalSeconds > 0 ? (uptime.uptimeSeconds / uptime.totalSeconds) * 100 : null,
+      uptimeSeconds: uptime.uptimeSeconds,
+      totalSeconds: uptime.totalSeconds,
+      latency: latencyStats.get(check.id) ?? { avgMs: null, minMs: null, maxMs: null },
+      tls: tlsResults[check.id] ?? null,
+    };
+  });
+}
+
+export async function getMonitorIncidentsForRange(
+  dashboardId: string,
+  siteId: string,
+  options: { start: Date; end: Date; monitorId?: string; state?: IncidentState; limit: number },
+): Promise<MonitorIncidentWithMonitor[]> {
+  const scoped = options.monitorId
+    ? [await getMonitorCheckById(dashboardId, options.monitorId)].filter((check) => check != null)
+    : await listMonitorChecks(dashboardId);
+
+  if (options.monitorId && !scoped.length) {
+    throw new Error('Monitor not found');
+  }
+  if (!scoped.length) return [];
+
+  const monitorsById = new Map(scoped.map((check) => [check.id, check]));
+  const incidents = await getMonitorIncidentsInRange(
+    scoped.map((check) => check.id),
+    siteId,
+    toDateTimeString(options.start),
+    toDateTimeString(options.end),
+    options.limit,
+    options.state,
+  );
+
+  return incidents.flatMap((incident) => {
+    const monitor = monitorsById.get(incident.monitorCheckId);
+    return monitor ? [{ ...incident, monitor }] : [];
+  });
 }
 
 function deriveCurrentStateSince(

--- a/docs/src/content/dashboard/mcp.mdx
+++ b/docs/src/content/dashboard/mcp.mdx
@@ -157,6 +157,9 @@ Once connected, your AI assistant has access to your analytics data. You can que
 - **Funnels**: list saved funnels with step-by-step conversion data, or run ad-hoc funnel analyses with custom steps
 - **User journeys**: analyze navigation paths through your site, showing page-to-page transitions with traffic volumes
 - **Error tracking**: list captured errors, inspect stack traces, and see the session trail leading up to each error
+- **Uptime monitoring**: check whether your monitors are up right now, along with uptime percentage, response times, and SSL certificate status
+- **Downtime incidents**: list ongoing and resolved outages with their severity, duration, and cause
+- **Status pages**: see what your public status page shows visitors right now, and spot detected outages that have no posted incident
 
 ## Example Questions
 
@@ -197,6 +200,18 @@ Here are some questions you can try:
 - "Where in my code is this error occurring?"
 - "What was the user doing right before this error occurred? Walk me through the session trail."
 - "Are there any new errors since my last deploy?"
+
+**Uptime monitoring**
+- "Are all my monitors up right now?"
+- "What outages did we have this week, and how long did each one last?"
+- "What's the uptime percentage for my API health check over the last 28 days?"
+- "Are any of my SSL certificates expiring soon?"
+- "Which monitor has the slowest response times this month?"
+
+**Status pages**
+- "What does my status page show visitors right now?"
+- "Is there an ongoing outage that I haven't posted an incident for?"
+- "Summarize the incidents currently published on my status page and their latest updates."
 
 **Cross-dimensional**
 - "What browsers do my mobile visitors from Germany use?"

--- a/docs/src/content/dashboard/monitoring.mdx
+++ b/docs/src/content/dashboard/monitoring.mdx
@@ -278,6 +278,17 @@ For HTTPS monitors, the detail page shows:
 - **Expiry date**
 - **Last SSL check result**
 
+## Checking Uptime with AI
+
+Monitors and their incidents are available through the [MCP server](/dashboard/mcp). You can ask your AI assistant whether your site is up, or have your coding agent check for outages before it starts digging into a bug report.
+
+```
+"Are all my monitors up right now?"
+"What outages did we have this week, and how long did each one last?"
+"What's the uptime percentage for my API health check over the last 28 days?"
+"Are any of my SSL certificates expiring soon?"
+```
+
 ## Pausing and Deleting Monitors
 
 ### Pausing

--- a/docs/src/content/dashboard/status-pages.mdx
+++ b/docs/src/content/dashboard/status-pages.mdx
@@ -151,6 +151,20 @@ A good incident timeline is short and honest: *Investigating* ("We're looking in
 
 Resolved incidents stay visible in the page's past-incidents section for 90 days (if **Show past incidents** is enabled). You can also permanently delete incidents you don't want in the record.
 
+## Checking Your Page with AI
+
+Status pages are readable through the [MCP server](/dashboard/mcp). Your AI assistant can see exactly what your page shows visitors right now, and tell you when a detected outage has no posted incident behind it.
+
+```
+"What does my status page show visitors right now?"
+"Is there an ongoing outage I haven't posted an incident for?"
+"Summarize the incidents currently published on my status page and their latest updates."
+```
+
+<Callout type="info">
+The MCP tools are read-only. As with the suggestions above, nothing is ever published on your behalf.
+</Callout>
+
 ## Roles & Permissions
 
 What team members can do with status pages depends on their dashboard role:


### PR DESCRIPTION
Adds four read-only MCP tools so an agent can answer "is my site up right now" and "is my status page missing an incident": `list_monitors`, `list_monitor_incidents`, `list_status_pages`, and `list_incident_suggestions`. All delegate to the existing monitoring and status page services, and each family is registered only when its feature flag is on.

Closes betterlytics/betterlytics-internal#58
Closes betterlytics/betterlytics-internal#59

**Deviation from the ticket:** #58 spec 3 asked for row caps in line with existing tools. `list_monitors` and `list_status_pages` deliberately return everything instead, because neither has an offset parameter and their ids are the only way to address a specific monitor or page, so a cap would strand the remainder with no way to reach it. `list_monitor_incidents` does cap (1 to 100, default 20) and reports a `truncated` flag.

**Reviewer notes**

- Self-host: both tool families are gated twice. They are not registered when the flag is off, and each executor re-asserts the flag so a client holding a cached tool list gets a clear error rather than data.
- Risk is concentrated in the three new batched ClickHouse reads in `monitoring.repository.ts`. The uptime query mirrors the existing `getUptime24h` logic one for one, including its overlapping-incident double count (already tracked in #123).
- Two drive-by fixes outside the MCP layer: incident durations in `parseIncidentSegmentRow` were parsed as local time instead of UTC, and two `in` checks in `monitorReasonCodes.ts` matched prototype keys like `toString`.
