### PR TITLE
Made the insert pipeline survive ClickHouse outages without losing or duplicating events

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -736,6 +736,7 @@ dependencies = [
  "governor",
  "hex",
  "html-escape",
+ "http 1.3.1",
  "httpdate",
  "ipnet",
  "isbot",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -90,3 +90,4 @@ html-escape = "0.2"
 [dev-dependencies]
 clickhouse = { version = "0.13.2", features = ["test-util"] }
 tokio = { version = "1.44.2", features = ["full", "test-util"] }
+http = "1"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -89,3 +89,4 @@ html-escape = "0.2"
 
 [dev-dependencies]
 clickhouse = { version = "0.13.2", features = ["test-util"] }
+tokio = { version = "1.44.2", features = ["full", "test-util"] }

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -246,10 +246,10 @@ async fn run_inserter(
     }
 }
 
-/// Inserts the whole batch as one INSERT, clearing it only after ClickHouse
-/// confirms. Transient failures retry forever with capped backoff (the
-/// channel buffers upstream); recognized rejections drop the batch after a
-/// few attempts so a poison batch cannot block the pipeline. Retries are deduped.
+/// Clears the batch only once ClickHouse confirms it. Transient failures retry
+/// forever (the channel buffers upstream); recognized rejections drop the batch
+/// after a few attempts so a poison batch cannot block the pipeline. All
+/// attempts share one dedup token, so a re-sent batch is ignored server-side.
 async fn flush(
     client: &clickhouse::Client,
     batch: &mut Vec<EventRow>,
@@ -347,7 +347,6 @@ enum ErrorClass {
     Deterministic,
 }
 
-/// Whether an insert error can plausibly succeed on retry.
 fn classify(error: &ClickHouseError) -> ErrorClass {
     match error {
         ClickHouseError::Network(_) | ClickHouseError::TimedOut => ErrorClass::Transient,
@@ -367,7 +366,6 @@ fn classify(error: &ClickHouseError) -> ErrorClass {
     }
 }
 
-/// Parses the leading "Code: NNN." from a ClickHouse exception message.
 fn server_exception_code(response: &str) -> Option<u32> {
     let rest = response.trim_start().strip_prefix("Code: ")?;
     let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
@@ -489,9 +487,6 @@ mod tests {
         assert!(rows.iter().all(|r| r.site_id == "test-site"));
     }
 
-    /// Transient failures must never kill the inserter: it holds the batch
-    /// and keeps retrying until ClickHouse returns. (At shutdown, main's
-    /// drain deadline caps the wait; the task itself never gives up.)
     #[tokio::test(start_paused = true)]
     async fn inserter_retries_forever_when_clickhouse_is_unreachable() {
         let client = clickhouse::Client::default().with_url("http://127.0.0.1:9");
@@ -502,13 +497,10 @@ mod tests {
         tx.send(test_event(0)).await.unwrap();
         drop(tx);
 
-        // Ten virtual minutes of backoff-retries later, the task is still
-        // alive and still trying - not dead like before issue #19.
+        // Still retrying ten virtual minutes later: the timeout is the pass.
         assert!(timeout(Duration::from_secs(600), handle).await.is_err());
     }
 
-    /// A transient failure (here: a 500 with no ClickHouse exception body)
-    /// must lose nothing: the batch is held and the retry delivers it whole.
     #[tokio::test(start_paused = true)]
     async fn transient_failure_then_recovery_loses_no_events() {
         let mock = Mock::new();
@@ -533,8 +525,6 @@ mod tests {
         assert_eq!(rows.len(), 3);
     }
 
-    /// A batch that ClickHouse can never accept is dropped after a few
-    /// attempts instead of head-of-line-blocking every batch behind it.
     #[tokio::test(start_paused = true)]
     async fn poison_batch_is_dropped_and_does_not_block_later_batches() {
         let mock = Mock::new();
@@ -550,11 +540,9 @@ mod tests {
         poison.timestamp = chrono::DateTime::from_timestamp(5_000_000_000, 0).unwrap();
         tx.send(poison).await.unwrap();
 
-        // Let the flush period elapse and the rejected batch burn its
-        // attempts (virtual time).
+        // Long enough for the flush period plus every rejected attempt.
         tokio::time::sleep(Duration::from_secs(30)).await;
 
-        // A later, healthy batch must go through unimpeded.
         tx.send(test_event(1)).await.unwrap();
         drop(tx);
 

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -263,11 +263,16 @@ async fn flush(
         return;
     }
 
+    // One token per batch, stable across its retries: analytics.events keeps
+    // a window of recently seen tokens (migration 37) and silently ignores a
+    // block it has already committed, making retries exactly-once in effect.
+    let dedup_token = uuid::Uuid::new_v4().to_string();
+
     let mut transient_attempts: u32 = 0;
     let mut rejected_attempts: u32 = 0;
 
     loop {
-        match try_insert(client, batch).await {
+        match try_insert(client, batch, &dedup_token).await {
             Ok(()) => {
                 debug!(rows = batch.len(), "Committed batch to ClickHouse");
                 batch.clear();
@@ -317,8 +322,14 @@ async fn flush(
     }
 }
 
-async fn try_insert(client: &clickhouse::Client, batch: &[EventRow]) -> Result<(), ClickHouseError> {
+async fn try_insert(
+    client: &clickhouse::Client,
+    batch: &[EventRow],
+    dedup_token: &str,
+) -> Result<(), ClickHouseError> {
     let mut insert = client
+        .clone()
+        .with_option("insert_deduplication_token", dedup_token)
         .insert("analytics.events")?
         .with_timeouts(
             Some(Duration::from_secs(INSERTER_TIMEOUT_SECS)),

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -18,6 +18,10 @@ pub use models::{ActiveSessionRow, EventRow, ReferrerSourceCategoryRow, SessionR
 
 const EVENT_CHANNEL_CAPACITY: usize = 100_000;
 const INSERTER_TIMEOUT_SECS: u64 = 5;
+/// Cap on awaiting ClickHouse's insert acknowledgement. Without it a
+/// black-hole connection (paused/vanished server) hangs the flush forever
+/// instead of surfacing a timeout the retry loop can act on.
+const INSERTER_END_TIMEOUT_SECS: u64 = 10;
 const INSERTER_PERIOD_SECS: u64 = 10;
 const INSERTER_MAX_ROWS: u64 = 100_000;
 const INSERTER_MAX_BYTES: u64 = 50 * 1024 * 1024;
@@ -316,7 +320,10 @@ async fn flush(
 async fn try_insert(client: &clickhouse::Client, batch: &[EventRow]) -> Result<(), ClickHouseError> {
     let mut insert = client
         .insert("analytics.events")?
-        .with_timeouts(Some(Duration::from_secs(INSERTER_TIMEOUT_SECS)), None);
+        .with_timeouts(
+            Some(Duration::from_secs(INSERTER_TIMEOUT_SECS)),
+            Some(Duration::from_secs(INSERTER_END_TIMEOUT_SECS)),
+        );
     for row in batch {
         insert.write(row).await?;
     }

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -22,8 +22,11 @@ const INSERTER_TIMEOUT_SECS: u64 = 5;
 /// surfaces as a retryable timeout instead of hanging the flush.
 const INSERTER_END_TIMEOUT_SECS: u64 = 10;
 const INSERTER_PERIOD_SECS: u64 = 10;
-const INSERTER_MAX_ROWS: u64 = 100_000;
-const INSERTER_MAX_BYTES: u64 = 50 * 1024 * 1024;
+/// Flush when the batch reaches this many rows. Sized so even validation's
+/// worst-case event (~30 KB of properties + error payload) keeps a batch
+/// around ~60 MB; typical events (~0.5 KB) make ~1 MB batches. Revisit if
+/// validation's payload size caps change.
+const INSERTER_MAX_ROWS: usize = 2_000;
 const RETRY_BASE_BACKOFF_SECS: u64 = 1;
 const RETRY_MAX_BACKOFF_SECS: u64 = 30;
 const REJECTED_BATCH_ATTEMPTS: u32 = 3;
@@ -202,7 +205,6 @@ async fn run_inserter(
 
     let period = Duration::from_secs(INSERTER_PERIOD_SECS);
     let mut batch: Vec<EventRow> = Vec::new();
-    let mut batch_bytes: usize = 0;
     let mut flush_deadline = Instant::now() + period;
 
     loop {
@@ -220,22 +222,21 @@ async fn run_inserter(
                     url = %row.url,
                     timestamp = %row.timestamp,
                     "Buffered row for ClickHouse insertion");
-                batch_bytes += approx_row_bytes(&row);
                 batch.push(row);
 
-                if batch.len() as u64 >= INSERTER_MAX_ROWS || batch_bytes as u64 >= INSERTER_MAX_BYTES {
-                    flush(&client, &mut batch, &mut batch_bytes, &metrics).await;
+                if batch.len() >= INSERTER_MAX_ROWS {
+                    flush(&client, &mut batch, &metrics).await;
                     flush_deadline = Instant::now() + period;
                 }
             }
             Ok(None) => {
                 info!(rows = batch.len(), "Ingest channel closed, committing final batch");
-                flush(&client, &mut batch, &mut batch_bytes, &metrics).await;
+                flush(&client, &mut batch, &metrics).await;
                 info!("Inserter shutdown complete, final batch committed");
                 return;
             }
             Err(_) => {
-                flush(&client, &mut batch, &mut batch_bytes, &metrics).await;
+                flush(&client, &mut batch, &metrics).await;
                 flush_deadline = Instant::now() + period;
             }
         }
@@ -249,7 +250,6 @@ async fn run_inserter(
 async fn flush(
     client: &clickhouse::Client,
     batch: &mut Vec<EventRow>,
-    batch_bytes: &mut usize,
     metrics: &Option<Arc<MetricsCollector>>,
 ) {
     if batch.is_empty() {
@@ -266,7 +266,6 @@ async fn flush(
             Ok(()) => {
                 debug!(rows = batch.len(), "Committed batch to ClickHouse");
                 batch.clear();
-                *batch_bytes = 0;
                 return;
             }
             Err(e) => match classify(&e) {
@@ -297,7 +296,6 @@ async fn flush(
                             metrics.increment_events_dropped("insert_gave_up", batch.len() as u64);
                         }
                         batch.clear();
-                        *batch_bytes = 0;
                         return;
                     }
                     warn!(
@@ -361,13 +359,6 @@ fn server_exception_code(response: &str) -> Option<u32> {
     let rest = response.trim_start().strip_prefix("Code: ")?;
     let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
     digits.parse().ok()
-}
-
-/// Per-row size for the batch byte threshold, measured by serializing the
-/// row itself so it can never drift from the schema. JSON is a close upper
-/// bound for the RowBinary wire size, so flushes trigger marginally early.
-fn approx_row_bytes(row: &EventRow) -> usize {
-    serde_json::to_vec(row).map_or(1024, |bytes| bytes.len())
 }
 
 /// SQL to load each active visitor's most recent session. Filtering on `session_end` uses the

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -18,9 +18,8 @@ pub use models::{ActiveSessionRow, EventRow, ReferrerSourceCategoryRow, SessionR
 
 const EVENT_CHANNEL_CAPACITY: usize = 100_000;
 const INSERTER_TIMEOUT_SECS: u64 = 5;
-/// Cap on awaiting ClickHouse's insert acknowledgement. Without it a
-/// black-hole connection (paused/vanished server) hangs the flush forever
-/// instead of surfacing a timeout the retry loop can act on.
+/// Cap on awaiting the insert acknowledgement, so a black-hole connection
+/// surfaces as a retryable timeout instead of hanging the flush.
 const INSERTER_END_TIMEOUT_SECS: u64 = 10;
 const INSERTER_PERIOD_SECS: u64 = 10;
 const INSERTER_MAX_ROWS: u64 = 100_000;
@@ -243,16 +242,12 @@ async fn run_inserter(
     }
 }
 
-/// Inserts the whole batch as one INSERT and clears it only after ClickHouse
-/// confirms. Transient failures (network, timeout, overload) retry forever
-/// with capped backoff while the ingest channel buffers upstream; recognized
-/// server rejections drop the batch after a few attempts so a poison batch
-/// cannot block the pipeline forever.
-///
-/// Delivery is therefore at-least-once: a timeout after the server already
-/// committed duplicates the batch on retry. Accepted trade-off (issue #19);
-/// an insert_deduplication_token would make retries idempotent if the table
-/// gains a non-replicated dedup window.
+/// Inserts the whole batch as one INSERT, clearing it only after ClickHouse
+/// confirms. Transient failures retry forever with capped backoff (the
+/// channel buffers upstream); recognized rejections drop the batch after a
+/// few attempts so a poison batch cannot block the pipeline. Retries reuse
+/// one dedup token per batch, so a batch whose ack was lost is ignored by
+/// the server on re-send (migration 37) instead of duplicating events.
 async fn flush(
     client: &clickhouse::Client,
     batch: &mut Vec<EventRow>,
@@ -263,9 +258,6 @@ async fn flush(
         return;
     }
 
-    // One token per batch, stable across its retries: analytics.events keeps
-    // a window of recently seen tokens (migration 37) and silently ignores a
-    // block it has already committed, making retries exactly-once in effect.
     let dedup_token = uuid::Uuid::new_v4().to_string();
 
     let mut transient_attempts: u32 = 0;
@@ -346,8 +338,7 @@ enum ErrorClass {
     Deterministic,
 }
 
-/// Whether an insert error can plausibly succeed on retry. Only a recognized
-/// ClickHouse rejection is treated as deterministic - when in doubt, retry.
+/// Whether an insert error can plausibly succeed on retry.
 fn classify(error: &ClickHouseError) -> ErrorClass {
     match error {
         ClickHouseError::Network(_) | ClickHouseError::TimedOut => ErrorClass::Transient,
@@ -374,39 +365,19 @@ fn server_exception_code(response: &str) -> Option<u32> {
     digits.parse().ok()
 }
 
-/// Approximate in-memory size of a row, used to bound batch memory between
-/// flushes. Not the exact wire size; string fields dominate, so close enough.
+/// Rough per-row memory estimate for the batch byte cap. Only fields that
+/// validation allows to grow beyond ~100 bytes are measured; the fixed
+/// overhead generously covers every small column, present and future.
 fn approx_row_bytes(row: &EventRow) -> usize {
-    const FIXED_FIELDS: usize = 128;
-    FIXED_FIELDS
-        + row.site_id.len()
-        + row.domain.len()
+    const FIXED_OVERHEAD: usize = 512;
+    FIXED_OVERHEAD
         + row.url.len()
-        + row.device_type.len()
-        + row.country_code.len()
-        + row.subdivision_code.len()
-        + row.city.len()
-        + row.browser.len()
-        + row.browser_version.len()
-        + row.os.len()
-        + row.os_version.len()
-        + row.referrer_source.len()
-        + row.referrer_source_canonical.len()
-        + row.referrer_source_name.len()
-        + row.referrer_search_term.len()
         + row.referrer_url.len()
-        + row.utm_source.len()
-        + row.utm_medium.len()
-        + row.utm_campaign.len()
-        + row.utm_term.len()
-        + row.utm_content.len()
-        + row.custom_event_name.len()
+        + row.referrer_search_term.len()
         + row.custom_event_json.len()
         + row.outbound_link_url.len()
         + row.error_exceptions.len()
-        + row.error_type.len()
         + row.error_message.len()
-        + row.error_fingerprint.len()
         + row.global_properties_keys.iter().map(String::len).sum::<usize>()
         + row.global_properties_values.iter().map(String::len).sum::<usize>()
 }

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -245,9 +245,7 @@ async fn run_inserter(
 /// Inserts the whole batch as one INSERT, clearing it only after ClickHouse
 /// confirms. Transient failures retry forever with capped backoff (the
 /// channel buffers upstream); recognized rejections drop the batch after a
-/// few attempts so a poison batch cannot block the pipeline. Retries reuse
-/// one dedup token per batch, so a batch whose ack was lost is ignored by
-/// the server on re-send (migration 37) instead of duplicating events.
+/// few attempts so a poison batch cannot block the pipeline. Retries are deduped.
 async fn flush(
     client: &clickhouse::Client,
     batch: &mut Vec<EventRow>,
@@ -365,21 +363,11 @@ fn server_exception_code(response: &str) -> Option<u32> {
     digits.parse().ok()
 }
 
-/// Rough per-row memory estimate for the batch byte cap. Only fields that
-/// validation allows to grow beyond ~100 bytes are measured; the fixed
-/// overhead generously covers every small column, present and future.
+/// Per-row size for the batch byte threshold, measured by serializing the
+/// row itself so it can never drift from the schema. JSON is a close upper
+/// bound for the RowBinary wire size, so flushes trigger marginally early.
 fn approx_row_bytes(row: &EventRow) -> usize {
-    const FIXED_OVERHEAD: usize = 512;
-    FIXED_OVERHEAD
-        + row.url.len()
-        + row.referrer_url.len()
-        + row.referrer_search_term.len()
-        + row.custom_event_json.len()
-        + row.outbound_link_url.len()
-        + row.error_exceptions.len()
-        + row.error_message.len()
-        + row.global_properties_keys.iter().map(String::len).sum::<usize>()
-        + row.global_properties_values.iter().map(String::len).sum::<usize>()
+    serde_json::to_vec(row).map_or(1024, |bytes| bytes.len())
 }
 
 /// SQL to load each active visitor's most recent session. Filtering on `session_end` uses the

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -20,6 +20,9 @@ const INSERTER_TIMEOUT_SECS: u64 = 5;
 const INSERTER_PERIOD_SECS: u64 = 10;
 const INSERTER_MAX_ROWS: u64 = 100_000;
 const INSERTER_MAX_BYTES: u64 = 50 * 1024 * 1024;
+const RETRY_BASE_BACKOFF_SECS: u64 = 1;
+const RETRY_MAX_BACKOFF_SECS: u64 = 30;
+const REJECTED_BATCH_ATTEMPTS: u32 = 3;
 
 pub struct Database {
     clickhouse: Arc<ClickHouseClient>,
@@ -37,11 +40,7 @@ impl Database {
         let (event_tx, event_rx) = mpsc::channel(EVENT_CHANNEL_CAPACITY);
 
         let client = clickhouse.inner().clone();
-        let inserter_handle = tokio::spawn(async move {
-            if let Err(e) = run_inserter(client, event_rx).await {
-                error!("Inserter task failed: {}", e);
-            }
-        });
+        let inserter_handle = tokio::spawn(run_inserter(client, event_rx));
 
         Ok((Self { clickhouse, config }, event_tx, inserter_handle))
     }
@@ -189,10 +188,7 @@ impl Database {
     }
 }
 
-async fn run_inserter(
-    client: clickhouse::Client,
-    mut rx: Receiver<ProcessedEvent>,
-) -> Result<(), ClickHouseError> {
+async fn run_inserter(client: clickhouse::Client, mut rx: Receiver<ProcessedEvent>) {
     info!("Inserter starting (owned-batch mode)");
 
     let period = Duration::from_secs(INSERTER_PERIOD_SECS);
@@ -219,18 +215,18 @@ async fn run_inserter(
                 batch.push(row);
 
                 if batch.len() as u64 >= INSERTER_MAX_ROWS || batch_bytes as u64 >= INSERTER_MAX_BYTES {
-                    flush(&client, &mut batch, &mut batch_bytes).await?;
+                    flush(&client, &mut batch, &mut batch_bytes).await;
                     flush_deadline = Instant::now() + period;
                 }
             }
             Ok(None) => {
                 info!(rows = batch.len(), "Ingest channel closed, committing final batch");
-                flush(&client, &mut batch, &mut batch_bytes).await?;
+                flush(&client, &mut batch, &mut batch_bytes).await;
                 info!("Inserter shutdown complete, final batch committed");
-                return Ok(());
+                return;
             }
             Err(_) => {
-                flush(&client, &mut batch, &mut batch_bytes).await?;
+                flush(&client, &mut batch, &mut batch_bytes).await;
                 flush_deadline = Instant::now() + period;
             }
         }
@@ -238,28 +234,112 @@ async fn run_inserter(
 }
 
 /// Inserts the whole batch as one INSERT and clears it only after ClickHouse
-/// confirms, so a failed insert leaves the rows owned and retryable.
-async fn flush(
-    client: &clickhouse::Client,
-    batch: &mut Vec<EventRow>,
-    batch_bytes: &mut usize,
-) -> Result<(), ClickHouseError> {
+/// confirms. Transient failures (network, timeout, overload) retry forever
+/// with capped backoff while the ingest channel buffers upstream; recognized
+/// server rejections drop the batch after a few attempts so a poison batch
+/// cannot block the pipeline forever.
+///
+/// Delivery is therefore at-least-once: a timeout after the server already
+/// committed duplicates the batch on retry. Accepted trade-off (issue #19);
+/// an insert_deduplication_token would make retries idempotent if the table
+/// gains a non-replicated dedup window.
+async fn flush(client: &clickhouse::Client, batch: &mut Vec<EventRow>, batch_bytes: &mut usize) {
     if batch.is_empty() {
-        return Ok(());
+        return;
     }
 
+    let mut transient_attempts: u32 = 0;
+    let mut rejected_attempts: u32 = 0;
+
+    loop {
+        match try_insert(client, batch).await {
+            Ok(()) => {
+                debug!(rows = batch.len(), "Committed batch to ClickHouse");
+                batch.clear();
+                *batch_bytes = 0;
+                return;
+            }
+            Err(e) => match classify(&e) {
+                ErrorClass::Transient => {
+                    transient_attempts += 1;
+                    let exp = transient_attempts.saturating_sub(1).min(5);
+                    let backoff = Duration::from_secs(
+                        (RETRY_BASE_BACKOFF_SECS << exp).min(RETRY_MAX_BACKOFF_SECS),
+                    );
+                    error!(
+                        error = %e,
+                        attempt = transient_attempts,
+                        backoff_secs = backoff.as_secs(),
+                        rows = batch.len(),
+                        "Transient ClickHouse insert failure, retrying batch"
+                    );
+                    tokio::time::sleep(backoff).await;
+                }
+                ErrorClass::Deterministic => {
+                    rejected_attempts += 1;
+                    if rejected_attempts >= REJECTED_BATCH_ATTEMPTS {
+                        error!(
+                            error = %e,
+                            rows = batch.len(),
+                            "ClickHouse rejected batch deterministically, dropping it"
+                        );
+                        batch.clear();
+                        *batch_bytes = 0;
+                        return;
+                    }
+                    warn!(
+                        error = %e,
+                        attempt = rejected_attempts,
+                        "ClickHouse rejected batch, retrying"
+                    );
+                    tokio::time::sleep(Duration::from_secs(RETRY_BASE_BACKOFF_SECS)).await;
+                }
+            },
+        }
+    }
+}
+
+async fn try_insert(client: &clickhouse::Client, batch: &[EventRow]) -> Result<(), ClickHouseError> {
     let mut insert = client
         .insert("analytics.events")?
         .with_timeouts(Some(Duration::from_secs(INSERTER_TIMEOUT_SECS)), None);
-    for row in batch.iter() {
+    for row in batch {
         insert.write(row).await?;
     }
-    insert.end().await?;
+    insert.end().await
+}
 
-    debug!(rows = batch.len(), "Committed batch to ClickHouse");
-    batch.clear();
-    *batch_bytes = 0;
-    Ok(())
+enum ErrorClass {
+    Transient,
+    Deterministic,
+}
+
+/// Whether an insert error can plausibly succeed on retry. Only a recognized
+/// ClickHouse rejection is treated as deterministic - when in doubt, retry.
+fn classify(error: &ClickHouseError) -> ErrorClass {
+    match error {
+        ClickHouseError::Network(_) | ClickHouseError::TimedOut => ErrorClass::Transient,
+        ClickHouseError::BadResponse(response) => match server_exception_code(response) {
+            // Capacity/availability conditions that clear on their own:
+            // 159 TIMEOUT_EXCEEDED, 202 TOO_MANY_SIMULTANEOUS_QUERIES,
+            // 209 SOCKET_TIMEOUT, 210 NETWORK_ERROR, 241 MEMORY_LIMIT_EXCEEDED,
+            // 242 TABLE_IS_READ_ONLY, 252 TOO_MANY_PARTS
+            Some(159 | 202 | 209 | 210 | 241 | 242 | 252) => ErrorClass::Transient,
+            // Any other exception code rejects these exact bytes every time.
+            Some(_) => ErrorClass::Deterministic,
+            // Unparseable body (proxy mangling, truncation): retryable.
+            None => ErrorClass::Transient,
+        },
+        // Client-side serialization/params errors reproduce on every attempt.
+        _ => ErrorClass::Deterministic,
+    }
+}
+
+/// Parses the leading "Code: NNN." from a ClickHouse exception message.
+fn server_exception_code(response: &str) -> Option<u32> {
+    let rest = response.trim_start().strip_prefix("Code: ")?;
+    let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+    digits.parse().ok()
 }
 
 /// Approximate in-memory size of a row, used to bound batch memory between
@@ -407,18 +487,18 @@ mod tests {
         timeout(Duration::from_secs(10), handle)
             .await
             .expect("inserter did not exit after channel close")
-            .expect("inserter task panicked")
-            .expect("inserter returned an error");
+            .expect("inserter task panicked");
 
         let rows: Vec<EventRow> = recording.collect().await;
         assert_eq!(rows.len(), 5);
         assert!(rows.iter().all(|r| r.site_id == "test-site"));
     }
 
-    /// The deadline-safety property: an unreachable ClickHouse must never
-    /// leave the drain hanging - the task finishes (with an error) promptly.
-    #[tokio::test]
-    async fn inserter_exits_when_clickhouse_is_unreachable() {
+    /// Transient failures must never kill the inserter: it holds the batch
+    /// and keeps retrying until ClickHouse returns. (At shutdown, main's
+    /// drain deadline caps the wait; the task itself never gives up.)
+    #[tokio::test(start_paused = true)]
+    async fn inserter_retries_forever_when_clickhouse_is_unreachable() {
         let client = clickhouse::Client::default().with_url("http://127.0.0.1:9");
 
         let (tx, rx) = mpsc::channel(100);
@@ -427,10 +507,8 @@ mod tests {
         tx.send(test_event(0)).await.unwrap();
         drop(tx);
 
-        timeout(Duration::from_secs(10), handle)
-            .await
-            .expect("inserter did not exit after channel close")
-            .expect("inserter task panicked")
-            .ok();
+        // Ten virtual minutes of backoff-retries later, the task is still
+        // alive and still trying - not dead like before issue #19.
+        assert!(timeout(Duration::from_secs(600), handle).await.is_err());
     }
 }

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -3,9 +3,9 @@ use clickhouse::error::Error as ClickHouseError;
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::sync::mpsc::{self, error::TryRecvError, Receiver, Sender};
+use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio::task::JoinHandle;
-use tokio::time::timeout;
+use tokio::time::{timeout_at, Instant};
 use tracing::{debug, error, info, warn};
 
 use crate::clickhouse::ClickHouseClient;
@@ -193,75 +193,110 @@ async fn run_inserter(
     client: clickhouse::Client,
     mut rx: Receiver<ProcessedEvent>,
 ) -> Result<(), ClickHouseError> {
-    info!("Inserter starting (sparse stream mode)");
+    info!("Inserter starting (owned-batch mode)");
 
-    let mut inserter = client
-        .inserter("analytics.events")?
-        .with_timeouts(
-            Some(Duration::from_secs(INSERTER_TIMEOUT_SECS)),
-            None,
-        )
-        .with_period(Some(Duration::from_secs(INSERTER_PERIOD_SECS)))
-        .with_max_rows(INSERTER_MAX_ROWS)
-        .with_max_bytes(INSERTER_MAX_BYTES);
-
-    debug!("Inserter configured");
+    let period = Duration::from_secs(INSERTER_PERIOD_SECS);
+    let mut batch: Vec<EventRow> = Vec::new();
+    let mut batch_bytes: usize = 0;
+    let mut flush_deadline = Instant::now() + period;
 
     loop {
-        let event = match rx.try_recv() {
-            Ok(received_event) => received_event,
-            Err(TryRecvError::Empty) => {
-                // Channel empty, wait for the next event or until the inserter period ends.
-                let time_left = inserter
-                    .time_left()
-                    .unwrap_or_else(|| Duration::from_secs(INSERTER_PERIOD_SECS));
+        match timeout_at(flush_deadline, rx.recv()).await {
+            Ok(Some(event)) => {
+                let row = match EventRow::from_processed(event) {
+                    Some(row) => row,
+                    None => continue,
+                };
+                debug!(
+                    site_id = %row.site_id,
+                    visitor_id = %row.visitor_id,
+                    session_id = %row.session_id,
+                    event_type = ?row.event_type,
+                    url = %row.url,
+                    timestamp = %row.timestamp,
+                    "Buffered row for ClickHouse insertion");
+                batch_bytes += approx_row_bytes(&row);
+                batch.push(row);
 
-                match timeout(time_left, rx.recv()).await {
-                    Ok(Some(received_event)) => received_event,
-                    Ok(None) => {
-                        info!("Ingest channel closed, committing final batch");
-                        inserter.commit().await?;
-                        break;
-                    }
-                    Err(_) => {
-                        inserter.commit().await?;
-                        continue;
-                    }
+                if batch.len() as u64 >= INSERTER_MAX_ROWS || batch_bytes as u64 >= INSERTER_MAX_BYTES {
+                    flush(&client, &mut batch, &mut batch_bytes).await?;
+                    flush_deadline = Instant::now() + period;
                 }
             }
-            Err(TryRecvError::Disconnected) => {
-                info!("Ingest channel disconnected, committing final batch");
-                break;
+            Ok(None) => {
+                info!(rows = batch.len(), "Ingest channel closed, committing final batch");
+                flush(&client, &mut batch, &mut batch_bytes).await?;
+                info!("Inserter shutdown complete, final batch committed");
+                return Ok(());
             }
-        };
-
-        let row = match EventRow::from_processed(event) {
-            Some(row) => row,
-            None => continue,
-        };
-
-        debug!(
-            site_id = %row.site_id,
-            visitor_id = %row.visitor_id,
-            session_id = %row.session_id,
-            event_type = ?row.event_type,
-            custom_event_name = ?row.custom_event_name,
-            url = %row.url,
-            timestamp = %row.timestamp,
-            device_type = %row.device_type,
-            browser = %row.browser,
-            os = %row.os,
-            "Prepared row for ClickHouse insertion");
-        if let Err(e) = inserter.write(&row) {
-            error!("Failed to write row to inserter buffer: {}. Row: {:?}", e, row);
-            // TODO: Implement retry logic or dead-letter queue for inserter write failures.
-            continue;
+            Err(_) => {
+                flush(&client, &mut batch, &mut batch_bytes).await?;
+                flush_deadline = Instant::now() + period;
+            }
         }
     }
+}
 
-    let stats = inserter.end().await?;
-    info!(stats = ?stats, "Inserter shutdown complete, final batch committed");
+/// Inserts the whole batch as one INSERT and clears it only after ClickHouse
+/// confirms, so a failed insert leaves the rows owned and retryable.
+async fn flush(
+    client: &clickhouse::Client,
+    batch: &mut Vec<EventRow>,
+    batch_bytes: &mut usize,
+) -> Result<(), ClickHouseError> {
+    if batch.is_empty() {
+        return Ok(());
+    }
+
+    let mut insert = client
+        .insert("analytics.events")?
+        .with_timeouts(Some(Duration::from_secs(INSERTER_TIMEOUT_SECS)), None);
+    for row in batch.iter() {
+        insert.write(row).await?;
+    }
+    insert.end().await?;
+
+    debug!(rows = batch.len(), "Committed batch to ClickHouse");
+    batch.clear();
+    *batch_bytes = 0;
     Ok(())
+}
+
+/// Approximate in-memory size of a row, used to bound batch memory between
+/// flushes. Not the exact wire size; string fields dominate, so close enough.
+fn approx_row_bytes(row: &EventRow) -> usize {
+    const FIXED_FIELDS: usize = 128;
+    FIXED_FIELDS
+        + row.site_id.len()
+        + row.domain.len()
+        + row.url.len()
+        + row.device_type.len()
+        + row.country_code.len()
+        + row.subdivision_code.len()
+        + row.city.len()
+        + row.browser.len()
+        + row.browser_version.len()
+        + row.os.len()
+        + row.os_version.len()
+        + row.referrer_source.len()
+        + row.referrer_source_canonical.len()
+        + row.referrer_source_name.len()
+        + row.referrer_search_term.len()
+        + row.referrer_url.len()
+        + row.utm_source.len()
+        + row.utm_medium.len()
+        + row.utm_campaign.len()
+        + row.utm_term.len()
+        + row.utm_content.len()
+        + row.custom_event_name.len()
+        + row.custom_event_json.len()
+        + row.outbound_link_url.len()
+        + row.error_exceptions.len()
+        + row.error_type.len()
+        + row.error_message.len()
+        + row.error_fingerprint.len()
+        + row.global_properties_keys.iter().map(String::len).sum::<usize>()
+        + row.global_properties_values.iter().map(String::len).sum::<usize>()
 }
 
 /// SQL to load each active visitor's most recent session. Filtering on `session_end` uses the
@@ -286,6 +321,7 @@ mod tests {
     use crate::campaign::CampaignInfo;
     use crate::referrer::ReferrerInfo;
     use clickhouse::test::{handlers, Mock};
+    use tokio::time::timeout;
 
     fn test_event(n: u64) -> ProcessedEvent {
         let raw = RawTrackingEvent {

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -10,6 +10,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::clickhouse::ClickHouseClient;
 use crate::config::Config;
+use crate::metrics::MetricsCollector;
 use crate::processing::ProcessedEvent;
 
 mod models;
@@ -36,11 +37,12 @@ impl Database {
     pub async fn new(
         clickhouse: Arc<ClickHouseClient>,
         config: Arc<Config>,
+        metrics: Option<Arc<MetricsCollector>>,
     ) -> Result<(Self, Sender<ProcessedEvent>, JoinHandle<()>)> {
         let (event_tx, event_rx) = mpsc::channel(EVENT_CHANNEL_CAPACITY);
 
         let client = clickhouse.inner().clone();
-        let inserter_handle = tokio::spawn(run_inserter(client, event_rx));
+        let inserter_handle = tokio::spawn(run_inserter(client, event_rx, metrics));
 
         Ok((Self { clickhouse, config }, event_tx, inserter_handle))
     }
@@ -188,7 +190,11 @@ impl Database {
     }
 }
 
-async fn run_inserter(client: clickhouse::Client, mut rx: Receiver<ProcessedEvent>) {
+async fn run_inserter(
+    client: clickhouse::Client,
+    mut rx: Receiver<ProcessedEvent>,
+    metrics: Option<Arc<MetricsCollector>>,
+) {
     info!("Inserter starting (owned-batch mode)");
 
     let period = Duration::from_secs(INSERTER_PERIOD_SECS);
@@ -215,18 +221,18 @@ async fn run_inserter(client: clickhouse::Client, mut rx: Receiver<ProcessedEven
                 batch.push(row);
 
                 if batch.len() as u64 >= INSERTER_MAX_ROWS || batch_bytes as u64 >= INSERTER_MAX_BYTES {
-                    flush(&client, &mut batch, &mut batch_bytes).await;
+                    flush(&client, &mut batch, &mut batch_bytes, &metrics).await;
                     flush_deadline = Instant::now() + period;
                 }
             }
             Ok(None) => {
                 info!(rows = batch.len(), "Ingest channel closed, committing final batch");
-                flush(&client, &mut batch, &mut batch_bytes).await;
+                flush(&client, &mut batch, &mut batch_bytes, &metrics).await;
                 info!("Inserter shutdown complete, final batch committed");
                 return;
             }
             Err(_) => {
-                flush(&client, &mut batch, &mut batch_bytes).await;
+                flush(&client, &mut batch, &mut batch_bytes, &metrics).await;
                 flush_deadline = Instant::now() + period;
             }
         }
@@ -243,7 +249,12 @@ async fn run_inserter(client: clickhouse::Client, mut rx: Receiver<ProcessedEven
 /// committed duplicates the batch on retry. Accepted trade-off (issue #19);
 /// an insert_deduplication_token would make retries idempotent if the table
 /// gains a non-replicated dedup window.
-async fn flush(client: &clickhouse::Client, batch: &mut Vec<EventRow>, batch_bytes: &mut usize) {
+async fn flush(
+    client: &clickhouse::Client,
+    batch: &mut Vec<EventRow>,
+    batch_bytes: &mut usize,
+    metrics: &Option<Arc<MetricsCollector>>,
+) {
     if batch.is_empty() {
         return;
     }
@@ -283,6 +294,9 @@ async fn flush(client: &clickhouse::Client, batch: &mut Vec<EventRow>, batch_byt
                             rows = batch.len(),
                             "ClickHouse rejected batch deterministically, dropping it"
                         );
+                        if let Some(metrics) = metrics {
+                            metrics.increment_events_dropped("insert_gave_up", batch.len() as u64);
+                        }
                         batch.clear();
                         *batch_bytes = 0;
                         return;
@@ -477,7 +491,7 @@ mod tests {
         let client = clickhouse::Client::default().with_url(mock.url());
 
         let (tx, rx) = mpsc::channel(100);
-        let handle = tokio::spawn(run_inserter(client, rx));
+        let handle = tokio::spawn(run_inserter(client, rx, None));
 
         for n in 0..5 {
             tx.send(test_event(n)).await.unwrap();
@@ -502,7 +516,7 @@ mod tests {
         let client = clickhouse::Client::default().with_url("http://127.0.0.1:9");
 
         let (tx, rx) = mpsc::channel(100);
-        let handle = tokio::spawn(run_inserter(client, rx));
+        let handle = tokio::spawn(run_inserter(client, rx, None));
 
         tx.send(test_event(0)).await.unwrap();
         drop(tx);

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -223,6 +223,9 @@ async fn run_inserter(
                     timestamp = %row.timestamp,
                     "Buffered row for ClickHouse insertion");
                 batch.push(row);
+                if let Some(metrics) = &metrics {
+                    metrics.set_inserter_batch_rows(batch.len());
+                }
 
                 if batch.len() >= INSERTER_MAX_ROWS {
                     flush(&client, &mut batch, &metrics).await;
@@ -265,12 +268,20 @@ async fn flush(
         match try_insert(client, batch, &dedup_token).await {
             Ok(()) => {
                 debug!(rows = batch.len(), "Committed batch to ClickHouse");
+                if let Some(metrics) = metrics {
+                    metrics.increment_events_inserted(batch.len() as u64);
+                    metrics.set_inserter_retry_attempts(0);
+                    metrics.set_inserter_batch_rows(0);
+                }
                 batch.clear();
                 return;
             }
             Err(e) => match classify(&e) {
                 ErrorClass::Transient => {
                     transient_attempts += 1;
+                    if let Some(metrics) = metrics {
+                        metrics.set_inserter_retry_attempts(transient_attempts);
+                    }
                     let exp = transient_attempts.saturating_sub(1).min(5);
                     let backoff = Duration::from_secs(
                         (RETRY_BASE_BACKOFF_SECS << exp).min(RETRY_MAX_BACKOFF_SECS),
@@ -294,6 +305,8 @@ async fn flush(
                         );
                         if let Some(metrics) = metrics {
                             metrics.increment_events_dropped("insert_gave_up", batch.len() as u64);
+                            metrics.set_inserter_retry_attempts(0);
+                            metrics.set_inserter_batch_rows(0);
                         }
                         batch.clear();
                         return;

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -525,4 +525,65 @@ mod tests {
         // alive and still trying - not dead like before issue #19.
         assert!(timeout(Duration::from_secs(600), handle).await.is_err());
     }
+
+    /// A transient failure (here: a 500 with no ClickHouse exception body)
+    /// must lose nothing: the batch is held and the retry delivers it whole.
+    #[tokio::test(start_paused = true)]
+    async fn transient_failure_then_recovery_loses_no_events() {
+        let mock = Mock::new();
+        mock.add(handlers::failure(http::StatusCode::INTERNAL_SERVER_ERROR));
+        let recording = mock.add(handlers::record());
+        let client = clickhouse::Client::default().with_url(mock.url());
+
+        let (tx, rx) = mpsc::channel(100);
+        let handle = tokio::spawn(run_inserter(client, rx, None));
+
+        for n in 0..3 {
+            tx.send(test_event(n)).await.unwrap();
+        }
+        drop(tx);
+
+        timeout(Duration::from_secs(120), handle)
+            .await
+            .expect("inserter did not recover from transient failure")
+            .expect("inserter task panicked");
+
+        let rows: Vec<EventRow> = recording.collect().await;
+        assert_eq!(rows.len(), 3);
+    }
+
+    /// A batch that ClickHouse can never accept is dropped after a few
+    /// attempts instead of head-of-line-blocking every batch behind it.
+    #[tokio::test(start_paused = true)]
+    async fn poison_batch_is_dropped_and_does_not_block_later_batches() {
+        let mock = Mock::new();
+        let recording = mock.add(handlers::record());
+        let client = clickhouse::Client::default().with_url(mock.url());
+
+        let (tx, rx) = mpsc::channel(100);
+        let handle = tokio::spawn(run_inserter(client, rx, None));
+
+        // Timestamp beyond DateTime's u32 range: serializing this row fails
+        // deterministically, poisoning its whole batch.
+        let mut poison = test_event(0);
+        poison.timestamp = chrono::DateTime::from_timestamp(5_000_000_000, 0).unwrap();
+        tx.send(poison).await.unwrap();
+
+        // Let the flush period elapse and the rejected batch burn its
+        // attempts (virtual time).
+        tokio::time::sleep(Duration::from_secs(30)).await;
+
+        // A later, healthy batch must go through unimpeded.
+        tx.send(test_event(1)).await.unwrap();
+        drop(tx);
+
+        timeout(Duration::from_secs(120), handle)
+            .await
+            .expect("inserter blocked on poison batch")
+            .expect("inserter task panicked");
+
+        let rows: Vec<EventRow> = recording.collect().await;
+        assert_eq!(rows.len(), 1, "only the healthy row should be inserted");
+        assert_eq!(rows[0].session_id, 1);
+    }
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -113,9 +113,21 @@ async fn main() {
     let clickhouse = Arc::new(ClickHouseClient::new(&config));
     info!("ClickHouse client initialized");
 
-    let (db, event_tx, inserter_handle) = Database::new(Arc::clone(&clickhouse), config.clone())
-        .await
-        .expect("Failed to initialize database");
+    let metrics_collector = if config.enable_monitoring {
+        let collector = MetricsCollector::new()
+            .expect("Failed to initialize metrics collector")
+            .start_system_metrics_updater();
+        info!("Metrics collector started");
+        Some(collector)
+    } else {
+        info!("Metrics collection disabled");
+        None
+    };
+
+    let (db, event_tx, inserter_handle) =
+        Database::new(Arc::clone(&clickhouse), config.clone(), metrics_collector.clone())
+            .await
+            .expect("Failed to initialize database");
     db.validate_schema().await.expect("Invalid database schema");
 
     if let Err(e) = referrer::sync_referrer_categories(
@@ -134,18 +146,11 @@ async fn main() {
 
     let db = Arc::new(db);
 
-    let metrics_collector = if config.enable_monitoring {
-        let collector = MetricsCollector::new()
-            .expect("Failed to initialize metrics collector")
-            .start_system_metrics_updater();
-        info!("Metrics collector started");
-        Some(collector)
-    } else {
-        info!("Metrics collection disabled");
-        None
-    };
-
-    let processor = Arc::new(EventProcessor::new(geoip_service, event_tx));
+    let processor = Arc::new(EventProcessor::new(
+        geoip_service,
+        event_tx,
+        metrics_collector.clone(),
+    ));
 
     let site_config_pool = Arc::new(
         PostgresPool::new(

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -129,22 +129,8 @@ async fn main() {
             .await
             .expect("Failed to initialize database");
 
-    // Pipeline pressure sampler. Holds only a weak channel handle so the
-    // ingest channel still closes when the processor drops at shutdown.
     if let Some(metrics) = metrics_collector.clone() {
-        let ingest_tx = event_tx.downgrade();
-        tokio::spawn(async move {
-            let mut tick = tokio::time::interval(Duration::from_secs(5));
-            loop {
-                tick.tick().await;
-                if let Some(tx) = ingest_tx.upgrade() {
-                    metrics.set_ingest_channel_depth(tx.max_capacity() - tx.capacity());
-                }
-                for (table, depth) in monitor::clickhouse_writer::writer_queue_depths() {
-                    metrics.set_writer_queue_depth(&table, depth);
-                }
-            }
-        });
+        spawn_pressure_sampler(metrics, event_tx.downgrade());
     }
     db.validate_schema().await.expect("Invalid database schema");
 
@@ -344,6 +330,26 @@ async fn shutdown_signal() {
             WATCHDOG_TIMEOUT
         );
         std::process::exit(1);
+    });
+}
+
+/// Samples pipeline buffer depths into metrics every few seconds. Holds only
+/// a weak channel handle so the ingest channel still closes at shutdown.
+fn spawn_pressure_sampler(
+    metrics: Arc<MetricsCollector>,
+    ingest_tx: tokio::sync::mpsc::WeakSender<processing::ProcessedEvent>,
+) {
+    tokio::spawn(async move {
+        let mut tick = tokio::time::interval(Duration::from_secs(5));
+        loop {
+            tick.tick().await;
+            if let Some(tx) = ingest_tx.upgrade() {
+                metrics.set_ingest_channel_depth(tx.max_capacity() - tx.capacity());
+            }
+            for (table, depth) in monitor::clickhouse_writer::writer_queue_depths() {
+                metrics.set_writer_queue_depth(&table, depth);
+            }
+        }
     });
 }
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -270,10 +270,9 @@ async fn main() {
             app.into_make_service_with_connect_info::<SocketAddr>(),
         )
         .with_graceful_shutdown(shutdown_signal()) => result.unwrap(),
-        // The inserter retries all insert errors, so it never exits on its
-        // own: completing here means it panicked. A backend acking events
-        // into a dead channel is worse than a restart - fail fast so the
-        // container restart policy brings up a working process.
+        // The inserter only returns once the ingest channel closes, so reaching
+        // here means it panicked. Exit non-zero rather than keep acking events
+        // into a dead channel; the container restart policy brings us back.
         result = &mut inserter_handle => {
             error!(?result, "Inserter task exited while the server is running, exiting");
             std::process::exit(1);
@@ -333,8 +332,8 @@ async fn shutdown_signal() {
     });
 }
 
-/// Samples pipeline buffer depths into metrics every few seconds. Holds only
-/// a weak channel handle so the ingest channel still closes at shutdown.
+/// Holds only a weak channel handle, so the ingest channel still closes when
+/// the processor drops at shutdown.
 fn spawn_pressure_sampler(
     metrics: Arc<MetricsCollector>,
     ingest_tx: tokio::sync::mpsc::WeakSender<processing::ProcessedEvent>,

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -128,6 +128,24 @@ async fn main() {
         Database::new(Arc::clone(&clickhouse), config.clone(), metrics_collector.clone())
             .await
             .expect("Failed to initialize database");
+
+    // Pipeline pressure sampler. Holds only a weak channel handle so the
+    // ingest channel still closes when the processor drops at shutdown.
+    if let Some(metrics) = metrics_collector.clone() {
+        let ingest_tx = event_tx.downgrade();
+        tokio::spawn(async move {
+            let mut tick = tokio::time::interval(Duration::from_secs(5));
+            loop {
+                tick.tick().await;
+                if let Some(tx) = ingest_tx.upgrade() {
+                    metrics.set_ingest_channel_depth(tx.max_capacity() - tx.capacity());
+                }
+                for (table, depth) in monitor::clickhouse_writer::writer_queue_depths() {
+                    metrics.set_writer_queue_depth(&table, depth);
+                }
+            }
+        });
+    }
     db.validate_schema().await.expect("Invalid database schema");
 
     if let Err(e) = referrer::sync_referrer_categories(

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -259,13 +259,22 @@ async fn main() {
 
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
     info!("Listening on {}", addr);
-    axum::serve(
-        listener,
-        app.into_make_service_with_connect_info::<SocketAddr>(),
-    )
-    .with_graceful_shutdown(shutdown_signal())
-    .await
-    .unwrap();
+    let mut inserter_handle = inserter_handle;
+    tokio::select! {
+        result = axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .with_graceful_shutdown(shutdown_signal()) => result.unwrap(),
+        // The inserter retries all insert errors, so it never exits on its
+        // own: completing here means it panicked. A backend acking events
+        // into a dead channel is worse than a restart - fail fast so the
+        // container restart policy brings up a working process.
+        result = &mut inserter_handle => {
+            error!(?result, "Inserter task exited while the server is running, exiting");
+            std::process::exit(1);
+        }
+    }
 
     info!("HTTP server stopped, draining buffered data");
     let drain = async {

--- a/backend/src/metrics/mod.rs
+++ b/backend/src/metrics/mod.rs
@@ -1,6 +1,6 @@
 use prometheus::{
-    Encoder, Gauge, Histogram, HistogramOpts, HistogramVec, IntCounter, IntCounterVec, Opts,
-    Registry, TextEncoder,
+    Encoder, Gauge, GaugeVec, Histogram, HistogramOpts, HistogramVec, IntCounter, IntCounterVec,
+    Opts, Registry, TextEncoder,
 };
 use std::sync::Arc;
 use std::time::Duration;
@@ -28,6 +28,13 @@ pub struct MetricsCollector {
     events_dropped_total: IntCounterVec,
     validation_duration: Histogram,
 
+    // Ingest pipeline pressure
+    ingest_channel_depth: Gauge,
+    inserter_batch_rows: Gauge,
+    inserter_retry_attempts: Gauge,
+    events_inserted_total: IntCounter,
+    writer_queue_depth: GaugeVec,
+
     // Cache lookup metrics
     cache_lookups_total: IntCounterVec,
 
@@ -47,7 +54,6 @@ pub struct MetricsCollector {
     monitor_probe_total: IntCounter,
     monitor_probe_latency_seconds: HistogramVec,
     monitor_active_probes: Gauge,
-    monitor_writer_queue_depth: Gauge,
 
     // System info
     system: Arc<RwLock<System>>,
@@ -107,6 +113,34 @@ impl MetricsCollector {
                 "Total number of accepted analytics events lost before reaching ClickHouse",
             ),
             &["reason"],
+        )?;
+
+        let ingest_channel_depth = Gauge::with_opts(Opts::new(
+            "analytics_ingest_channel_depth",
+            "Events waiting in the ingest channel",
+        ))?;
+
+        let inserter_batch_rows = Gauge::with_opts(Opts::new(
+            "analytics_inserter_batch_rows",
+            "Rows held in the inserter's current batch",
+        ))?;
+
+        let inserter_retry_attempts = Gauge::with_opts(Opts::new(
+            "analytics_inserter_retry_attempts",
+            "Consecutive failed insert attempts for the current batch (0 = healthy)",
+        ))?;
+
+        let events_inserted_total = IntCounter::with_opts(Opts::new(
+            "analytics_events_inserted_total",
+            "Total events confirmed inserted into ClickHouse",
+        ))?;
+
+        let writer_queue_depth = GaugeVec::new(
+            Opts::new(
+                "writer_queue_depth",
+                "Queued batches per ClickHouse channel writer",
+            ),
+            &["table"],
         )?;
 
         let validation_duration = Histogram::with_opts(HistogramOpts::new(
@@ -186,11 +220,6 @@ impl MetricsCollector {
             "Current number of concurrent monitor probes in flight",
         ))?;
 
-        let monitor_writer_queue_depth = Gauge::with_opts(Opts::new(
-            "monitor_writer_queue_depth",
-            "Current depth of the monitor writer channel queue",
-        ))?;
-
         registry.register(Box::new(system_cpu_usage.clone()))?;
         registry.register(Box::new(system_memory_usage.clone()))?;
         registry.register(Box::new(system_memory_total.clone()))?;
@@ -200,6 +229,11 @@ impl MetricsCollector {
         registry.register(Box::new(events_processing_duration.clone()))?;
         registry.register(Box::new(events_rejected_total.clone()))?;
         registry.register(Box::new(events_dropped_total.clone()))?;
+        registry.register(Box::new(ingest_channel_depth.clone()))?;
+        registry.register(Box::new(inserter_batch_rows.clone()))?;
+        registry.register(Box::new(inserter_retry_attempts.clone()))?;
+        registry.register(Box::new(events_inserted_total.clone()))?;
+        registry.register(Box::new(writer_queue_depth.clone()))?;
         registry.register(Box::new(validation_duration.clone()))?;
         registry.register(Box::new(cache_lookups_total.clone()))?;
         registry.register(Box::new(site_config_cache_healthy.clone()))?;
@@ -215,7 +249,6 @@ impl MetricsCollector {
         registry.register(Box::new(monitor_probe_total.clone()))?;
         registry.register(Box::new(monitor_probe_latency_seconds.clone()))?;
         registry.register(Box::new(monitor_active_probes.clone()))?;
-        registry.register(Box::new(monitor_writer_queue_depth.clone()))?;
 
         let mut system = System::new_all();
         system.refresh_all(); // This refresh is an attempt to ensure that when the metrics_updater starts it has accurate initial values
@@ -234,6 +267,11 @@ impl MetricsCollector {
             events_processing_duration,
             events_rejected_total,
             events_dropped_total,
+            ingest_channel_depth,
+            inserter_batch_rows,
+            inserter_retry_attempts,
+            events_inserted_total,
+            writer_queue_depth,
             validation_duration,
             cache_lookups_total,
             site_config_cache_healthy,
@@ -247,7 +285,6 @@ impl MetricsCollector {
             monitor_probe_total,
             monitor_probe_latency_seconds,
             monitor_active_probes,
-            monitor_writer_queue_depth,
             system: Arc::new(RwLock::new(system)),
             current_pid,
         };
@@ -390,8 +427,26 @@ impl MetricsCollector {
         self.monitor_active_probes.set(count as f64);
     }
 
-    pub fn set_monitor_writer_queue_depth(&self, depth: usize) {
-        self.monitor_writer_queue_depth.set(depth as f64);
+    pub fn set_ingest_channel_depth(&self, depth: usize) {
+        self.ingest_channel_depth.set(depth as f64);
+    }
+
+    pub fn set_inserter_batch_rows(&self, rows: usize) {
+        self.inserter_batch_rows.set(rows as f64);
+    }
+
+    pub fn set_inserter_retry_attempts(&self, attempts: u32) {
+        self.inserter_retry_attempts.set(f64::from(attempts));
+    }
+
+    pub fn increment_events_inserted(&self, count: u64) {
+        self.events_inserted_total.inc_by(count);
+    }
+
+    pub fn set_writer_queue_depth(&self, table: &str, depth: usize) {
+        self.writer_queue_depth
+            .with_label_values(&[table])
+            .set(depth as f64);
     }
 
     pub fn export_metrics(&self) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {

--- a/backend/src/metrics/mod.rs
+++ b/backend/src/metrics/mod.rs
@@ -25,6 +25,7 @@ pub struct MetricsCollector {
 
     // Event rejection and validation metrics
     events_rejected_total: IntCounterVec,
+    events_dropped_total: IntCounterVec,
     validation_duration: Histogram,
 
     // Cache lookup metrics
@@ -96,6 +97,14 @@ impl MetricsCollector {
             Opts::new(
                 "analytics_events_rejected_total",
                 "Total number of analytics events rejected by validation",
+            ),
+            &["reason"],
+        )?;
+
+        let events_dropped_total = IntCounterVec::new(
+            Opts::new(
+                "analytics_events_dropped_total",
+                "Total number of accepted analytics events lost before reaching ClickHouse",
             ),
             &["reason"],
         )?;
@@ -190,6 +199,7 @@ impl MetricsCollector {
         registry.register(Box::new(events_processed_total.clone()))?;
         registry.register(Box::new(events_processing_duration.clone()))?;
         registry.register(Box::new(events_rejected_total.clone()))?;
+        registry.register(Box::new(events_dropped_total.clone()))?;
         registry.register(Box::new(validation_duration.clone()))?;
         registry.register(Box::new(cache_lookups_total.clone()))?;
         registry.register(Box::new(site_config_cache_healthy.clone()))?;
@@ -223,6 +233,7 @@ impl MetricsCollector {
             events_processed_total,
             events_processing_duration,
             events_rejected_total,
+            events_dropped_total,
             validation_duration,
             cache_lookups_total,
             site_config_cache_healthy,
@@ -307,6 +318,14 @@ impl MetricsCollector {
         self.events_rejected_total
             .with_label_values(&[reason])
             .inc();
+    }
+
+    /// Counts accepted (200-acked) events that were lost before reaching
+    /// ClickHouse - the alertable "silent loss" signal from issue #19.
+    pub fn increment_events_dropped(&self, reason: &str, count: u64) {
+        self.events_dropped_total
+            .with_label_values(&[reason])
+            .inc_by(count);
     }
 
     pub fn record_validation_duration(&self, duration: Duration) {

--- a/backend/src/metrics/mod.rs
+++ b/backend/src/metrics/mod.rs
@@ -357,8 +357,6 @@ impl MetricsCollector {
             .inc();
     }
 
-    /// Counts accepted (200-acked) events that were lost before reaching
-    /// ClickHouse - the alertable "silent loss" signal from issue #19.
     pub fn increment_events_dropped(&self, reason: &str, count: u64) {
         self.events_dropped_total
             .with_label_values(&[reason])

--- a/backend/src/monitor/clickhouse_writer.rs
+++ b/backend/src/monitor/clickhouse_writer.rs
@@ -46,7 +46,6 @@ fn register_writer<R: Send + 'static>(
     });
 }
 
-/// Current queue depth of every live writer, for pipeline pressure metrics.
 pub fn writer_queue_depths() -> Vec<(String, usize)> {
     FLUSH_REGISTRY
         .lock()

--- a/backend/src/monitor/clickhouse_writer.rs
+++ b/backend/src/monitor/clickhouse_writer.rs
@@ -20,19 +20,40 @@ static FLUSH_REGISTRY: Mutex<Vec<FlushHandle>> = Mutex::new(Vec::new());
 struct FlushHandle {
     table: String,
     request: Box<dyn Fn() -> Option<oneshot::Receiver<()>> + Send + Sync>,
+    depth: Box<dyn Fn() -> Option<usize> + Send + Sync>,
 }
 
-fn register_for_shutdown_flush<R: Send + 'static>(table: &str, sender: mpsc::WeakSender<Msg<R>>) {
+fn register_writer<R: Send + 'static>(
+    table: &str,
+    sender: mpsc::WeakSender<Msg<R>>,
+    capacity: usize,
+) {
+    let depth_sender = sender.clone();
     let request = Box::new(move || {
         let sender = sender.upgrade()?;
         let (ack_tx, ack_rx) = oneshot::channel();
         sender.try_send(Msg::Flush(ack_tx)).ok()?;
         Some(ack_rx)
     });
+    let depth = Box::new(move || {
+        let sender = depth_sender.upgrade()?;
+        Some(capacity - sender.capacity())
+    });
     FLUSH_REGISTRY.lock().unwrap().push(FlushHandle {
         table: table.to_string(),
         request,
+        depth,
     });
+}
+
+/// Current queue depth of every live writer, for pipeline pressure metrics.
+pub fn writer_queue_depths() -> Vec<(String, usize)> {
+    FLUSH_REGISTRY
+        .lock()
+        .unwrap()
+        .iter()
+        .filter_map(|handle| (handle.depth)().map(|depth| (handle.table.clone(), depth)))
+        .collect()
 }
 
 /// Sends a flush fence into every live writer, then waits for the acks: once
@@ -59,7 +80,6 @@ pub async fn flush_all_writers() {
 /// to a background worker for insertion
 pub struct ClickhouseChannelWriter<R: clickhouse::Row + Serialize + Send + Sync + 'static> {
     sender: mpsc::Sender<Msg<R>>,
-    capacity: usize,
 }
 
 impl<R: clickhouse::Row + Serialize + Send + Sync + 'static> ClickhouseChannelWriter<R> {
@@ -70,11 +90,8 @@ impl<R: clickhouse::Row + Serialize + Send + Sync + 'static> ClickhouseChannelWr
         batch_size: usize,
     ) -> Result<Arc<Self>> {
         let (sender, receiver) = mpsc::channel(channel_capacity);
-        register_for_shutdown_flush(table, sender.downgrade());
-        let writer = Arc::new(Self {
-            sender,
-            capacity: channel_capacity,
-        });
+        register_writer(table, sender.downgrade(), channel_capacity);
+        let writer = Arc::new(Self { sender });
 
         Self::spawn_worker(clickhouse, table.to_string(), batch_size, receiver);
 
@@ -85,10 +102,6 @@ impl<R: clickhouse::Row + Serialize + Send + Sync + 'static> ClickhouseChannelWr
         self.sender
             .try_send(Msg::Rows(rows))
             .map_err(|e| anyhow::anyhow!("enqueue_failed: {e}"))
-    }
-
-    pub fn queue_depth(&self) -> usize {
-        self.capacity - self.sender.capacity()
     }
 
     fn spawn_worker(

--- a/backend/src/monitor/runner.rs
+++ b/backend/src/monitor/runner.rs
@@ -517,10 +517,6 @@ async fn run_loop<S: RunnerStrategy>(
             if let Err(err) = writer.enqueue_rows(collected) {
                 warn!(runner = config.name, error = ?err, "Failed to enqueue monitor rows");
             }
-
-            if let Some(ref m) = metrics {
-                m.set_monitor_writer_queue_depth(writer.queue_depth());
-            }
         }
     }
 }

--- a/backend/src/processing/mod.rs
+++ b/backend/src/processing/mod.rs
@@ -1,7 +1,10 @@
 use anyhow::Result;
-use tokio::sync::mpsc;
-use tracing::{error, debug};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use tokio::sync::mpsc::{self, error::TrySendError};
+use tracing::{error, debug, warn};
 use crate::analytics::{AnalyticsEvent, VisitorAttrs};
+use crate::metrics::MetricsCollector;
 use crate::geoip::GeoIpService;
 use crate::visitor;
 use crate::bot_detection;
@@ -71,16 +74,25 @@ pub struct ProcessedEvent {
     pub page_duration_seconds: u32,
 }
 
+/// Sampling counter so a sustained channel overflow logs once per 1000 drops
+/// instead of flooding: the dropped_total metric carries the exact count.
+static DROP_LOG_SAMPLE: AtomicU64 = AtomicU64::new(0);
+
 /// Event processor that handles real-time processing
 pub struct EventProcessor {
     event_tx: mpsc::Sender<ProcessedEvent>,
     geoip_service: GeoIpService,
+    metrics: Option<Arc<MetricsCollector>>,
 }
 
 impl EventProcessor {
     /// `event_tx` is the ingest channel consumed by the ClickHouse inserter task.
-    pub fn new(geoip_service: GeoIpService, event_tx: mpsc::Sender<ProcessedEvent>) -> Self {
-        Self { event_tx, geoip_service }
+    pub fn new(
+        geoip_service: GeoIpService,
+        event_tx: mpsc::Sender<ProcessedEvent>,
+        metrics: Option<Arc<MetricsCollector>>,
+    ) -> Self {
+        Self { event_tx, geoip_service, metrics }
     }
 
     pub async fn process_event(&self, event: AnalyticsEvent) -> Result<()> {
@@ -185,8 +197,21 @@ impl EventProcessor {
         debug!("Site ID: {}", processed.site_id);
         debug!("Session ID: {}", processed.session_id);
 
-        if let Err(e) = self.event_tx.send(processed).await {
-            error!("Failed to send processed event: {}", e);
+        // Drop instead of blocking when the ingest buffer is exhausted (e.g.
+        // a ClickHouse outage longer than the channel's ~2-day headroom):
+        // ingestion must stay responsive, and every drop is counted.
+        if let Err(e) = self.event_tx.try_send(processed) {
+            let reason = match e {
+                TrySendError::Full(_) => "channel_full",
+                TrySendError::Closed(_) => "channel_closed",
+            };
+            if let Some(metrics) = &self.metrics {
+                metrics.increment_events_dropped(reason, 1);
+            }
+            let dropped = DROP_LOG_SAMPLE.fetch_add(1, Ordering::Relaxed);
+            if dropped % 1000 == 0 {
+                warn!(reason, sampled_drop_number = dropped + 1, "Ingest channel unavailable, dropping event");
+            }
         }
 
         debug!("Processed event finished!");

--- a/backend/src/processing/mod.rs
+++ b/backend/src/processing/mod.rs
@@ -74,8 +74,8 @@ pub struct ProcessedEvent {
     pub page_duration_seconds: u32,
 }
 
-/// Sampling counter so a sustained channel overflow logs once per 1000 drops
-/// instead of flooding: the dropped_total metric carries the exact count.
+/// Logs one in every 1000 drops so a sustained overflow cannot flood the log;
+/// the dropped_total metric carries the exact count.
 static DROP_LOG_SAMPLE: AtomicU64 = AtomicU64::new(0);
 
 /// Event processor that handles real-time processing
@@ -197,9 +197,8 @@ impl EventProcessor {
         debug!("Site ID: {}", processed.site_id);
         debug!("Session ID: {}", processed.session_id);
 
-        // Drop instead of blocking when the ingest buffer is exhausted (e.g.
-        // a ClickHouse outage longer than the channel's ~2-day headroom):
-        // ingestion must stay responsive, and every drop is counted.
+        // try_send, not send: ingestion stays responsive if the buffer fills,
+        // at the cost of dropping the newest events (counted, never silent).
         if let Err(e) = self.event_tx.try_send(processed) {
             let reason = match e {
                 TrySendError::Full(_) => "channel_full",

--- a/migrations/37_events_insert_dedup_window.sql
+++ b/migrations/37_events_insert_dedup_window.sql
@@ -1,0 +1,7 @@
+-- The backend retries failed insert batches (at-least-once delivery), so an
+-- insert whose acknowledgement timed out can land twice. Remember the last 100
+-- insert blocks (compared by insert_deduplication_token, which the backend
+-- sends per batch) so retried batches are silently ignored instead of
+-- duplicating events. Metadata-only change; no data rewrite.
+ALTER TABLE analytics.events
+    MODIFY SETTING non_replicated_deduplication_window = 100;


### PR DESCRIPTION
The first failed insert used to kill the inserter permanently (fired in prod Jul 19 during new release), silently dropping all events afterward. The inserter now owns its batch and retries by error class: transient failures retry forever with capped backoff while the 100k channel buffers upstream, recognized rejections drop the poison batch after 3 attempts so it can't block the pipeline. Retried batches carry a stable insert_deduplication_token (migration 37 enables the table's dedup window) making retries idempotent, every loss edge is counted in analytics_events_dropped_total{reason}, and the process fails fast if the inserter ever dies so Docker restarts a healthy instance.

Closes betterlytics/betterlytics-internal#19

Reviewer notes: migration 37 is metadata-only (instant, ships to self-host via the normal path). Also adds pipeline pressure metrics (channel depth, batch rows, retry attempts, inserted rate, per-writer queue depths); the old monitor_writer_queue_depth gauge is replaced by writer_queue_depth{table}, so update any dashboard referencing it. Verified live: ClickHouse paused mid-traffic, retries with escalating backoff, exactly 15/15 events after recovery with zero duplicates (the same scenario measured 5x duplication before the dedup commit). Mock-server tests cover drain, retry-forever, transient recovery, and poison isolation.
