### PR TITLE
Attribute the rrweb bundle vendored into static/replay.js

### DIFF
--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -30,6 +30,51 @@ limitations under the License.
 
 ---
 
+## rrweb
+
+**Files**: `static/replay.js` (the bundled rrweb build at the top of the file, below the banner comment; Betterlytics' own recorder wrapper follows it)  
+**Source**: [rrweb-io/rrweb](https://github.com/rrweb-io/rrweb)  
+**Version**: 2.0.0-alpha.11 (`dist/rrweb.min.js`, reformatted but otherwise unmodified)  
+**License**: MIT License  
+**Copyright**: Copyright (c) 2018 Contributors (https://github.com/rrweb-io/rrweb/graphs/contributors) and SmartX Inc.  
+**Description**: Session recording and replay library. The bundled build is embedded in the session replay script served to instrumented sites, and provides the DOM serialization, mutation recording and playback used by session replay.
+
+The rrweb bundle inlines `rrweb-snapshot` and `rrdom` (same project, same terms), plus the following, all under the same MIT terms:
+
+- `@xstate/fsm` - Copyright (c) 2015 David Khourshid
+- `base64-arraybuffer` - Copyright (c) 2012 Niklas von Hertzen
+- `mitt` - Copyright (c) 2021 Jason Miller
+
+It also inlines `tslib` (0BSD, Copyright (c) Microsoft Corporation), whose notice is retained inline in `static/replay.js`.
+
+### MIT License
+
+```
+MIT License
+
+Copyright (c) 2018 Contributors (https://github.com/rrweb-io/rrweb/graphs/contributors) and SmartX Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+---
+
 ## Snowplow Referer Parser (based on Piwik)
 
 **Files**: `backend/assets/referers/referers-latest.json`  

--- a/static/replay.js
+++ b/static/replay.js
@@ -1,3 +1,36 @@
+/*!
+ * The bundle below is rrweb v2.0.0-alpha.11 (dist/rrweb.min.js), reformatted but
+ * otherwise unmodified: https://github.com/rrweb-io/rrweb
+ * Betterlytics' own recorder wrapper follows it at the end of this file.
+ *
+ * MIT License
+ *
+ * Copyright (c) 2018 Contributors (https://github.com/rrweb-io/rrweb/graphs/contributors) and SmartX Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * The rrweb bundle inlines rrweb-snapshot and rrdom (same project, same terms),
+ * plus @xstate/fsm (MIT, (c) 2015 David Khourshid), base64-arraybuffer
+ * (MIT, (c) 2012 Niklas von Hertzen) and mitt (MIT, (c) 2021 Jason Miller), all
+ * under the MIT terms above, and tslib (0BSD, (c) Microsoft Corporation) whose
+ * notice is retained inline further down.
+ */
 var rrweb = (function (re) {
   "use strict";
   var N;


### PR DESCRIPTION
`static/replay.js` embeds a verbatim copy of rrweb (~250 KB of the 276 KB file, everything above our own recorder wrapper), but carried no copyright or license notice. rrweb is MIT, which requires the notice to travel with substantial copies, so this adds it.

Version pinned by minify-normalizing the vendored region and comparing it against published rrweb builds: it is **2.0.0-alpha.11** `dist/rrweb.min.js`, byte-identical, reformatted only. alpha.10 and alpha.12 both differ, and the exact match confirms the vendored code was never hand-edited since it was inlined in d65515706.

- `THIRD-PARTY-LICENSES.md`: rrweb entry with version, source, and full MIT text, plus the deps the bundle inlines (rrweb-snapshot, rrdom, @xstate/fsm, base64-arraybuffer, mitt; tslib is 0BSD and its notice was already inline).
- `static/replay.js`: banner comment carrying the same notice. nginx serves this file standalone, so the markdown alone would not reach the people receiving the code. `/*!` survives minification.

No behaviour change - comments and docs only.