### PR TITLE
Fixed unknown event names permanently killing event ingestion

### DIFF
--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -282,7 +282,10 @@ async fn run_inserter_worker(
             }
         };
 
-        let row = EventRow::from_processed(event);
+        let row = match EventRow::from_processed(event) {
+            Some(row) => row,
+            None => continue,
+        };
 
         tracing::debug!(
             worker_id = worker_id, 

--- a/backend/src/db/models.rs
+++ b/backend/src/db/models.rs
@@ -107,10 +107,25 @@ pub struct ReferrerSourceCategoryRow {
 }
 
 impl EventRow {
-    pub fn from_processed(event: ProcessedEvent) -> Self {
+    /// Returns None when the event type has no ClickHouse enum value: clients
+    /// can send arbitrary event names, and a panic here kills the insert
+    /// pipeline until the container is restarted.
+    pub fn from_processed(event: ProcessedEvent) -> Option<Self> {
         let timestamp = event.timestamp;
 
-        Self {
+        let event_type = match event.event_type.parse() {
+            Ok(event_type) => event_type,
+            Err(_) => {
+                tracing::warn!(
+                    event_type = %event.event_type,
+                    site_id = %event.site_id,
+                    "Unknown event type, dropping event"
+                );
+                return None;
+            }
+        };
+
+        Some(Self {
             site_id: event.site_id,
             visitor_id: event.visitor_fingerprint,
             session_id: event.session_id,
@@ -136,7 +151,7 @@ impl EventRow {
             utm_campaign: event.campaign_info.utm_campaign.unwrap_or_default(),
             utm_term: event.campaign_info.utm_term.unwrap_or_default(),
             utm_content: event.campaign_info.utm_content.unwrap_or_default(),
-            event_type: event.event_type.parse().unwrap(),
+            event_type,
             custom_event_name: event.custom_event_name,
             custom_event_json: event.custom_event_json,
             outbound_link_url: event.outbound_link_url,
@@ -155,6 +170,91 @@ impl EventRow {
             global_properties_keys: event.global_properties_keys,
             global_properties_values: event.global_properties_values,
             page_duration_seconds: event.page_duration_seconds,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analytics::{AnalyticsEvent, RawTrackingEvent};
+    use crate::campaign::CampaignInfo;
+    use crate::referrer::ReferrerInfo;
+
+    fn processed_event(event_type: &str) -> ProcessedEvent {
+        let raw = RawTrackingEvent {
+            site_id: "test-site".to_string(),
+            event_name: event_type.to_string(),
+            is_custom_event: false,
+            properties: String::new(),
+            url: "https://example.com/".to_string(),
+            referrer: None,
+            user_agent: "test-agent".to_string(),
+            screen_resolution: "1920x1080".to_string(),
+            timestamp: 1_700_000_000,
+            outbound_link_url: None,
+            cwv_cls: None,
+            cwv_lcp: None,
+            cwv_inp: None,
+            cwv_fcp: None,
+            cwv_ttfb: None,
+            scroll_depth_percentage: None,
+            scroll_depth_pixels: None,
+            error_exceptions: None,
+            global_properties: None,
+            page_duration_seconds: None,
+        };
+
+        ProcessedEvent {
+            event: AnalyticsEvent::new(raw, "127.0.0.1".to_string()),
+            event_type: event_type.to_string(),
+            session_id: 1,
+            session_created_at: chrono::Utc::now(),
+            country_code: None,
+            subdivision_code: None,
+            city: None,
+            browser: None,
+            browser_version: None,
+            os: None,
+            os_version: None,
+            device_type: None,
+            site_id: "test-site".to_string(),
+            visitor_fingerprint: 1,
+            timestamp: chrono::Utc::now(),
+            domain: Some("example.com".to_string()),
+            url: "/".to_string(),
+            referrer_info: ReferrerInfo::default(),
+            user_agent: "test-agent".to_string(),
+            campaign_info: CampaignInfo::default(),
+            custom_event_name: String::new(),
+            custom_event_json: String::new(),
+            outbound_link_url: String::new(),
+            cwv_cls: None,
+            cwv_lcp: None,
+            cwv_inp: None,
+            cwv_fcp: None,
+            cwv_ttfb: None,
+            scroll_depth_percentage: None,
+            scroll_depth_pixels: None,
+            error_exceptions: String::new(),
+            error_type: String::new(),
+            error_message: String::new(),
+            error_fingerprint: String::new(),
+            global_properties_keys: Vec::new(),
+            global_properties_values: Vec::new(),
+            page_duration_seconds: 0,
+        }
+    }
+
+    #[test]
+    fn unknown_event_type_is_dropped_instead_of_panicking() {
+        assert!(EventRow::from_processed(processed_event("not_a_real_event_type")).is_none());
+    }
+
+    #[test]
+    fn known_event_types_convert() {
+        for name in ["pageview", "custom", "outbound_link", "cwv", "engagement"] {
+            assert!(EventRow::from_processed(processed_event(name)).is_some());
         }
     }
 }

--- a/backend/src/db/models.rs
+++ b/backend/src/db/models.rs
@@ -107,9 +107,7 @@ pub struct ReferrerSourceCategoryRow {
 }
 
 impl EventRow {
-    /// Returns None when the event type has no ClickHouse enum value: clients
-    /// can send arbitrary event names, and a panic here kills the insert
-    /// pipeline until the container is restarted.
+    /// Returns None when the event type has no ClickHouse enum value.
     pub fn from_processed(event: ProcessedEvent) -> Option<Self> {
         let timestamp = event.timestamp;
 

--- a/backend/src/processing/mod.rs
+++ b/backend/src/processing/mod.rs
@@ -210,7 +210,7 @@ impl EventProcessor {
                     processed.outbound_link_url = outbound_info.url;
                 }
             }
-        } else if event_name.eq_ignore_ascii_case("cwv") {
+        } else if event_name == "cwv" {
             processed.event_type = "cwv".to_string();
             processed.cwv_cls = processed.event.raw.cwv_cls;
             processed.cwv_lcp = processed.event.raw.cwv_lcp;

--- a/backend/src/validation/mod.rs
+++ b/backend/src/validation/mod.rs
@@ -103,7 +103,15 @@ impl EventValidator {
         self.validate_required_fields(raw_event)?;
         self.validate_payload_sizes(raw_event)?;
         self.validate_formats(raw_event, ip_address)?;
-        
+
+        // Non-custom events must use a known event name; anything else has no
+        // ClickHouse event_type enum value and can never be stored.
+        if !raw_event.is_custom_event && !is_known_event_name(&raw_event.event_name) {
+            return Err(ValidationError::InvalidEventName(
+                "Unknown event name for non-custom event".to_string(),
+            ));
+        }
+
         if raw_event.event_name == "outbound_link" {
             self.validate_outbound_link_url(raw_event)?;
         }
@@ -406,6 +414,15 @@ impl EventValidator {
     }
 }
 
+/// Event names for non-custom events that map to a ClickHouse event_type enum
+/// value ("cwv" is matched case-insensitively downstream).
+fn is_known_event_name(name: &str) -> bool {
+    matches!(
+        name,
+        "pageview" | "custom" | "outbound_link" | "scroll_depth" | "engagement" | "client_error"
+    ) || name.eq_ignore_ascii_case("cwv")
+}
+
 /// Check if an IP address is blocked by the provided blacklist entries.
 /// Supports IPv4, IPv6, and CIDR ranges (both v4 and v6).
 pub fn check_blacklist(
@@ -500,4 +517,65 @@ fn contains_control_characters(input: &str) -> bool {
 /// Check if a string contains control characters (excluding newlines and tabs for custom properties)
 fn contains_dangerous_control_characters(input: &str) -> bool {
     input.chars().any(|c| c.is_control() && c != '\n' && c != '\t')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn raw_event(event_name: &str, is_custom_event: bool) -> RawTrackingEvent {
+        RawTrackingEvent {
+            site_id: "test-site".to_string(),
+            event_name: event_name.to_string(),
+            is_custom_event,
+            properties: String::new(),
+            url: "https://example.com/".to_string(),
+            referrer: None,
+            user_agent: "test-agent".to_string(),
+            screen_resolution: "1920x1080".to_string(),
+            timestamp: 1_700_000_000,
+            outbound_link_url: None,
+            cwv_cls: None,
+            cwv_lcp: None,
+            cwv_inp: None,
+            cwv_fcp: None,
+            cwv_ttfb: None,
+            scroll_depth_percentage: None,
+            scroll_depth_pixels: None,
+            error_exceptions: None,
+            global_properties: None,
+            page_duration_seconds: None,
+        }
+    }
+
+    fn validator() -> EventValidator {
+        EventValidator::new(ValidationConfig {
+            enforce_timestamp_validation: false,
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn unknown_non_custom_event_name_is_rejected() {
+        let result = validator().validate_event_internal(&raw_event("not_a_thing", false), "127.0.0.1");
+        assert!(matches!(result, Err(ValidationError::InvalidEventName(_))));
+    }
+
+    #[test]
+    fn known_non_custom_event_names_pass() {
+        for name in ["pageview", "outbound_link", "engagement", "CWV"] {
+            let mut event = raw_event(name, false);
+            if name == "outbound_link" {
+                event.outbound_link_url = Some("https://external.example.org/".to_string());
+            }
+            let result = validator().validate_event_internal(&event, "127.0.0.1");
+            assert!(result.is_ok(), "expected '{name}' to validate");
+        }
+    }
+
+    #[test]
+    fn custom_events_may_use_any_name() {
+        let result = validator().validate_event_internal(&raw_event("my_signup_funnel", true), "127.0.0.1");
+        assert!(result.is_ok());
+    }
 }

--- a/backend/src/validation/mod.rs
+++ b/backend/src/validation/mod.rs
@@ -116,7 +116,7 @@ impl EventValidator {
             self.validate_outbound_link_url(raw_event)?;
         }
 
-        if raw_event.event_name.eq_ignore_ascii_case("cwv") {
+        if raw_event.event_name == "cwv" {
             self.validate_cwv_fields(raw_event)?;
         }
 
@@ -414,13 +414,18 @@ impl EventValidator {
     }
 }
 
-/// Event names for non-custom events that map to a ClickHouse event_type enum
-/// value ("cwv" is matched case-insensitively downstream).
+/// Event names for non-custom events that map to a ClickHouse event_type enum value.
 fn is_known_event_name(name: &str) -> bool {
     matches!(
         name,
-        "pageview" | "custom" | "outbound_link" | "scroll_depth" | "engagement" | "client_error"
-    ) || name.eq_ignore_ascii_case("cwv")
+        "pageview"
+            | "custom"
+            | "outbound_link"
+            | "cwv"
+            | "scroll_depth"
+            | "engagement"
+            | "client_error"
+    )
 }
 
 /// Check if an IP address is blocked by the provided blacklist entries.
@@ -563,7 +568,7 @@ mod tests {
 
     #[test]
     fn known_non_custom_event_names_pass() {
-        for name in ["pageview", "outbound_link", "engagement", "CWV"] {
+        for name in ["pageview", "outbound_link", "engagement", "cwv"] {
             let mut event = raw_event(name, false);
             if name == "outbound_link" {
                 event.outbound_link_url = Some("https://external.example.org/".to_string());


### PR DESCRIPTION
Any client could send a non-custom event with an unknown event name: row conversion panicked on it, killing the insert task, after which every event was silently dropped (still 200-acked, /health still green) until a container restart. Validation now rejects unknown non-custom event names with a 400, and row conversion drops the row with a warning instead of panicking as a second layer of defense.

Reviewer notes: reproduced live before the fix (a single curl stopped all ingestion, zero rows stored afterward). The whitelist is exactly the set of names that map to the ClickHouse event_type enum; custom events keep free-form names. Unit tests cover both layers.
