### PR TITLE
Made /dashboard redirect to the dashboards overview when the user has multiple dashboards

### DIFF
--- a/dashboard/src/app/(app)/(protected)/dashboard/page.tsx
+++ b/dashboard/src/app/(app)/(protected)/dashboard/page.tsx
@@ -1,8 +1,8 @@
 import { redirect } from 'next/navigation';
-import { getFirstUserDashboardAction } from '@/app/actions/index.actions';
+import { getSoleUserDashboardAction } from '@/app/actions/index.actions';
 
 export default async function DashboardPage() {
-  const dashboard = await getFirstUserDashboardAction();
+  const dashboard = await getSoleUserDashboardAction();
 
   if (!dashboard.success || dashboard.data === null) {
     redirect(`/dashboards`);

--- a/dashboard/src/app/actions/dashboard/dashboard.action.ts
+++ b/dashboard/src/app/actions/dashboard/dashboard.action.ts
@@ -5,6 +5,7 @@ import { withUserAuth, withDashboardAuthContext, withDashboardMutationAuthContex
 import {
   createNewDashboard,
   getAllUserDashboards,
+  getSoleUserDashboard,
   updateDashboardDomain,
 } from '@/services/dashboard/dashboard.service';
 import {
@@ -36,6 +37,10 @@ export const deleteDashboardAction = withDashboardMutationAuthContext(
 
 export const getFirstUserDashboardAction = withUserAuth(async (user: User): Promise<Dashboard | null> => {
   return findFirstUserDashboard(user.id);
+});
+
+export const getSoleUserDashboardAction = withUserAuth(async (user: User): Promise<Dashboard | null> => {
+  return getSoleUserDashboard(user.id);
 });
 
 export const getAllUserDashboardsAction = withUserAuth(async (user: User): Promise<DashboardWithMemberCount[]> => {

--- a/dashboard/src/repositories/postgres/dashboard.repository.ts
+++ b/dashboard/src/repositories/postgres/dashboard.repository.ts
@@ -103,8 +103,8 @@ export async function findSoleUserDashboard(userId: string): Promise<Dashboard |
     }
 
     return DashboardSchema.parse(prismaUserDashboards[0].dashboard);
-  } catch {
-    console.error("Error while finding user's sole dashboard");
+  } catch (error) {
+    console.error("Error while finding user's sole dashboard:", error);
     throw new Error('Failed to find dashboard');
   }
 }

--- a/dashboard/src/repositories/postgres/dashboard.repository.ts
+++ b/dashboard/src/repositories/postgres/dashboard.repository.ts
@@ -85,6 +85,30 @@ export async function findFirstUserDashboard(userId: string): Promise<Dashboard 
   }
 }
 
+export async function findSoleUserDashboard(userId: string): Promise<Dashboard | null> {
+  try {
+    const prismaUserDashboards = await prisma.userDashboard.findMany({
+      where: {
+        userId,
+        dashboard: { deletedAt: null },
+      },
+      include: {
+        dashboard: true,
+      },
+      take: 2,
+    });
+
+    if (prismaUserDashboards.length !== 1) {
+      return null;
+    }
+
+    return DashboardSchema.parse(prismaUserDashboards[0].dashboard);
+  } catch {
+    console.error("Error while finding user's sole dashboard");
+    throw new Error('Failed to find dashboard');
+  }
+}
+
 export async function findAllUserDashboards(userId: string): Promise<DashboardWithMemberCount[]> {
   try {
     const prismaUserDashboards = await prisma.userDashboard.findMany({

--- a/dashboard/src/services/dashboard/dashboard.service.ts
+++ b/dashboard/src/services/dashboard/dashboard.service.ts
@@ -5,6 +5,7 @@ import {
   createDashboard,
   findAllUserDashboards,
   findOwnedDashboards,
+  findSoleUserDashboard,
   updateDashboardDomain as updateDashboardDomainRepo,
 } from '@/repositories/postgres/dashboard.repository';
 import { generateSiteId } from '@/lib/site-id-generator';
@@ -20,6 +21,10 @@ export async function createNewDashboard(domain: string, userId: string): Promis
 
 export async function getAllUserDashboards(userId: string): Promise<DashboardWithMemberCount[]> {
   return findAllUserDashboards(userId);
+}
+
+export async function getSoleUserDashboard(userId: string): Promise<Dashboard | null> {
+  return findSoleUserDashboard(userId);
 }
 
 export async function getOwnedDashboards(userId: string): Promise<Dashboard[]> {


### PR DESCRIPTION
`/dashboard` now enters a dashboard directly only when the user has exactly one. With zero or several it redirects to `/dashboards` so the user picks, instead of landing in an arbitrary "first" dashboard (the old lookup was an unordered `findFirst`).

Closes betterlytics/betterlytics-internal#134

**Reviewer notes:** the new `findSoleUserDashboard` fetches with `take: 2` and returns the dashboard only when exactly one row comes back, so the zero and many cases share the `/dashboards` branch. Onboarding still uses `getFirstUserDashboardAction`, unchanged. Docs links keep pointing at `/dashboard` as the entry point.
