### PR TITLE
Fixed the top loading bar running forever after opening external links in a new tab

### DIFF
--- a/dashboard/src/components/ExternalLink.tsx
+++ b/dashboard/src/components/ExternalLink.tsx
@@ -9,14 +9,12 @@ function willUnloadPage(e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) {
   if (e.defaultPrevented || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return false;
   const target = e.currentTarget.getAttribute('target');
   if (target && target !== '_self') return false;
-  // Only http(s) and relative URLs navigate the page; other schemes (mailto:, tel:, otpauth:, ...) don't unload it
-  const protocol = /^([a-z][a-z0-9+.-]*):/i.exec(e.currentTarget.getAttribute('href') ?? '')?.[1];
-  return !protocol || /^https?$/i.test(protocol);
+  return !/^(mailto:|tel:|otpauth:)/i.test(e.currentTarget.getAttribute('href') ?? '');
 }
 
 /**
  * Wrapper for the anchor HTML-element (<a>), that triggers the TopLoader's loading animation before navigating.
- * Skips the loader when the click won't unload the page (new tab, modifier keys, non-http(s) schemes).
+ * Skips the loader when the click won't unload the page (new tab, modifier keys, mailto/tel/otpauth).
  */
 function ExternalLink({ children, onClick, ...props }: ExternalLinkProps) {
   const { start: startLoader } = useTopLoader();

--- a/dashboard/src/components/ExternalLink.tsx
+++ b/dashboard/src/components/ExternalLink.tsx
@@ -9,12 +9,14 @@ function willUnloadPage(e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) {
   if (e.defaultPrevented || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return false;
   const target = e.currentTarget.getAttribute('target');
   if (target && target !== '_self') return false;
-  return !/^(mailto:|tel:)/i.test(e.currentTarget.getAttribute('href') ?? '');
+  // Only http(s) and relative URLs navigate the page; other schemes (mailto:, tel:, otpauth:, ...) don't unload it
+  const protocol = /^([a-z][a-z0-9+.-]*):/i.exec(e.currentTarget.getAttribute('href') ?? '')?.[1];
+  return !protocol || /^https?$/i.test(protocol);
 }
 
 /**
  * Wrapper for the anchor HTML-element (<a>), that triggers the TopLoader's loading animation before navigating.
- * Skips the loader when the click won't unload the page (new tab, modifier keys, mailto/tel).
+ * Skips the loader when the click won't unload the page (new tab, modifier keys, non-http(s) schemes).
  */
 function ExternalLink({ children, onClick, ...props }: ExternalLinkProps) {
   const { start: startLoader } = useTopLoader();

--- a/dashboard/src/components/ExternalLink.tsx
+++ b/dashboard/src/components/ExternalLink.tsx
@@ -5,16 +5,24 @@ import { useTopLoader } from 'nextjs-toploader';
 
 type ExternalLinkProps = React.AnchorHTMLAttributes<HTMLAnchorElement>;
 
+function willUnloadPage(e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) {
+  if (e.defaultPrevented || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return false;
+  const target = e.currentTarget.getAttribute('target');
+  if (target && target !== '_self') return false;
+  return !/^(mailto:|tel:)/i.test(e.currentTarget.getAttribute('href') ?? '');
+}
+
 /**
- * Wrapper for the anchor HTML-element (<a>), that triggers the TopLoader's loading animation before navigating
+ * Wrapper for the anchor HTML-element (<a>), that triggers the TopLoader's loading animation before navigating.
+ * Skips the loader when the click won't unload the page (new tab, modifier keys, mailto/tel).
  */
 function ExternalLink({ children, onClick, ...props }: ExternalLinkProps) {
   const { start: startLoader } = useTopLoader();
 
   const handleClick = useCallback(
     (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
-      startLoader();
       onClick?.(e);
+      if (willUnloadPage(e)) startLoader();
     },
     [startLoader, onClick],
   );

--- a/docs/src/shared/ExternalLink.tsx
+++ b/docs/src/shared/ExternalLink.tsx
@@ -9,14 +9,12 @@ function willUnloadPage(e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) {
   if (e.defaultPrevented || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return false;
   const target = e.currentTarget.getAttribute('target');
   if (target && target !== '_self') return false;
-  // Only http(s) and relative URLs navigate the page; other schemes (mailto:, tel:, otpauth:, ...) don't unload it
-  const protocol = /^([a-z][a-z0-9+.-]*):/i.exec(e.currentTarget.getAttribute('href') ?? '')?.[1];
-  return !protocol || /^https?$/i.test(protocol);
+  return !/^(mailto:|tel:|otpauth:)/i.test(e.currentTarget.getAttribute('href') ?? '');
 }
 
 /**
  * Wrapper for the anchor HTML-element (<a>), that triggers the TopLoader's loading animation before navigating.
- * Skips the loader when the click won't unload the page (new tab, modifier keys, non-http(s) schemes).
+ * Skips the loader when the click won't unload the page (new tab, modifier keys, mailto/tel/otpauth).
  */
 function ExternalLink({ children, onClick, ...props }: ExternalLinkProps) {
   const { start: startLoader } = useTopLoader();

--- a/docs/src/shared/ExternalLink.tsx
+++ b/docs/src/shared/ExternalLink.tsx
@@ -9,12 +9,14 @@ function willUnloadPage(e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) {
   if (e.defaultPrevented || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return false;
   const target = e.currentTarget.getAttribute('target');
   if (target && target !== '_self') return false;
-  return !/^(mailto:|tel:)/i.test(e.currentTarget.getAttribute('href') ?? '');
+  // Only http(s) and relative URLs navigate the page; other schemes (mailto:, tel:, otpauth:, ...) don't unload it
+  const protocol = /^([a-z][a-z0-9+.-]*):/i.exec(e.currentTarget.getAttribute('href') ?? '')?.[1];
+  return !protocol || /^https?$/i.test(protocol);
 }
 
 /**
  * Wrapper for the anchor HTML-element (<a>), that triggers the TopLoader's loading animation before navigating.
- * Skips the loader when the click won't unload the page (new tab, modifier keys, mailto/tel).
+ * Skips the loader when the click won't unload the page (new tab, modifier keys, non-http(s) schemes).
  */
 function ExternalLink({ children, onClick, ...props }: ExternalLinkProps) {
   const { start: startLoader } = useTopLoader();

--- a/docs/src/shared/ExternalLink.tsx
+++ b/docs/src/shared/ExternalLink.tsx
@@ -5,16 +5,24 @@ import { useTopLoader } from 'nextjs-toploader';
 
 type ExternalLinkProps = React.AnchorHTMLAttributes<HTMLAnchorElement>;
 
+function willUnloadPage(e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) {
+  if (e.defaultPrevented || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return false;
+  const target = e.currentTarget.getAttribute('target');
+  if (target && target !== '_self') return false;
+  return !/^(mailto:|tel:)/i.test(e.currentTarget.getAttribute('href') ?? '');
+}
+
 /**
- * Wrapper for the anchor HTML-element (<a>), that triggers the TopLoader's loading animation before navigating
+ * Wrapper for the anchor HTML-element (<a>), that triggers the TopLoader's loading animation before navigating.
+ * Skips the loader when the click won't unload the page (new tab, modifier keys, mailto/tel).
  */
 function ExternalLink({ children, onClick, ...props }: ExternalLinkProps) {
   const { start: startLoader } = useTopLoader();
 
   const handleClick = useCallback(
     (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
-      startLoader();
       onClick?.(e);
+      if (willUnloadPage(e)) startLoader();
     },
     [startLoader, onClick],
   );


### PR DESCRIPTION
`ExternalLink` now starts the toploader only when the click will actually unload the page. It skips the loader for new-tab/new-window clicks (any non-`_self` target, modifier keys, middle click), `mailto:`/`tel:` links, and clicks a consumer cancels with `preventDefault`, mirroring the check Next.js `Link` uses internally.

Closes betterlytics/betterlytics-internal#71

Slightly broader than the ticket's spec (which named `target="_blank"` and ctrl/cmd/middle-click): shift/alt-click and named targets also leave the page in place, so they skip the loader too. The `mailto:`/`tel:` cases are per the ticket's follow-up comment.

The two files are identical copies of the same component (dashboard and docs), per existing convention.
