### PR TITLE
Gated the cloud-only features, contact, vs and demo pages off-cloud

### DIFF
--- a/dashboard/src/app/(app)/[locale]/(public)/contact/page.tsx
+++ b/dashboard/src/app/(app)/[locale]/(public)/contact/page.tsx
@@ -8,6 +8,8 @@ import { Button } from '@/components/ui/button';
 import { Card, CardHeader, CardTitle, CardDescription, CardFooter } from '@/components/ui/card';
 import type { SupportedLanguages } from '@/constants/i18n';
 import type { ReactNode } from 'react';
+import { env } from '@/lib/env';
+import { redirect } from 'next/navigation';
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: SupportedLanguages }> }) {
   const { locale } = await params;
@@ -97,6 +99,10 @@ function FAQItem({ question, answer }: FAQItemProps) {
 }
 
 export default async function ContactPage() {
+  if (!env.IS_CLOUD) {
+    redirect('/');
+  }
+
   const t = await getTranslations('public.contact');
   const seoConfig = await buildSEOConfig(SEO_CONFIGS.contact);
 

--- a/dashboard/src/app/(app)/[locale]/(public)/demo/page.tsx
+++ b/dashboard/src/app/(app)/[locale]/(public)/demo/page.tsx
@@ -2,5 +2,9 @@ import { redirect } from 'next/navigation';
 import { env } from '@/lib/env';
 
 export default function DemoPage() {
+  if (!env.IS_CLOUD) {
+    redirect('/');
+  }
+
   redirect(`/share/${env.DEMO_DASHBOARD_ID}`);
 }

--- a/dashboard/src/app/(app)/[locale]/(public)/features/page.tsx
+++ b/dashboard/src/app/(app)/[locale]/(public)/features/page.tsx
@@ -6,6 +6,8 @@ import { buildSEOConfig, generateSEO, SEO_CONFIGS } from '@/lib/seo';
 import { FeaturesHero } from './components/FeaturesHero';
 import { FeatureCategories } from './components/FeatureCategories';
 import { CtaStrip } from '@/components/public/ctaStrip';
+import { env } from '@/lib/env';
+import { redirect } from 'next/navigation';
 
 export async function generateMetadata(): Promise<Metadata> {
   const locale = await getLocale();
@@ -14,6 +16,10 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function FeaturesPage() {
+  if (!env.IS_CLOUD) {
+    redirect('/');
+  }
+
   const seoConfig = await buildSEOConfig(SEO_CONFIGS.features);
 
   return (

--- a/dashboard/src/app/(app)/[locale]/(public)/vs/[competitor]/page.tsx
+++ b/dashboard/src/app/(app)/[locale]/(public)/vs/[competitor]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import { Link } from '@/i18n/navigation';
 import Image from 'next/image';
 import { getTranslations } from 'next-intl/server';
@@ -26,6 +26,7 @@ import Logo from '@/components/logo';
 import { CtaStrip } from '@/components/public/ctaStrip';
 import { getCompetitorData, getCompetitorSlugs, SUPPORTED_LOCALES, type ComparisonLocaleContent } from './config';
 import { generateSEO } from '@/lib/seo';
+import { env } from '@/lib/env';
 
 export async function generateStaticParams() {
   const competitors = getCompetitorSlugs();
@@ -208,6 +209,10 @@ function TimelineItem({
 }
 
 export default async function ComparisonPage({ params }: PageProps) {
+  if (!env.IS_CLOUD) {
+    redirect('/');
+  }
+
   const { competitor, locale } = await params;
   const data = getCompetitorData(competitor, locale);
   const t = await getTranslations('public.comparison');


### PR DESCRIPTION
Selfhosted instances served the Betterlytics marketing and competitor-comparison pages on the operator's own domain, and `/demo` redirected to the literal `/share/undefined` with `DEMO_DASHBOARD_ID` unset. `/features`, `/contact`, `/vs/[competitor]` and `/demo` now redirect home when `IS_CLOUD` is false, using the same gate as `about/page.tsx`.

Closes betterlytics/betterlytics-internal#155

Reviewer notes: the gate is deliberately per-page rather than in the `(public)` layout, since that segment also holds accept-invite, forgot-password, reset-password and verify-email, which must stay reachable off-cloud. `generateStaticParams` on `/vs/[competitor]` is left alone (the selfhost image prerenders no page routes, so the runtime gate holds). The public topbar and footer still link to these routes off-cloud; that cleanup is tracked separately in betterlytics/betterlytics-internal#175.

Verification: build, lint and unit tests pass. Runtime redirect behavior was not exercised, so the `IS_CLOUD=false` acceptance check is still open.
