### PR TITLE
Removed user settings from the session, cutting a database query from every auth check

### DIFF
--- a/dashboard/src/app/(app)/(protected)/layout.tsx
+++ b/dashboard/src/app/(app)/(protected)/layout.tsx
@@ -6,7 +6,7 @@ import { isUserInvitedDashboardMemberAction } from '@/app/actions/index.actions'
 import { env } from '@/lib/env';
 import { DevWidget } from '@/components/dev/DevWidget';
 import { getUserSubscription } from '@/repositories/postgres/subscription.repository';
-import { getUserSettings } from '@/services/account/userSettings.service';
+import { getCachedUserSettings } from '@/services/account/userSettings.service';
 import { UserSettingsProvider } from '@/contexts/UserSettingsProvider';
 import { PublicEnvironmentVariablesProvider } from '@/contexts/PublicEnvironmentVariablesContextProvider';
 import { BillingFlowProvider } from '@/contexts/BillingFlowProvider';
@@ -22,7 +22,7 @@ export default async function ProtectedLayout({ children }: { children: React.Re
     }
   }
 
-  const initialSettings = await getUserSettings(session.user.id);
+  const initialSettings = await getCachedUserSettings(session.user.id);
 
   const publicEnvironmentVariables = getPublicEnvironmentVariables();
 

--- a/dashboard/src/app/(app)/(protected)/layout.tsx
+++ b/dashboard/src/app/(app)/(protected)/layout.tsx
@@ -6,6 +6,7 @@ import { isUserInvitedDashboardMemberAction } from '@/app/actions/index.actions'
 import { env } from '@/lib/env';
 import { DevWidget } from '@/components/dev/DevWidget';
 import { getUserSubscription } from '@/repositories/postgres/subscription.repository';
+import { getUserSettings } from '@/services/account/userSettings.service';
 import { UserSettingsProvider } from '@/contexts/UserSettingsProvider';
 import { PublicEnvironmentVariablesProvider } from '@/contexts/PublicEnvironmentVariablesContextProvider';
 import { BillingFlowProvider } from '@/contexts/BillingFlowProvider';
@@ -21,10 +22,7 @@ export default async function ProtectedLayout({ children }: { children: React.Re
     }
   }
 
-  const initialSettings = session.user.settings;
-  if (!initialSettings) {
-    throw new Error('Failed to load user settings');
-  }
+  const initialSettings = await getUserSettings(session.user.id);
 
   const publicEnvironmentVariables = getPublicEnvironmentVariables();
 

--- a/dashboard/src/app/(app)/[locale]/share/[dashboardId]/layout.tsx
+++ b/dashboard/src/app/(app)/[locale]/share/[dashboardId]/layout.tsx
@@ -11,6 +11,7 @@ import { type SupportedLanguages } from '@/constants/i18n';
 import { buildSEOConfig, generateSEO, SEO_CONFIGS } from '@/lib/seo';
 import TimezoneCookieInitializer from '@/app/(app)/(protected)/TimezoneCookieInitializer';
 import { UserSettingsProvider } from '@/contexts/UserSettingsProvider';
