### PR TITLE
Polished country flag icon rendering

### DIFF
--- a/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/errors/detail/[fingerprint]/ErrorOccurrencePanel.tsx
+++ b/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/errors/detail/[fingerprint]/ErrorOccurrencePanel.tsx
@@ -138,7 +138,7 @@ function OccurrenceContext({ occurrence }: { occurrence: ErrorOccurrence }) {
         <FlagIcon
           countryCode={occurrence.country_code as FlagIconProps['countryCode']}
           countryName={occurrence.country_code}
-          className='h-6 w-6'
+          className='h-4!'
         />
       ),
     },

--- a/dashboard/src/components/filters/CountryFlagLabel.tsx
+++ b/dashboard/src/components/filters/CountryFlagLabel.tsx
@@ -15,9 +15,13 @@ export function CountryFlagLabel({ countryCode, className, children }: CountryFl
   const code = countryCode.toUpperCase();
 
   return (
-    <span className={cn('inline-flex items-center gap-1.5', className)}>
+    <span className={cn('inline-flex items-center gap-1', className)}>
       {hasFlag(code) && (
-        <FlagIcon countryCode={code as FlagIconProps['countryCode']} countryName={getCountryName(countryCode, locale)} />
+        <FlagIcon
+          countryCode={code as FlagIconProps['countryCode']}
+          countryName={getCountryName(countryCode, locale)}
+          className=''
+        />
       )}
       {children}
     </span>

--- a/dashboard/src/components/filters/CountryFlagLabel.tsx
+++ b/dashboard/src/components/filters/CountryFlagLabel.tsx
@@ -15,12 +15,11 @@ export function CountryFlagLabel({ countryCode, className, children }: CountryFl
   const code = countryCode.toUpperCase();
 
   return (
-    <span className={cn('inline-flex items-center gap-1', className)}>
+    <span className={cn('inline-flex items-center gap-1.5', className)}>
       {hasFlag(code) && (
         <FlagIcon
           countryCode={code as FlagIconProps['countryCode']}
           countryName={getCountryName(countryCode, locale)}
-          className=''
         />
       )}
       {children}

--- a/dashboard/src/components/filters/CountryFlagLabel.tsx
+++ b/dashboard/src/components/filters/CountryFlagLabel.tsx
@@ -17,10 +17,7 @@ export function CountryFlagLabel({ countryCode, className, children }: CountryFl
   return (
     <span className={cn('inline-flex items-center gap-1.5', className)}>
       {hasFlag(code) && (
-        <FlagIcon
-          countryCode={code as FlagIconProps['countryCode']}
-          countryName={getCountryName(countryCode, locale)}
-        />
+        <FlagIcon countryCode={code as FlagIconProps['countryCode']} countryName={getCountryName(countryCode, locale)} />
       )}
       {children}
     </span>

--- a/dashboard/src/components/icons/FlagIcon.tsx
+++ b/dashboard/src/components/icons/FlagIcon.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import * as Flags from 'country-flag-icons/react/3x2';
 import { HelpCircle } from 'lucide-react';
+import { cn } from '@/lib/utils';
 
 export type FlagIconProps = {
   countryCode: keyof typeof Flags;
   countryName: string;
 } & Flags.ElementAttributes<Flags.HTMLSVGElement>;
 
-function FlagIconComponent({ countryCode, countryName, ...props }: FlagIconProps) {
+function FlagIconComponent({ countryCode, countryName, className, ...props }: FlagIconProps) {
   const FlagComponent = Flags[countryCode];
 
   if (!FlagComponent) {
@@ -29,16 +30,15 @@ function FlagIconComponent({ countryCode, countryName, ...props }: FlagIconProps
     <span title={countryName || 'Unknown'} className='relative flex items-center justify-center'>
       <FlagComponent
         {...props}
-        className='shadow-foreground/50 dark:shadow-background/50 inline-block !h-[1.15em] rounded-xs shadow-sm dark:rounded-none'
+        className={cn('inline-block h-4 rounded-xs dark:rounded-none', className)}
         style={{
           imageRendering: 'auto',
           shapeRendering: 'geometricPrecision',
-          height: '1.15em',
           width: 'auto',
           display: 'inline-block',
         }}
       />
-      <div className='absolute h-full w-full rounded-xs border border-x-gray-900/40 border-y-gray-900/30 bg-gradient-to-b from-white/15 to-black/10 bg-origin-padding dark:rounded-none'></div>
+      <div className='absolute h-full w-full rounded-xs border border-x-gray-900/30 border-t-gray-900/25 border-b-gray-900/50 bg-linear-to-b from-white/5 via-white/15 via-20% to-black/10 bg-origin-padding dark:rounded-none dark:border-x-white/10 dark:border-t-gray-900/50 dark:border-b-black/15 dark:via-white/10'></div>
     </span>
   );
 }

--- a/dashboard/src/components/icons/FlagIcon.tsx
+++ b/dashboard/src/components/icons/FlagIcon.tsx
@@ -30,10 +30,11 @@ function FlagIconComponent({ countryCode, countryName, className, ...props }: Fl
     <span title={countryName || 'Unknown'} className='relative flex items-center justify-center'>
       <FlagComponent
         {...props}
-        className={cn('inline-block h-4 rounded-xs dark:rounded-none', className)}
+        className={cn('inline-block rounded-xs dark:rounded-none', className)}
         style={{
           imageRendering: 'auto',
           shapeRendering: 'geometricPrecision',
+          height: '1.1em',
           width: 'auto',
           display: 'inline-block',
         }}


### PR DESCRIPTION
FlagIcon no longer bakes in a drop shadow (too prominent in light mode). Its edge
definition now comes from a single overlay with per-side border tones, including
dark mode variants the old border lacked, plus a softer gloss gradient. The height
default switches from font-relative (!h-[1.15em]) to a plain h-4, and the component
now merges a caller-supplied className instead of silently discarding it, so call
sites can size flags themselves.

Reviewer notes:
- The className merge revives ErrorOccurrencePanel's previously inert h-6 w-6, so
  the error detail flag now renders 24px like the browser/OS/device icons next to it.
- With the height default no longer important, the active filter chips inherit
  FilterDescription's [&_svg]:size-3 (12px flag, was 13.8px). Everywhere else
  renders 16px, close to the old 1.15em at typical font sizes.

Before:
<img width="176" height="39" alt="image" src="https://github.com/user-attachments/assets/93c840c6-91cb-45c7-a0b6-2985ae73ff1e" />

After:
<img width="174" height="39" alt="image" src="https://github.com/user-attachments/assets/93441332-3cb5-4bb8-be17-1ccca9c12e6d" />


Before:
<img width="739" height="435" alt="image" src="https://github.com/user-attachments/assets/e01e1568-2383-4442-affe-8955e187da76" />

After:
<img width="740" height="431" alt="image" src="https://github.com/user-attachments/assets/187cee18-ece6-4875-86f6-5bf410a674d2" />

Dark mode:
<img width="778" height="474" alt="image" src="https://github.com/user-attachments/assets/8848f730-2854-4b9c-ad72-3af1e1e2c164" />

<img width="176" height="40" alt="image" src="https://github.com/user-attachments/assets/8a3403cf-8b33-4e3a-9df3-fb9f8df1c762" />

