### PR TITLE
Pointed the docs navbar To Dashboard link at /dashboard

### DIFF
--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -70,7 +70,7 @@ const navbar = (
       chatLink="https://discord.gg/vwqSvPn6sP"
     >
       <ExternalLink
-        href="https://betterlytics.io/dashboards"
+        href="https://betterlytics.io/dashboard"
         title="To Dashboard"
       >
         To Dashboard


### PR DESCRIPTION
The docs navbar's To Dashboard link now goes to `/dashboard`, which sends signed-in users straight to their own dashboard instead of the dashboards overview.

Closes betterlytics/betterlytics-internal#133
