### PR TITLE
Made the backend fail fast when uptime monitoring is enabled without a monitoring database URL

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -30,6 +30,11 @@ POSTGRES_SITECONFIG_RO_PASSWORD=password
 SALTS_DATABASE_URL="postgresql://salts_rw:password@localhost:5432/dashboard"
 POSTGRES_SALTS_RW_PASSWORD=password
 
+ENABLE_UPTIME_MONITORING=false
+ENABLE_PUBLIC_STATUS_PAGES=false
+MONITORING_DATABASE_URL="postgresql://monitoring_ro:password@localhost:5432/dashboard"
+POSTGRES_MONITORING_RO_PASSWORD=password
+
 
 #####################################
 ### BACKEND ENVIRONMENT VARIABLES ###

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -150,7 +150,9 @@ impl Config {
             enable_uptime_monitoring: env::var("ENABLE_UPTIME_MONITORING")
                 .map(|val| val.to_lowercase() == "true")
                 .unwrap_or(false),
-            monitor_database_url: env::var("MONITORING_DATABASE_URL").ok(),
+            monitor_database_url: env::var("MONITORING_DATABASE_URL")
+                .ok()
+                .filter(|url| !url.trim().is_empty()),
             monitor_clickhouse_table: env::var("CLICKHOUSE_MONITOR_TABLE")
                 .unwrap_or_else(|_| "analytics.monitor_results".to_string()),
             monitor_incidents_table: env::var("CLICKHOUSE_INCIDENT_TABLE")

--- a/backend/src/monitor/init.rs
+++ b/backend/src/monitor/init.rs
@@ -26,13 +26,26 @@ pub fn spawn_monitoring(
 ) {
     super::init_dev_mode(config.is_development);
 
+    let monitor_db_url = config
+        .monitor_database_url
+        .clone()
+        .expect("MONITORING_DATABASE_URL must be set to a valid Postgres URL when ENABLE_UPTIME_MONITORING is true; set it or disable uptime monitoring");
+
     tokio::spawn(async move {
-        run_monitoring_init_loop(config, clickhouse, metrics, notification_engine).await;
+        run_monitoring_init_loop(
+            config,
+            monitor_db_url,
+            clickhouse,
+            metrics,
+            notification_engine,
+        )
+        .await;
     });
 }
 
 async fn run_monitoring_init_loop(
     config: Arc<Config>,
+    monitor_db_url: String,
     clickhouse: Arc<ClickHouseClient>,
     metrics: Option<Arc<MetricsCollector>>,
     notification_engine: Option<Arc<NotificationEngine>>,
@@ -42,14 +55,6 @@ async fn run_monitoring_init_loop(
 
     loop {
         info!("uptime monitoring enabled; initializing monitor components");
-
-        let monitor_db_url = match config.monitor_database_url.as_ref() {
-            Some(url) => url.clone(),
-            None => {
-                warn!("MONITORING_DATABASE_URL not set; cannot start uptime monitoring");
-                return;
-            }
-        };
 
         let monitor_pool = match PostgresPool::new(&monitor_db_url, "betterlytics_monitor", 4).await
         {


### PR DESCRIPTION
With `ENABLE_UPTIME_MONITORING=true` and no `MONITORING_DATABASE_URL`, the backend booted normally, logged one warning, and never scheduled a check, while the dashboard still offered the full monitoring UI, so monitors sat on "Preparing first check" forever. A missing URL never resolves on its own (unlike the rest of the monitor init failures), so it now panics in `spawn_monitoring` before the listener binds instead of returning quietly from the spawned task.

Closes betterlytics/betterlytics-internal#99

Reviewer notes:

- Breaking for anyone running today with the flag on and the variable unset: they get a boot failure instead of a silently idle monitor. That is the point of the ticket, but worth knowing before it ships in a self-host image.
- The panic is at `main.rs:185`, so ClickHouse and the Postgres pools initialize first. Nothing is served (the listener binds at `main.rs:255`), but a deploy with two problems surfaces the ClickHouse one first.
