### PR TITLE
Documented Session Replay support for self-hosted instances

### DIFF
--- a/docs/src/app/components/HostingComparisonTable.tsx
+++ b/docs/src/app/components/HostingComparisonTable.tsx
@@ -58,7 +58,7 @@ const FEATURE_CATEGORIES: FeatureCategory[] = [
     features: [
       { name: "Core Web Vitals", cloud: true, selfHosted: true },
       { name: "Error tracking", cloud: true, selfHosted: false },
-      { name: "Session replays", cloud: true, selfHosted: false },
+      { name: "Session replays", cloud: true, selfHosted: true },
       { name: "Uptime monitoring", cloud: true, selfHosted: "Configurable" },
       { name: "SSL certificate monitoring", cloud: true, selfHosted: "Configurable" },
       { name: "Alert integrations (Slack, Discord, Teams, webhooks)", cloud: true, selfHosted: "Configurable" },

--- a/docs/src/content/dashboard/session-replay.mdx
+++ b/docs/src/content/dashboard/session-replay.mdx
@@ -9,10 +9,6 @@ import { Callout } from "nextra/components";
 
 Session Replay lets you watch real user sessions recorded with privacy‑aware defaults. Use it to debug UX issues, verify designs, and correlate with analytics.
 
-<Callout type="info">
-**Availability**: Session Replay is currently available on Betterlytics Cloud. Self-hosted support is planned. See the [feature comparison](/installation#cloud-vs-self-hosted).
-</Callout>
-
 <div style={{ textAlign: "center", margin: "20px 0" }}>
   ![Session Replay In Action](/images/dashboard/session-replay-in-action.webp)
 </div>

--- a/docs/src/content/faq.mdx
+++ b/docs/src/content/faq.mdx
@@ -71,7 +71,7 @@ description: "Answers to common questions about Betterlytics: what it is, privac
           name: "Do Betterlytics Cloud and self-hosted have the same features?",
           acceptedAnswer: {
             "@type": "Answer",
-            text: "Mostly, but not always at the same time. New features launch on Betterlytics Cloud first, and the self-hosted image is updated periodically from stable releases, so a recently launched feature may be live on Cloud before it reaches the self-hosted image. A few features also depend on additional infrastructure and are not yet supported when self-hosting, such as Session Replay, which requires S3-compatible object storage.",
+            text: "Mostly, but not always at the same time. New features launch on Betterlytics Cloud first, and the self-hosted image is updated periodically from stable releases, so a recently launched feature may be live on Cloud before it reaches the self-hosted image.",
           },
         },
         {
@@ -127,7 +127,7 @@ Yes. Betterlytics has a built‑in [MCP server](/dashboard/mcp) (Model Context P
 Teams of all sizes that want actionable insights without cookie banners or invasive tracking: anyone who would rather run one tool than juggle separate analytics, error tracking, and uptime monitoring services, marketers who need clear acquisition and content insights, product and engineering teams optimizing UX and performance, and privacy‑conscious organizations that value data ownership. Choose the hosted service for the fastest setup and managed operations, or self‑host for maximum control over your data and infrastructure.
 
 ## Do Betterlytics Cloud and self-hosted have the same features?
-Mostly, but not always at the same time. New features launch on Betterlytics Cloud first, and the self‑hosted image is updated periodically from our stable releases, so a recently launched feature may be live on Cloud before it reaches the self‑hosted image. A few features also depend on additional infrastructure and are not yet supported when self‑hosting, such as Session Replay, which requires S3‑compatible object storage. Check the [cloud vs self‑hosted comparison](/installation#cloud-vs-self-hosted) for the current status of each feature.
+Mostly, but not always at the same time. New features launch on Betterlytics Cloud first, and the self‑hosted image is updated periodically from our stable releases, so a recently launched feature may be live on Cloud before it reaches the self‑hosted image. Check the [cloud vs self‑hosted comparison](/installation#cloud-vs-self-hosted) for the current status of each feature.
 
 ## Is there a free plan?
 Yes. The Growth plan is free up to 10,000 events per month and includes the core analytics features. As you grow, you can upgrade to plans with higher limits and longer data retention. See the full details on [Pricing & Billing](/pricing) and the guides for [Upgrading](/pricing/upgrading), [Changing Plans](/pricing/changing-plans) and [Managing Subscription](/pricing/managing-subscription).

--- a/docs/src/content/installation/index.mdx
+++ b/docs/src/content/installation/index.mdx
@@ -20,7 +20,7 @@ Both options provide the same privacy-first, cookieless analytics experience. Cl
 **How to read the table:**
 
 - **Configurable** - Included in the self-hosted image, but requires configuration on your side (for example SMTP credentials for email features).
-- A cross in the self-hosted column does not mean never. Most features are planned for self-hosting and arrive with later image updates, while some depend on additional infrastructure first (for example, session replays require S3-compatible object storage).
+- A cross in the self-hosted column does not mean never. Most features are planned for self-hosting and arrive with later image updates.
 
 New features launch on Betterlytics Cloud first and reach the self-hosted image with periodic updates. See [feature availability for self-hosting](/installation/self-hosting#feature-availability) for how this works.
 

--- a/docs/src/content/installation/self-hosting.mdx
+++ b/docs/src/content/installation/self-hosting.mdx
@@ -16,7 +16,7 @@ All self-hosting files and configuration live in the [betterlytics-selfhost](htt
 
 Betterlytics Cloud always runs the latest version, and new features launch there first. The self-hosted image is updated periodically from our stable releases, so it can temporarily lag behind what you see on Cloud or elsewhere in these docs.
 
-A few features also depend on additional infrastructure and are not yet supported when self-hosting. For example, Session Replay requires S3-compatible object storage.
+A few features are not yet supported when self-hosting. For example, Error Tracking is not included in the self-hosted image yet.
 
 <Callout type="info">
 Before relying on a specific feature, check the [cloud vs self-hosted comparison](/installation#cloud-vs-self-hosted) for its current self-hosted status. Getting the newest features is as simple as [updating your instance](#updating) when a new image is released.
@@ -200,6 +200,21 @@ When `GEOLOCATION_MODE=full` is set (alongside `ENABLE_GEOLOCATION=true`), both 
 **Forward-only data:** Enabling subdivisions mode only populates city and subdivision data for **new events** going forward. Existing events recorded before enabling this mode will only have country-level data. There is no way to backfill since IP addresses are never stored.
 </Callout>
 
+
+## Session Replay
+
+The self-hosted image ships with Session Replay support ready to use: recording storage is bundled, so there is no external storage to set up. This only makes the feature available. Nothing is recorded until you enable replay in the tracking script for each website, following the [Session Replay integration guide](/integration/session-replay).
+
+| Variable | Default | Behavior |
+|----------|---------|----------|
+| `SESSION_REPLAYS_ENABLED` | `true` | Enables session replay capability |
+| `REPLAY_RETENTION_DAYS` | `DATA_RETENTION_DAYS` | Days to keep recordings before automatic deletion |
+
+After changing either value, restart:
+
+```bash
+docker compose down && docker compose up -d
+```
 
 ## Updating
 

--- a/docs/src/content/integration/index.mdx
+++ b/docs/src/content/integration/index.mdx
@@ -24,7 +24,7 @@ Haven't installed the script yet? Start with the [Cloud Quick Start](/installati
 | Session replay | `data-replay` | [Session Replay](/integration/session-replay) |
 
 <Callout type="info">
-Self-hosting? A few capabilities, like Error Tracking and Session Replay, are not in the self-hosted image yet. Check the [cloud vs self-hosted comparison](/installation#cloud-vs-self-hosted) for the current status.
+Self-hosting? New capabilities land on Cloud first and reach the self-hosted image with its periodic updates. The [cloud vs self-hosted comparison](/installation#cloud-vs-self-hosted) shows the current status.
 </Callout>
 
 ## A Complete Example

--- a/docs/src/content/integration/session-replay.mdx
+++ b/docs/src/content/integration/session-replay.mdx
@@ -9,10 +9,6 @@ import { Callout } from "nextra/components";
 
 Betterlytics captures privacy‑aware session replays from real users. Replays help you debug UX issues by watching what users actually experienced, alongside your analytics metrics.
 
-<Callout type="info">
-**Availability**: Session Replay is currently available on Betterlytics Cloud. Self-hosted support is planned, but requires S3-compatible object storage. See the [feature comparison](/installation#cloud-vs-self-hosted).
-</Callout>
-
 ## Quick start
 
 ### Using the script tag


### PR DESCRIPTION
Updated the docs for Session Replay shipping on selfhost: the self-hosting guide gets a Session Replay section (bundled recording storage, `SESSION_REPLAYS_ENABLED`, `REPLAY_RETENTION_DAYS`), the cloud vs self-hosted comparison table now shows replay as supported, and the "Cloud only, requires S3-compatible storage" wording is removed from the FAQ, installation, and integration pages.

Part of betterlytics/betterlytics-internal#158 (docs portion, alongside betterlytics/betterlytics-selfhost#6 and betterlytics/betterlytics#1054).