+import { getUserSettings } from '@/services/account/userSettings.service';
 import { getAuthSession } from '@/auth/auth-actions';
 
 export async function generateMetadata({
@@ -55,6 +56,7 @@ export default async function PublicDashboardLayout({ params, children }: Public
     getDashboardSettingsAction(dashboardId),
     getAuthSession(),
   ]);
+  const userSettings = session?.user ? await getUserSettings(session.user.id) : null;
 
   const shell = (
     <DashboardLayoutShell
@@ -73,8 +75,8 @@ export default async function PublicDashboardLayout({ params, children }: Public
       <DashboardAuthProvider isDemo={true} role='viewer'>
         <DashboardProvider initialSettings={initialSettings}>
           <BillingFlowProvider>
-            {session?.user.settings ? (
-              <UserSettingsProvider initialSettings={session.user.settings}>{shell}</UserSettingsProvider>
+            {userSettings ? (
+              <UserSettingsProvider initialSettings={userSettings}>{shell}</UserSettingsProvider>
             ) : (
               shell
             )}

--- a/dashboard/src/app/(app)/[locale]/share/[dashboardId]/layout.tsx
+++ b/dashboard/src/app/(app)/[locale]/share/[dashboardId]/layout.tsx
@@ -11,7 +11,7 @@ import { type SupportedLanguages } from '@/constants/i18n';
 import { buildSEOConfig, generateSEO, SEO_CONFIGS } from '@/lib/seo';
 import TimezoneCookieInitializer from '@/app/(app)/(protected)/TimezoneCookieInitializer';
 import { UserSettingsProvider } from '@/contexts/UserSettingsProvider';
-import { getUserSettings } from '@/services/account/userSettings.service';
+import { getCachedUserSettings } from '@/services/account/userSettings.service';
 import { getAuthSession } from '@/auth/auth-actions';
 
 export async function generateMetadata({
@@ -56,7 +56,7 @@ export default async function PublicDashboardLayout({ params, children }: Public
     getDashboardSettingsAction(dashboardId),
     getAuthSession(),
   ]);
-  const userSettings = session?.user ? await getUserSettings(session.user.id) : null;
+  const userSettings = session?.user ? await getCachedUserSettings(session.user.id) : null;
 
   const shell = (
     <DashboardLayoutShell

--- a/dashboard/src/i18n/request.ts
+++ b/dashboard/src/i18n/request.ts
@@ -4,9 +4,25 @@ import { hasLocale } from 'next-intl';
 import { LOCALE_COOKIE_NAME } from '@/constants/cookies';
 import { cookies } from 'next/headers';
 import { routing } from '@/i18n/routing';
+import { getCachedSession } from '@/auth/api-auth';
+import { getCachedUserSettings } from '@/services/account/userSettings.service';
 
 export default getRequestConfig(async ({ requestLocale }) => {
   let requested = await requestLocale;
+
+  // Routes without a [locale] segment (the signed-in app). The saved user setting is
+  // authoritative so a language change follows the user across devices; the cookie
+  // covers signed-out visitors.
+  if (!requested) {
+    try {
+      const session = await getCachedSession();
+      if (session?.user) {
+        requested = (await getCachedUserSettings(session.user.id)).language;
+      }
+    } catch {
+      // Session may not be resolvable in all contexts (e.g., during build)
+    }
+  }
 
   if (!requested) {
     try {

--- a/dashboard/src/lib/auth.ts
+++ b/dashboard/src/lib/auth.ts
@@ -76,6 +76,22 @@ export const authOptions: NextAuthOptions = {
     },
   },
   events: {
+    // Applies the user's saved language when signing in on a browser that doesn't have it yet.
+    // Skipped for new users: their settings are defaults, and overwriting the locale cookie here
+    // would flip the language they were browsing in right before onboarding.
+    async signIn({ user, isNewUser }) {
+      if (isNewUser) return;
+
+      try {
+        const settings = await getUserSettings(user.id);
+        if (settings.language) {
+          await setLocaleCookie(settings.language);
+        }
+      } catch (error) {
+        console.error('Failed to sync locale cookie on sign-in:', error);
+      }
+    },
+
     async createUser({ user }) {
       try {
         await createStarterSubscriptionForUser(user.id);
@@ -136,8 +152,6 @@ export const authOptions: NextAuthOptions = {
     async session({ session, user }) {
       if (!session.user || !user) return session;
 
-      const settings = await getUserSettings(user.id);
-
       session.user.id = user.id;
       session.user.name = user.name;
       session.user.email = user.email;
@@ -151,11 +165,6 @@ export const authOptions: NextAuthOptions = {
       session.user.changelogVersionSeen = user.changelogVersionSeen;
       session.user.createdAt = user.createdAt;
       session.user.githubStarPromptState = user.githubStarPromptState;
-      session.user.settings = settings;
-
-      if (session.user.settings?.language) {
-        await setLocaleCookie(session.user.settings.language);
-      }
 
       return session;
     },

--- a/dashboard/src/services/account/userSettings.service.ts
+++ b/dashboard/src/services/account/userSettings.service.ts
@@ -1,5 +1,6 @@
 'server-only';
 
+import { cache } from 'react';
 import { UpdateUserData } from '@/entities/auth/user.entities';
 import { UserSettings, UserSettingsUpdate, DEFAULT_USER_SETTINGS } from '@/entities/account/userSettings.entities';
 import * as UserSettingsRepository from '@/repositories/postgres/userSettings.repository';
@@ -24,6 +25,8 @@ export async function getUserSettings(userId: string): Promise<UserSettings> {
     throw new Error('Failed to get user settings');
   }
 }
+
+export const getCachedUserSettings = cache(getUserSettings);
 
 export async function createDefaultUserSettings(userId: string): Promise<UserSettings> {
   try {

--- a/dashboard/src/types/next-auth.d.ts
+++ b/dashboard/src/types/next-auth.d.ts
@@ -1,7 +1,6 @@
 import 'next-auth';
 import 'next-auth/jwt';
 import type { GithubStarPromptState } from '@prisma/client';
-import type { UserSettings } from '@/entities/account/userSettings.entities';
 import type { AdapterUser } from 'next-auth/adapters';
 
 declare module 'next-auth' {
@@ -15,7 +14,6 @@ declare module 'next-auth' {
     totpEnabled: boolean;
     hasPassword?: boolean;
     onboardingCompletedAt?: Date | null;
-    settings?: UserSettings;
     termsAcceptedAt?: Date | null;
     termsAcceptedVersion?: number | null;
     changelogVersionSeen?: string | null;
@@ -38,8 +36,6 @@ declare module 'next-auth/jwt' {
     totpEnabled: boolean;
     hasPassword?: boolean;
     onboardingCompletedAt?: Date | null;
-    settings?: UserSettings;
-    userLastFetched?: number;
     termsAcceptedAt?: Date | null;
     termsAcceptedVersion?: number | null;
     changelogVersionSeen?: string | null;


### PR DESCRIPTION
The session callback fetched user settings on every session resolution (every server action, tRPC request, and session poll) though only two layouts used them. Sessions now carry identity only: those layouts fetch settings directly, and the dead settings/userLastFetched JWT fields are gone.

Language keeps working as before, by a cheaper route. It stayed in sync across devices because the session callback rewrote the NEXT_LOCALE cookie wherever cookie writes were allowed; with that gone, i18n/request.ts resolves the language from the saved setting for signed-in rendering (request-memoized and shared with the layout fetch, so a page render still pays one settings query), with the cookie as the signed-out fallback, so a language change still reaches the user's other devices. The cookie write itself moved to the signIn event.

Closes betterlytics/betterlytics-internal#79

**Reviewer notes:** risk sits in i18n/request.ts. Static pages take their locale from the URL segment, so the new session lookup never runs during prerender; building this branch and its parent gives identical static/dynamic route classification. The signIn event skips new users on purpose: onboarding renders from the URL segment rather than the DB path and saves the locale it rendered in, so syncing the cookie from the freshly created default-language row would drop the user out of the language they signed up in.
