### PR TITLE
Added graceful shutdown that drains buffered events on deploy

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,5 +1,3 @@
 target/
 .gitignore
-# Local cargo config (bl-wt worktrees point target-dir outside the tree,
-# which breaks the containerized build)
 .cargo/config.toml

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,2 +1,5 @@
 target/
 .gitignore
+# Local cargo config (bl-wt worktrees point target-dir outside the tree,
+# which breaks the containerized build)
+.cargo/config.toml

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -86,3 +86,6 @@ async-trait = "0.1"
 arc-swap = "1.7"
 dashmap = "5.5"
 html-escape = "0.2"
+
+[dev-dependencies]
+clickhouse = { version = "0.13.2", features = ["test-util"] }

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -33,4 +33,5 @@ WORKDIR /app
 COPY --from=builder /app/target/release/betterlytics /app/app
 COPY --from=builder /app/assets /app/assets
 
-CMD ./app
+# Exec form so the binary runs as PID 1 and receives SIGTERM from Docker
+CMD ["./app"]

--- a/backend/src/clickhouse.rs
+++ b/backend/src/clickhouse.rs
@@ -24,4 +24,10 @@ impl ClickHouseClient {
     pub fn inner(&self) -> &Client {
         &self.client
     }
+
+    /// Test-only constructor wrapping an arbitrary client (e.g. a mock server).
+    #[cfg(test)]
+    pub fn from_client(client: Client) -> Self {
+        Self { client }
+    }
 }

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -267,6 +267,21 @@ async fn run_inserter(
     Ok(())
 }
 
