### PR TITLE
Fixed topbar hydration error introduced by the better-auth migration

### DIFF
--- a/dashboard/src/components/topbar/BATopbar.tsx
+++ b/dashboard/src/components/topbar/BATopbar.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { authClient } from '@/lib/auth-client';
+import { useHydratedSession } from '@/hooks/use-hydrated-session';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -38,7 +39,7 @@ import { cn } from '@/lib/utils';
 import { Link as LocaleLink } from '@/i18n/navigation';
 
 export default function BATopbar() {
-  const { data: session, isPending } = authClient.useSession();
+  const { data: session, isPending } = useHydratedSession();
   const [showSettingsDialog, setShowSettingsDialog] = useState(false);
   const [showBugReportDialog, setShowBugReportDialog] = useState(false);
   const { start: startLoader } = useTopLoader();

--- a/dashboard/src/components/topbar/PublicTopBar.tsx
+++ b/dashboard/src/components/topbar/PublicTopBar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { authClient } from '@/lib/auth-client';
+import { useHydratedSession } from '@/hooks/use-hydrated-session';
 import { Button } from '@/components/ui/button';
 import { Link, usePathname } from '@/i18n/navigation';
 import Logo from '@/components/logo';
@@ -13,7 +13,7 @@ import NextLink from 'next/link';
 
 export default function PublicTopBar() {
   const t = useTranslations('public.nav');
-  const { data: session, isPending } = authClient.useSession();
+  const { data: session, isPending } = useHydratedSession();
   const pathname = usePathname();
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 

--- a/dashboard/src/hooks/use-hydrated-session.ts
+++ b/dashboard/src/hooks/use-hydrated-session.ts
@@ -1,0 +1,23 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { authClient } from '@/lib/auth-client';
+
+/**
+ * Hydration-safe wrapper around authClient.useSession().
+ *
+ * better-auth's session store is shared across all subscribers and can resolve
+ * before a component hydrates, making its first client render differ from the
+ * server HTML (which always renders with isPending=true). Keep isPending true
+ * until after hydration so both renders match.
+ */
+export function useHydratedSession() {
+  const session = authClient.useSession();
+  const [isHydrated, setIsHydrated] = useState(false);
+
+  useEffect(() => {
+    setIsHydrated(true);
+  }, []);
+
+  return { ...session, isPending: session.isPending || !isHydrated };
+}


### PR DESCRIPTION
better-auth's `useSession` reads the live value of its shared client store during hydration, unlike next-auth which held `loading` state through the first client render. When the session fetch resolves before the topbar hydrates, the first client render (sign-in buttons) no longer matches the server HTML (pending skeleton), producing a recoverable hydration error on public pages. Added a `useHydratedSession` wrapper that keeps `isPending` true until after hydration so both renders match, and swapped it into `PublicTopBar` and `BATopbar` (same latent race).

Reviewer notes: the wrapper is only needed where session-dependent markup is part of the server-rendered HTML. The other `useSession` call sites render behind these pending gates or after user interaction, so they are unchanged.