+/// SQL to load each active visitor's most recent session. Filtering on `session_end` uses the
+/// `idx_session_end` minmax skip index, so the cost is bounded by the number of *active*
+/// sessions, not total history; `argMax(.., session_end)` picks each visitor's current session.
+fn active_sessions_query(window: Duration) -> String {
+    let window_secs = window.as_secs();
+    format!(
+        "SELECT site_id, toUInt64(visitor_id) AS visitor_id, \
+                argMax(session_id, session_end) AS session_id, \
+                argMax(session_created_at, session_end) AS session_created_at \
+         FROM analytics.sessions \
+         WHERE session_end > now() - toIntervalSecond({window_secs}) \
+         GROUP BY site_id, visitor_id"
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -385,19 +400,4 @@ mod tests {
             .expect("inserter task panicked")
             .ok();
     }
-}
-
-/// SQL to load each active visitor's most recent session. Filtering on `session_end` uses the
-/// `idx_session_end` minmax skip index, so the cost is bounded by the number of *active*
-/// sessions, not total history; `argMax(.., session_end)` picks each visitor's current session.
-fn active_sessions_query(window: Duration) -> String {
-    let window_secs = window.as_secs();
-    format!(
-        "SELECT site_id, toUInt64(visitor_id) AS visitor_id, \
-                argMax(session_id, session_end) AS session_id, \
-                argMax(session_created_at, session_end) AS session_created_at \
-         FROM analytics.sessions \
-         WHERE session_end > now() - toIntervalSecond({window_secs}) \
-         GROUP BY site_id, visitor_id"
-    )
 }

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use tokio::sync::mpsc::{self, error::TryRecvError, Receiver, Sender};
 use tokio::task::JoinHandle;
 use tokio::time::timeout;
+use tracing::{debug, error, info, warn};
 
 use crate::clickhouse::ClickHouseClient;
 use crate::config::Config;
@@ -41,7 +42,7 @@ impl Database {
         let client = clickhouse.inner().clone();
         let inserter_handle = tokio::spawn(async move {
             if let Err(e) = run_inserter(client, event_rx).await {
-                eprintln!("Inserter: Error - {}", e);
+                error!("Inserter task failed: {}", e);
             }
         });
 
@@ -62,14 +63,14 @@ impl Database {
     pub async fn validate_schema(&self) -> Result<()> {
         self.check_connection().await?;
         
-        println!("Validating database schema");
+        info!("Validating database schema");
         let db_exists: u8 = self.clickhouse.inner()
             .query("SELECT count() FROM system.databases WHERE name = 'analytics'")
             .fetch_one()
             .await?;
-        
+
         if db_exists == 0 {
-            println!("[WARNING] Analytics database does not exist. Please run migrations.");
+            warn!("Analytics database does not exist. Please run migrations.");
             return Ok(());
         }
 
@@ -79,29 +80,29 @@ impl Database {
             .await?;
 
         if table_exists == 0 {
-            println!("[WARNING] Events table does not exist. Please run migrations.");
+            warn!("Events table does not exist. Please run migrations.");
             return Ok(());
         }
 
         if self.config.data_retention_days == -1 {
-            println!("[INFO] Data retention explicitly disabled (data_retention_days = -1). Removing TTL if present.");
+            info!("Data retention explicitly disabled (data_retention_days = -1). Removing TTL if present.");
             if let Err(e) = Self::remove_data_retention_policy(self.clickhouse.inner()).await {
-                eprintln!("[ERROR] Could not remove data retention policy: {}", e);
+                error!("Could not remove data retention policy: {}", e);
                 return Err(e);
             }
         } else if self.config.data_retention_days > 0 {
             if let Err(e) = Self::apply_data_retention_policy(self.clickhouse.inner(), self.config.data_retention_days).await {
-                eprintln!("[ERROR] Could not apply data retention policy: {}", e);
+                error!("Could not apply data retention policy: {}", e);
                 return Err(e);
             }
         } else {
-            println!(
-                "[WARNING] Invalid value for DATA_RETENTION_DAYS: {}. TTL policy will not be changed. Use a positive integer to set TTL, or -1 to remove TTL.",
+            warn!(
+                "Invalid value for DATA_RETENTION_DAYS: {}. TTL policy will not be changed. Use a positive integer to set TTL, or -1 to remove TTL.",
                 self.config.data_retention_days
             );
         }
 
-        println!("Database schema validation and TTL setup complete.");
+        info!("Database schema validation and TTL setup complete.");
         Ok(())
     }
 
@@ -123,25 +124,25 @@ impl Database {
             .await?;
 
         if create_table_query.contains("TTL ") {
-            println!("[INFO] TTL policy exists, removing it.");
+            info!("TTL policy exists, removing it.");
             let alter_query = "ALTER TABLE analytics.events REMOVE TTL";
             client
                 .query(alter_query)
                 .execute()
                 .await
                 .map_err(|e| anyhow::anyhow!("Failed to remove data retention policy: {}", e))?;
-            println!("[INFO] TTL policy removed successfully.");
+            info!("TTL policy removed successfully.");
         } else {
-            println!("[INFO] No TTL policy found on events table, nothing to remove.");
+            info!("No TTL policy found on events table, nothing to remove.");
         }
 
         Ok(())
     }
 
     pub async fn check_connection(&self) -> Result<()> {
-        println!("Checking database connection");
+        debug!("Checking database connection");
         self.clickhouse.inner().query("SELECT 1").execute().await?;
-        println!("Database connection check successful");
+        debug!("Database connection check successful");
         Ok(())
     }
 
@@ -195,7 +196,7 @@ async fn run_inserter(
     client: clickhouse::Client,
     mut rx: Receiver<ProcessedEvent>,
 ) -> Result<(), ClickHouseError> {
-    println!("Inserter: Starting (Sparse Stream Mode).");
+    info!("Inserter starting (sparse stream mode)");
 
     let mut inserter = client
         .inserter("analytics.events")?
@@ -207,7 +208,7 @@ async fn run_inserter(
         .with_max_rows(INSERTER_MAX_ROWS)
         .with_max_bytes(INSERTER_MAX_BYTES);
 
-    println!("Inserter: Configured.");
+    debug!("Inserter configured");
 
     loop {
         let event = match rx.try_recv() {
@@ -221,7 +222,7 @@ async fn run_inserter(
                 match timeout(time_left, rx.recv()).await {
                     Ok(Some(received_event)) => received_event,
                     Ok(None) => {
-                        println!("Inserter: Channel closed during timeout wait. Committing final batch.");
+                        info!("Ingest channel closed, committing final batch");
                         inserter.commit().await?;
                         break;
                     }
@@ -232,7 +233,7 @@ async fn run_inserter(
                 }
             }
             Err(TryRecvError::Disconnected) => {
-                println!("Inserter: Channel disconnected. Committing final batch.");
+                info!("Ingest channel disconnected, committing final batch");
                 break;
             }
         };
@@ -242,7 +243,7 @@ async fn run_inserter(
             None => continue,
         };
 
-        tracing::debug!(
+        debug!(
             site_id = %row.site_id,
             visitor_id = %row.visitor_id,
             session_id = %row.session_id,
@@ -255,19 +256,135 @@ async fn run_inserter(
             os = %row.os,
             "Prepared row for ClickHouse insertion");
         if let Err(e) = inserter.write(&row) {
-            eprintln!(
-                "Inserter: Failed to write row to inserter buffer: {}. Row: {:?}",
-                e, row
-            );
+            error!("Failed to write row to inserter buffer: {}. Row: {:?}", e, row);
             // TODO: Implement retry logic or dead-letter queue for inserter write failures.
             continue;
         }
     }
 
-    println!("Inserter: Exiting loop. Finalizing inserter.");
     let stats = inserter.end().await?;
-    println!("Inserter: Shutdown complete. Final stats: {:?}", stats);
+    info!(stats = ?stats, "Inserter shutdown complete, final batch committed");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analytics::{AnalyticsEvent, RawTrackingEvent};
+    use crate::campaign::CampaignInfo;
+    use crate::referrer::ReferrerInfo;
+    use clickhouse::test::{handlers, Mock};
+
+    fn test_event(n: u64) -> ProcessedEvent {
+        let raw = RawTrackingEvent {
+            site_id: "test-site".to_string(),
+            event_name: "pageview".to_string(),
+            is_custom_event: false,
+            properties: String::new(),
+            url: format!("https://example.com/page-{n}"),
+            referrer: None,
+            user_agent: "test-agent".to_string(),
+            screen_resolution: "1920x1080".to_string(),
+            timestamp: 1_700_000_000,
+            outbound_link_url: None,
+            cwv_cls: None,
+            cwv_lcp: None,
+            cwv_inp: None,
+            cwv_fcp: None,
+            cwv_ttfb: None,
+            scroll_depth_percentage: None,
+            scroll_depth_pixels: None,
+            error_exceptions: None,
+            global_properties: None,
+            page_duration_seconds: None,
+        };
+
+        ProcessedEvent {
+            event: AnalyticsEvent::new(raw, "127.0.0.1".to_string()),
+            event_type: "pageview".to_string(),
+            session_id: n,
+            session_created_at: chrono::Utc::now(),
+            country_code: None,
+            subdivision_code: None,
+            city: None,
+            browser: None,
+            browser_version: None,
+            os: None,
+            os_version: None,
+            device_type: None,
+            site_id: "test-site".to_string(),
+            visitor_fingerprint: n,
+            timestamp: chrono::Utc::now(),
+            domain: Some("example.com".to_string()),
+            url: format!("/page-{n}"),
+            referrer_info: ReferrerInfo::default(),
+            user_agent: "test-agent".to_string(),
+            campaign_info: CampaignInfo::default(),
+            custom_event_name: String::new(),
+            custom_event_json: String::new(),
+            outbound_link_url: String::new(),
+            cwv_cls: None,
+            cwv_lcp: None,
+            cwv_inp: None,
+            cwv_fcp: None,
+            cwv_ttfb: None,
+            scroll_depth_percentage: None,
+            scroll_depth_pixels: None,
+            error_exceptions: String::new(),
+            error_type: String::new(),
+            error_message: String::new(),
+            error_fingerprint: String::new(),
+            global_properties_keys: Vec::new(),
+            global_properties_values: Vec::new(),
+            page_duration_seconds: 0,
+        }
+    }
+
+    /// The drain contract main relies on at shutdown: once all senders drop,
+    /// the inserter commits everything buffered and its task completes.
+    #[tokio::test]
+    async fn inserter_commits_buffered_events_when_channel_closes() {
+        let mock = Mock::new();
+        let recording = mock.add(handlers::record());
+        let client = clickhouse::Client::default().with_url(mock.url());
+
+        let (tx, rx) = mpsc::channel(100);
+        let handle = tokio::spawn(run_inserter(client, rx));
+
+        for n in 0..5 {
+            tx.send(test_event(n)).await.unwrap();
+        }
+        drop(tx);
+
+        timeout(Duration::from_secs(10), handle)
+            .await
+            .expect("inserter did not exit after channel close")
+            .expect("inserter task panicked")
+            .expect("inserter returned an error");
+
+        let rows: Vec<EventRow> = recording.collect().await;
+        assert_eq!(rows.len(), 5);
+        assert!(rows.iter().all(|r| r.site_id == "test-site"));
+    }
+
+    /// The deadline-safety property: an unreachable ClickHouse must never
+    /// leave the drain hanging - the task finishes (with an error) promptly.
+    #[tokio::test]
+    async fn inserter_exits_when_clickhouse_is_unreachable() {
+        let client = clickhouse::Client::default().with_url("http://127.0.0.1:9");
+
+        let (tx, rx) = mpsc::channel(100);
+        let handle = tokio::spawn(run_inserter(client, rx));
+
+        tx.send(test_event(0)).await.unwrap();
+        drop(tx);
+
+        timeout(Duration::from_secs(10), handle)
+            .await
+            .expect("inserter did not exit after channel close")
+            .expect("inserter task panicked")
+            .ok();
+    }
 }
 
 /// SQL to load each active visitor's most recent session. Filtering on `session_end` uses the

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -29,10 +29,7 @@ pub struct Database {
 pub type SharedDatabase = Arc<Database>;
 
 impl Database {
-    /// Creates the database handle plus the ingest channel: events sent on the
-    /// returned sender are batched into ClickHouse by a single inserter task.
-    /// The returned handle completes once all senders are dropped and the
-    /// inserter has committed its final batch — await it to drain on shutdown.
+    /// Creates the database handle plus the ingest channel
     pub async fn new(
         clickhouse: Arc<ClickHouseClient>,
         config: Arc<Config>,

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::sync::mpsc::{self, error::TryRecvError, Receiver, Sender};
+use tokio::task::JoinHandle;
 use tokio::time::timeout;
 
 use crate::clickhouse::ClickHouseClient;
@@ -29,20 +30,22 @@ pub type SharedDatabase = Arc<Database>;
 impl Database {
     /// Creates the database handle plus the ingest channel: events sent on the
     /// returned sender are batched into ClickHouse by a single inserter task.
+    /// The returned handle completes once all senders are dropped and the
+    /// inserter has committed its final batch — await it to drain on shutdown.
     pub async fn new(
         clickhouse: Arc<ClickHouseClient>,
         config: Arc<Config>,
-    ) -> Result<(Self, Sender<ProcessedEvent>)> {
+    ) -> Result<(Self, Sender<ProcessedEvent>, JoinHandle<()>)> {
         let (event_tx, event_rx) = mpsc::channel(EVENT_CHANNEL_CAPACITY);
 
         let client = clickhouse.inner().clone();
-        tokio::spawn(async move {
+        let inserter_handle = tokio::spawn(async move {
             if let Err(e) = run_inserter(client, event_rx).await {
                 eprintln!("Inserter: Error - {}", e);
             }
         });
 
-        Ok((Self { clickhouse, config }, event_tx))
+        Ok((Self { clickhouse, config }, event_tx, inserter_handle))
     }
 
     /// Fetch the current session of every visitor active within `window`, from `analytics.sessions`

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -3,7 +3,7 @@ use clickhouse::error::Error as ClickHouseError;
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::sync::mpsc::{self, error::TryRecvError, Receiver};
+use tokio::sync::mpsc::{self, error::TryRecvError, Receiver, Sender};
 use tokio::time::timeout;
 
 use crate::clickhouse::ClickHouseClient;
@@ -13,9 +13,7 @@ use crate::processing::ProcessedEvent;
 mod models;
 pub use models::{ActiveSessionRow, EventRow, ReferrerSourceCategoryRow, SessionReplayRow};
 
-const NUM_INSERT_WORKERS: usize = 1;
 const EVENT_CHANNEL_CAPACITY: usize = 100_000;
-const WORKER_CHANNEL_CAPACITY: usize = 10_000;
 const INSERTER_TIMEOUT_SECS: u64 = 5;
 const INSERTER_PERIOD_SECS: u64 = 10;
 const INSERTER_MAX_ROWS: u64 = 100_000;
@@ -23,19 +21,28 @@ const INSERTER_MAX_BYTES: u64 = 50 * 1024 * 1024;
 
 pub struct Database {
     clickhouse: Arc<ClickHouseClient>,
-    event_tx: mpsc::Sender<ProcessedEvent>,
     config: Arc<Config>,
 }
 
 pub type SharedDatabase = Arc<Database>;
 
 impl Database {
-    pub async fn new(clickhouse: Arc<ClickHouseClient>, config: Arc<Config>) -> Result<Self> {
-        let (event_tx, event_rx) = Self::create_channels();
-        let worker_senders = Self::spawn_inserter_workers(clickhouse.inner().clone());
-        Self::spawn_dispatcher(event_rx, worker_senders);
+    /// Creates the database handle plus the ingest channel: events sent on the
+    /// returned sender are batched into ClickHouse by a single inserter task.
+    pub async fn new(
+        clickhouse: Arc<ClickHouseClient>,
+        config: Arc<Config>,
+    ) -> Result<(Self, Sender<ProcessedEvent>)> {
+        let (event_tx, event_rx) = mpsc::channel(EVENT_CHANNEL_CAPACITY);
 
-        Ok(Self { clickhouse, event_tx, config })
+        let client = clickhouse.inner().clone();
+        tokio::spawn(async move {
+            if let Err(e) = run_inserter(client, event_rx).await {
+                eprintln!("Inserter: Error - {}", e);
+            }
+        });
+
+        Ok((Self { clickhouse, config }, event_tx))
     }
 
     /// Fetch the current session of every visitor active within `window`, from `analytics.sessions`
@@ -47,46 +54,6 @@ impl Database {
             .fetch_all::<ActiveSessionRow>()
             .await?;
         Ok(rows)
-    }
-
-    fn create_channels() -> (mpsc::Sender<ProcessedEvent>, mpsc::Receiver<ProcessedEvent>) {
-        mpsc::channel(EVENT_CHANNEL_CAPACITY)
-    }
-
-    fn spawn_inserter_workers(client: clickhouse::Client) -> Vec<mpsc::Sender<ProcessedEvent>> {
-        let mut worker_senders = Vec::with_capacity(NUM_INSERT_WORKERS);
-
-        for i in 0..NUM_INSERT_WORKERS {
-            let (worker_tx, worker_rx) = mpsc::channel(WORKER_CHANNEL_CAPACITY);
-            worker_senders.push(worker_tx);
-            let client_clone = client.clone();
-            tokio::spawn(async move {
-                if let Err(e) = run_inserter_worker(i, client_clone, worker_rx).await {
-                    eprintln!("Worker {}: Error - {}", i, e);
-                }
-            });
-        }
-        worker_senders
-    }
-
-    fn spawn_dispatcher(
-        mut event_rx: mpsc::Receiver<ProcessedEvent>,
-        worker_senders: Vec<mpsc::Sender<ProcessedEvent>>,
-    ) {
-        tokio::spawn(async move {
-            let mut worker_index = 0;
-            while let Some(event) = event_rx.recv().await {
-                if let Err(e) = worker_senders[worker_index].send(event).await {
-                    eprintln!(
-                        "Dispatcher failed to send event to worker {}: {}",
-                        worker_index, e
-                    );
-                    // TODO: Add logic to handle potentially dead worker (e.g., skip, retry with backoff, remove worker from rotation).
-                }
-                worker_index = (worker_index + 1) % NUM_INSERT_WORKERS;
-            }
-            println!("Dispatcher: Event channel closed. Shutting down.");
-        });
     }
 
     pub async fn validate_schema(&self) -> Result<()> {
@@ -168,11 +135,6 @@ impl Database {
         Ok(())
     }
 
-    pub async fn insert_event(&self, event: ProcessedEvent) -> Result<()> {
-        self.event_tx.send(event).await?;
-        Ok(())
-    }
-
     pub async fn check_connection(&self) -> Result<()> {
         println!("Checking database connection");
         self.clickhouse.inner().query("SELECT 1").execute().await?;
@@ -226,15 +188,11 @@ impl Database {
     }
 }
 
-async fn run_inserter_worker(
-    worker_id: usize,
+async fn run_inserter(
     client: clickhouse::Client,
     mut rx: Receiver<ProcessedEvent>,
 ) -> Result<(), ClickHouseError> {
-    println!(
-        "Worker {}: Starting (Inserter Sparse Stream Mode).",
-        worker_id
-    );
+    println!("Inserter: Starting (Sparse Stream Mode).");
 
     let mut inserter = client
         .inserter("analytics.events")?
@@ -246,7 +204,7 @@ async fn run_inserter_worker(
         .with_max_rows(INSERTER_MAX_ROWS)
         .with_max_bytes(INSERTER_MAX_BYTES);
 
-    println!("Worker {}: Inserter configured.", worker_id);
+    println!("Inserter: Configured.");
 
     loop {
         let event = match rx.try_recv() {
@@ -260,10 +218,7 @@ async fn run_inserter_worker(
                 match timeout(time_left, rx.recv()).await {
                     Ok(Some(received_event)) => received_event,
                     Ok(None) => {
-                        println!(
-                            "Worker {}: Channel closed during timeout wait. Committing final batch.",
-                            worker_id
-                        );
+                        println!("Inserter: Channel closed during timeout wait. Committing final batch.");
                         inserter.commit().await?;
                         break;
                     }
@@ -274,10 +229,7 @@ async fn run_inserter_worker(
                 }
             }
             Err(TryRecvError::Disconnected) => {
-                println!(
-                    "Worker {}: Channel disconnected. Committing final batch.",
-                    worker_id
-                );
+                println!("Inserter: Channel disconnected. Committing final batch.");
                 break;
             }
         };
@@ -288,37 +240,30 @@ async fn run_inserter_worker(
         };
 
         tracing::debug!(
-            worker_id = worker_id, 
-            site_id = %row.site_id, 
+            site_id = %row.site_id,
             visitor_id = %row.visitor_id,
             session_id = %row.session_id,
             event_type = ?row.event_type,
             custom_event_name = ?row.custom_event_name,
-            url = %row.url, 
-            timestamp = %row.timestamp, 
+            url = %row.url,
+            timestamp = %row.timestamp,
             device_type = %row.device_type,
-            browser = %row.browser, 
-            os = %row.os, 
+            browser = %row.browser,
+            os = %row.os,
             "Prepared row for ClickHouse insertion");
         if let Err(e) = inserter.write(&row) {
             eprintln!(
-                "Worker {}: Failed to write row to inserter buffer: {}. Row: {:?}",
-                worker_id, e, row
+                "Inserter: Failed to write row to inserter buffer: {}. Row: {:?}",
+                e, row
             );
             // TODO: Implement retry logic or dead-letter queue for inserter write failures.
             continue;
         }
     }
 
-    println!(
-        "Worker {}: Exiting loop. Finalizing inserter.",
-        worker_id
-    );
+    println!("Inserter: Exiting loop. Finalizing inserter.");
     let stats = inserter.end().await?;
-    println!(
-        "Worker {}: Shutdown complete. Final stats: {:?}",
-        worker_id, stats
-    );
+    println!("Inserter: Shutdown complete. Final stats: {:?}", stats);
     Ok(())
 }
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -103,7 +103,7 @@ async fn main() {
     let clickhouse = Arc::new(ClickHouseClient::new(&config));
     info!("ClickHouse client initialized");
 
-    let db = Database::new(Arc::clone(&clickhouse), config.clone())
+    let (db, event_tx) = Database::new(Arc::clone(&clickhouse), config.clone())
         .await
         .expect("Failed to initialize database");
     db.validate_schema().await.expect("Invalid database schema");
@@ -135,8 +135,7 @@ async fn main() {
         None
     };
 
-    let (processor, mut processed_rx) = EventProcessor::new(geoip_service);
-    let processor = Arc::new(processor);
+    let processor = Arc::new(EventProcessor::new(geoip_service, event_tx));
 
     let site_config_pool = Arc::new(
         PostgresPool::new(
@@ -208,15 +207,6 @@ async fn main() {
             None
         }
     };
-
-    let db_clone = db.clone();
-    tokio::spawn(async move {
-        while let Some(processed) = processed_rx.recv().await {
-            if let Err(e) = db_clone.insert_event(processed).await {
-                tracing::error!("Failed to insert processed event: {}", e);
-            }
-        }
-    });
 
 	let mut router = Router::new()
 		.route("/health", get(health_check))

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -7,6 +7,7 @@ use axum::{
 };
 use std::sync::Arc;
 use std::net::SocketAddr;
+use std::time::Duration;
 use tower_http::cors::CorsLayer;
 use tracing::{debug, error, info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -52,6 +53,15 @@ use processing::EventProcessor;
 use site_config::{RefreshConfig, SiteConfigCache, SiteConfigDataSource, SiteConfigRepository};
 use storage::s3::S3Service;
 use validation::{EventValidator, ValidationConfig};
+
+/// Cap on draining buffered events to ClickHouse after the HTTP server stops.
+/// The container stop grace period must comfortably exceed this.
+const SHUTDOWN_DEADLINE: Duration = Duration::from_secs(5);
+
+/// Hard backstop measured from signal receipt. Covers anything that wedges the
+/// graceful path (e.g. a hung in-flight request keeping the server alive) so
+/// shutdown never depends on Docker's SIGKILL.
+const WATCHDOG_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[tokio::main]
 async fn main() {
@@ -103,7 +113,7 @@ async fn main() {
     let clickhouse = Arc::new(ClickHouseClient::new(&config));
     info!("ClickHouse client initialized");
 
-    let (db, event_tx) = Database::new(Arc::clone(&clickhouse), config.clone())
+    let (db, event_tx, inserter_handle) = Database::new(Arc::clone(&clickhouse), config.clone())
         .await
         .expect("Failed to initialize database");
     db.validate_schema().await.expect("Invalid database schema");
@@ -252,7 +262,23 @@ async fn main() {
     .await
     .unwrap();
 
-    info!("HTTP server stopped");
+    // Serve returning dropped the router state, and with it the EventProcessor
+    // holding the only ingest senders: the channel is now closed, so the
+    // inserter commits whatever is buffered and exits.
+    info!("HTTP server stopped, draining ingest pipeline");
+    match tokio::time::timeout(SHUTDOWN_DEADLINE, inserter_handle).await {
+        Ok(Ok(())) => info!("Ingest pipeline drained, buffered events committed"),
+        Ok(Err(e)) => error!("Inserter task failed during drain: {}", e),
+        Err(_) => {
+            error!(
+                "Shutdown deadline of {:?} exceeded, exiting without a full drain",
+                SHUTDOWN_DEADLINE
+            );
+            std::process::exit(1);
+        }
+    }
+
+    info!("Shutdown complete");
 }
 
 /// Resolves when SIGTERM (Unix) or Ctrl+C is received.
@@ -278,6 +304,15 @@ async fn shutdown_signal() {
         _ = ctrl_c => info!("Ctrl+C received, shutting down gracefully"),
         _ = terminate => info!("SIGTERM received, shutting down gracefully"),
     }
+
+    tokio::spawn(async {
+        tokio::time::sleep(WATCHDOG_TIMEOUT).await;
+        error!(
+            "Graceful shutdown did not complete within {:?}, forcing exit",
+            WATCHDOG_TIMEOUT
+        );
+        std::process::exit(1);
+    });
 }
 
 /// Warm the session cache from ClickHouse so in-flight sessions survive a restart

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -265,17 +265,20 @@ async fn main() {
     // Serve returning dropped the router state, and with it the EventProcessor
     // holding the only ingest senders: the channel is now closed, so the
     // inserter commits whatever is buffered and exits.
-    info!("HTTP server stopped, draining ingest pipeline");
-    match tokio::time::timeout(SHUTDOWN_DEADLINE, inserter_handle).await {
-        Ok(Ok(())) => info!("Ingest pipeline drained, buffered events committed"),
-        Ok(Err(e)) => error!("Inserter task failed during drain: {}", e),
-        Err(_) => {
-            error!(
-                "Shutdown deadline of {:?} exceeded, exiting without a full drain",
-                SHUTDOWN_DEADLINE
-            );
-            std::process::exit(1);
+    info!("HTTP server stopped, draining buffered data");
+    let drain = async {
+        match inserter_handle.await {
+            Ok(()) => info!("Ingest pipeline drained, buffered events committed"),
+            Err(e) => error!("Inserter task failed during drain: {}", e),
         }
+        monitor::clickhouse_writer::flush_all_writers().await;
+    };
+    if tokio::time::timeout(SHUTDOWN_DEADLINE, drain).await.is_err() {
+        error!(
+            "Shutdown deadline of {:?} exceeded, exiting without a full drain",
+            SHUTDOWN_DEADLINE
+        );
+        std::process::exit(1);
     }
 
     info!("Shutdown complete");

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -248,8 +248,36 @@ async fn main() {
         listener,
         app.into_make_service_with_connect_info::<SocketAddr>(),
     )
+    .with_graceful_shutdown(shutdown_signal())
     .await
     .unwrap();
+
+    info!("HTTP server stopped");
+}
+
+/// Resolves when SIGTERM (Unix) or Ctrl+C is received.
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("Failed to install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("Failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => info!("Ctrl+C received, shutting down gracefully"),
+        _ = terminate => info!("SIGTERM received, shutting down gracefully"),
+    }
 }
 
 /// Warm the session cache from ClickHouse so in-flight sessions survive a restart

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -58,9 +58,10 @@ use validation::{EventValidator, ValidationConfig};
 /// The container stop grace period must comfortably exceed this.
 const SHUTDOWN_DEADLINE: Duration = Duration::from_secs(5);
 
-/// Hard backstop measured from signal receipt so
-/// shutdown never depends on Docker's SIGKILL.
-const WATCHDOG_TIMEOUT: Duration = Duration::from_secs(10);
+/// Hard backstop measured from signal receipt so shutdown never depends on
+/// Docker's SIGKILL. Ordering invariant: SHUTDOWN_DEADLINE < WATCHDOG_TIMEOUT
+/// < the container stop grace period (10s Docker default).
+const WATCHDOG_TIMEOUT: Duration = Duration::from_secs(8);
 
 #[tokio::main]
 async fn main() {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -58,8 +58,7 @@ use validation::{EventValidator, ValidationConfig};
 /// The container stop grace period must comfortably exceed this.
 const SHUTDOWN_DEADLINE: Duration = Duration::from_secs(5);
 
-/// Hard backstop measured from signal receipt. Covers anything that wedges the
-/// graceful path (e.g. a hung in-flight request keeping the server alive) so
+/// Hard backstop measured from signal receipt so
 /// shutdown never depends on Docker's SIGKILL.
 const WATCHDOG_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -262,9 +261,6 @@ async fn main() {
     .await
     .unwrap();
 
-    // Serve returning dropped the router state, and with it the EventProcessor
-    // holding the only ingest senders: the channel is now closed, so the
-    // inserter commits whatever is buffered and exits.
     info!("HTTP server stopped, draining buffered data");
     let drain = async {
         match inserter_handle.await {

--- a/backend/src/monitor/clickhouse_writer.rs
+++ b/backend/src/monitor/clickhouse_writer.rs
@@ -135,6 +135,50 @@ impl<R: clickhouse::Row + Serialize + Send + Sync + 'static> ClickhouseChannelWr
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clickhouse::test::{handlers, Mock};
+    use serde::Deserialize;
+    use std::time::Duration;
+
+    #[derive(clickhouse::Row, Serialize, Deserialize, Debug)]
+    struct TestRow {
+        n: u32,
+    }
+
+    /// The fence contract shutdown relies on: when a Flush marker is acked,
+    /// every batch enqueued before it has been fully inserted.
+    #[tokio::test]
+    async fn flush_acks_only_after_prior_batches_are_inserted() {
+        let mock = Mock::new();
+        let first = mock.add(handlers::record());
+        let second = mock.add(handlers::record());
+        let client = clickhouse::Client::default().with_url(mock.url());
+        let clickhouse = Arc::new(ClickHouseClient::from_client(client));
+
+        let writer =
+            ClickhouseChannelWriter::<TestRow>::new(clickhouse, "test.rows", 100, 500).unwrap();
+        writer
+            .enqueue_rows(vec![TestRow { n: 1 }, TestRow { n: 2 }])
+            .unwrap();
+        writer.enqueue_rows(vec![TestRow { n: 3 }]).unwrap();
+
+        let (ack_tx, ack_rx) = oneshot::channel();
+        writer.sender.try_send(Msg::Flush(ack_tx)).unwrap();
+
+        tokio::time::timeout(Duration::from_secs(10), ack_rx)
+            .await
+            .expect("flush ack timed out")
+            .expect("worker dropped the ack");
+
+        let rows1: Vec<TestRow> = first.collect().await;
+        let rows2: Vec<TestRow> = second.collect().await;
+        let ns: Vec<u32> = rows1.iter().chain(rows2.iter()).map(|r| r.n).collect();
+        assert_eq!(ns, vec![1, 2, 3]);
+    }
+}
+
 const MONITOR_BATCH_SIZE: usize = 500;
 const MONITOR_CHANNEL_CAPACITY: usize = 2_000;
 

--- a/backend/src/monitor/clickhouse_writer.rs
+++ b/backend/src/monitor/clickhouse_writer.rs
@@ -135,6 +135,18 @@ impl<R: clickhouse::Row + Serialize + Send + Sync + 'static> ClickhouseChannelWr
     }
 }
 
+const MONITOR_BATCH_SIZE: usize = 500;
+const MONITOR_CHANNEL_CAPACITY: usize = 2_000;
+
+pub type MonitorWriter = ClickhouseChannelWriter<MonitorResultRow>;
+
+pub fn new_monitor_writer(
+    clickhouse: Arc<ClickHouseClient>,
+    table: &str,
+) -> Result<Arc<MonitorWriter>> {
+    ClickhouseChannelWriter::new(clickhouse, table, MONITOR_CHANNEL_CAPACITY, MONITOR_BATCH_SIZE)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -177,16 +189,4 @@ mod tests {
         let ns: Vec<u32> = rows1.iter().chain(rows2.iter()).map(|r| r.n).collect();
         assert_eq!(ns, vec![1, 2, 3]);
     }
-}
-
-const MONITOR_BATCH_SIZE: usize = 500;
-const MONITOR_CHANNEL_CAPACITY: usize = 2_000;
-
-pub type MonitorWriter = ClickhouseChannelWriter<MonitorResultRow>;
-
-pub fn new_monitor_writer(
-    clickhouse: Arc<ClickHouseClient>,
-    table: &str,
-) -> Result<Arc<MonitorWriter>> {
-    ClickhouseChannelWriter::new(clickhouse, table, MONITOR_CHANNEL_CAPACITY, MONITOR_BATCH_SIZE)
 }

--- a/backend/src/monitor/clickhouse_writer.rs
+++ b/backend/src/monitor/clickhouse_writer.rs
@@ -1,18 +1,67 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use serde::Serialize;
-use tokio::sync::mpsc;
-use tracing::warn;
+use tokio::sync::{mpsc, oneshot};
+use tracing::{info, warn};
 
 use crate::clickhouse::ClickHouseClient;
 use crate::monitor::MonitorResultRow;
+
+/// Message consumed by a writer's background worker.
+enum Msg<R> {
+    Rows(Vec<R>),
+    /// Shutdown fence: acked once every batch enqueued before it is inserted.
+    Flush(oneshot::Sender<()>),
+}
+
+/// Every live writer, registered at construction. Lets shutdown flush all
+/// writers without threading handles through each subsystem's init (the
+/// monitor writers are created inside a detached retry loop main can't reach).
+static FLUSH_REGISTRY: Mutex<Vec<FlushHandle>> = Mutex::new(Vec::new());
+
+struct FlushHandle {
+    table: String,
+    request: Box<dyn Fn() -> Option<oneshot::Receiver<()>> + Send + Sync>,
+}
+
+fn register_for_shutdown_flush<R: Send + 'static>(table: &str, sender: mpsc::WeakSender<Msg<R>>) {
+    let request = Box::new(move || {
+        let sender = sender.upgrade()?;
+        let (ack_tx, ack_rx) = oneshot::channel();
+        sender.try_send(Msg::Flush(ack_tx)).ok()?;
+        Some(ack_rx)
+    });
+    FLUSH_REGISTRY.lock().unwrap().push(FlushHandle {
+        table: table.to_string(),
+        request,
+    });
+}
+
+/// Sends a flush fence into every live writer, then waits for the acks: once
+/// a writer acks, every batch enqueued into it before the fence is durable in
+/// ClickHouse. Called during graceful shutdown; the caller bounds the wait.
+pub async fn flush_all_writers() {
+    let pending: Vec<(String, oneshot::Receiver<()>)> = FLUSH_REGISTRY
+        .lock()
+        .unwrap()
+        .iter()
+        .filter_map(|handle| (handle.request)().map(|rx| (handle.table.clone(), rx)))
+        .collect();
+
+    for (table, ack) in pending {
+        match ack.await {
+            Ok(()) => info!(table = %table, "Writer flushed"),
+            Err(_) => warn!(table = %table, "Writer exited before acking flush"),
+        }
+    }
+}
 
 /// Generic channel-based writer for ClickHouse rows.
 /// This provides a non-blocking `enqueue_rows` method that sends batches
 /// to a background worker for insertion
 pub struct ClickhouseChannelWriter<R: clickhouse::Row + Serialize + Send + Sync + 'static> {
-    sender: mpsc::Sender<Vec<R>>,
+    sender: mpsc::Sender<Msg<R>>,
     capacity: usize,
 }
 
@@ -24,6 +73,7 @@ impl<R: clickhouse::Row + Serialize + Send + Sync + 'static> ClickhouseChannelWr
         batch_size: usize,
     ) -> Result<Arc<Self>> {
         let (sender, receiver) = mpsc::channel(channel_capacity);
+        register_for_shutdown_flush(table, sender.downgrade());
         let writer = Arc::new(Self {
             sender,
             capacity: channel_capacity,
@@ -36,7 +86,7 @@ impl<R: clickhouse::Row + Serialize + Send + Sync + 'static> ClickhouseChannelWr
 
     pub fn enqueue_rows(&self, rows: Vec<R>) -> Result<()> {
         self.sender
-            .try_send(rows)
+            .try_send(Msg::Rows(rows))
             .map_err(|e| anyhow::anyhow!("enqueue_failed: {e}"))
     }
 
@@ -48,12 +98,21 @@ impl<R: clickhouse::Row + Serialize + Send + Sync + 'static> ClickhouseChannelWr
         clickhouse: Arc<ClickHouseClient>,
         table: String,
         batch_size: usize,
-        mut receiver: mpsc::Receiver<Vec<R>>,
+        mut receiver: mpsc::Receiver<Msg<R>>,
     ) {
         tokio::spawn(async move {
-            while let Some(batch) = receiver.recv().await {
-                if let Err(err) = Self::insert_rows(&clickhouse, &table, batch, batch_size).await {
-                    warn!(table = %table, error = ?err, "Failed to insert rows");
+            while let Some(msg) = receiver.recv().await {
+                match msg {
+                    Msg::Rows(batch) => {
+                        if let Err(err) =
+                            Self::insert_rows(&clickhouse, &table, batch, batch_size).await
+                        {
+                            warn!(table = %table, error = ?err, "Failed to insert rows");
+                        }
+                    }
+                    Msg::Flush(ack) => {
+                        let _ = ack.send(());
+                    }
                 }
             }
         });

--- a/backend/src/monitor/clickhouse_writer.rs
+++ b/backend/src/monitor/clickhouse_writer.rs
@@ -8,16 +8,13 @@ use tracing::{info, warn};
 use crate::clickhouse::ClickHouseClient;
 use crate::monitor::MonitorResultRow;
 
-/// Message consumed by a writer's background worker.
 enum Msg<R> {
     Rows(Vec<R>),
     /// Shutdown fence: acked once every batch enqueued before it is inserted.
     Flush(oneshot::Sender<()>),
 }
 
-/// Every live writer, registered at construction. Lets shutdown flush all
-/// writers without threading handles through each subsystem's init (the
-/// monitor writers are created inside a detached retry loop main can't reach).
+/// Every live writer, registered at construction. Lets shutdown flush all writers
 static FLUSH_REGISTRY: Mutex<Vec<FlushHandle>> = Mutex::new(Vec::new());
 
 struct FlushHandle {
@@ -40,7 +37,7 @@ fn register_for_shutdown_flush<R: Send + 'static>(table: &str, sender: mpsc::Wea
 
 /// Sends a flush fence into every live writer, then waits for the acks: once
 /// a writer acks, every batch enqueued into it before the fence is durable in
-/// ClickHouse. Called during graceful shutdown; the caller bounds the wait.
+/// ClickHouse.
 pub async fn flush_all_writers() {
     let pending: Vec<(String, oneshot::Receiver<()>)> = FLUSH_REGISTRY
         .lock()

--- a/backend/src/processing/mod.rs
+++ b/backend/src/processing/mod.rs
@@ -78,9 +78,9 @@ pub struct EventProcessor {
 }
 
 impl EventProcessor {
-    pub fn new(geoip_service: GeoIpService) -> (Self, mpsc::Receiver<ProcessedEvent>) {
-        let (event_tx, event_rx) = mpsc::channel(100_000);
-        (Self { event_tx, geoip_service }, event_rx)
+    /// `event_tx` is the ingest channel consumed by the ClickHouse inserter task.
+    pub fn new(geoip_service: GeoIpService, event_tx: mpsc::Sender<ProcessedEvent>) -> Self {
+        Self { event_tx, geoip_service }
     }
 
     pub async fn process_event(&self, event: AnalyticsEvent) -> Result<()> {


### PR DESCRIPTION
The backend never received SIGTERM (shell-form CMD), so every deploy waited out Docker's grace period into a SIGKILL that destroyed up to ~10s of already-acknowledged events plus queued monitor/alert state. The binary now handles SIGTERM: axum finishes in-flight requests, the ingest pipeline (collapsed to a single channel, replacing the forwarder/dispatcher relay tasks) commits its final batch, and the monitor/notification writers are flushed behind a FIFO fence, all capped by a 5s drain deadline and an 8s watchdog so shutdown never depends on SIGKILL.

Closes betterlytics/betterlytics-internal#90

Reviewer notes: read the pipeline-collapse commit first, then the shutdown wiring in main.rs. Exit codes are now meaningful (0 = clean drain, 1 = deadline/watchdog). Verified in a worktree stack: docker stop completes in ~1.4s with all 25 buffered events queryable afterward, and exits 1 within ~6s when ClickHouse is unreachable. The optional proxy-flip follow-up from the ticket is not included.
