### PR TITLE
Extracted a shared useCopy clipboard hook

### DIFF
--- a/dashboard/messages/da.json
+++ b/dashboard/messages/da.json
@@ -4075,6 +4075,7 @@
       "viewPage": "Vis side",
       "more": "Flere handlinger",
       "linkCopied": "Link kopieret til udklipsholderen",
+      "linkCopyFailed": "Kunne ikke kopiere linket",
       "openPublicPage": "Åbn offentlig side",
       "editPage": "Rediger side",
       "manageIncidents": "Administrer hændelser",

--- a/dashboard/messages/en.json
+++ b/dashboard/messages/en.json
@@ -4072,6 +4072,7 @@
       "viewPage": "View page",
       "more": "More actions",
       "linkCopied": "Link copied to clipboard",
+      "linkCopyFailed": "Failed to copy link",
       "openPublicPage": "Open public page",
       "editPage": "Edit page",
       "manageIncidents": "Manage incidents",

--- a/dashboard/messages/it.json
+++ b/dashboard/messages/it.json
@@ -4075,6 +4075,7 @@
       "viewPage": "Vedi pagina",
       "more": "Altre azioni",
       "linkCopied": "Link copiato negli appunti",
+      "linkCopyFailed": "Copia del link non riuscita",
       "openPublicPage": "Apri pagina pubblica",
       "editPage": "Modifica pagina",
       "manageIncidents": "Gestisci incidenti",

--- a/dashboard/messages/nb.json
+++ b/dashboard/messages/nb.json
@@ -4075,6 +4075,7 @@
       "viewPage": "Vis side",
       "more": "Flere handlinger",
       "linkCopied": "Lenke kopiert til utklippstavlen",
+      "linkCopyFailed": "Kunne ikke kopiere lenken",
       "openPublicPage": "Åpne offentlig side",
       "editPage": "Rediger side",
       "manageIncidents": "Administrer hendelser",

--- a/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/errors/detail/[fingerprint]/ErrorDetailHeader.tsx
+++ b/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/errors/detail/[fingerprint]/ErrorDetailHeader.tsx
@@ -12,6 +12,7 @@ import { STATUS_CONFIG } from '../../errors.constants';
 import { ErrorStatusActions } from '../../ErrorStatusActions';
 import { PermissionGate } from '@/components/tooltip/PermissionGate';
 import { useDashboardNavigation } from '@/contexts/DashboardNavigationContext';
+import { useCopy } from '@/hooks/use-copy';
 import { useTranslations } from 'next-intl';
 
 type ErrorDetailHeaderProps = {
@@ -24,14 +25,9 @@ export function ErrorDetailHeader({ dashboardId, errorGroup }: ErrorDetailHeader
   const tStatus = useTranslations('errors.status');
   const [status, setStatus] = useState<ErrorGroupStatusValue>(errorGroup.status);
   const [isPending, startTransition] = useTransition();
-  const [copied, setCopied] = useState(false);
+  const { copied, copy } = useCopy();
   const { resolveHref } = useDashboardNavigation();
 
-  function copyShareUrl() {
-    navigator.clipboard.writeText(window.location.href);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  }
   const cfg = STATUS_CONFIG[status];
 
   function updateStatus(newStatus: ErrorGroupStatusValue) {
@@ -74,7 +70,7 @@ export function ErrorDetailHeader({ dashboardId, errorGroup }: ErrorDetailHeader
                 />
               )}
             </PermissionGate>
-            <Button variant='outline' size='sm' className='cursor-pointer' onClick={copyShareUrl}>
+            <Button variant='outline' size='sm' className='cursor-pointer' onClick={() => copy(window.location.href)}>
               {copied ? (
                 <Check className='mr-1.5 h-4 w-4 text-emerald-600' />
               ) : (

--- a/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/status-pages/StatusPagesClient.tsx
+++ b/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/status-pages/StatusPagesClient.tsx
@@ -42,6 +42,7 @@ import { DashboardHeader } from '@/components/dashboard/DashboardHeader';
 import { UpgradeButton } from '@/components/billing/UpgradeButton';
 import { useCapabilities } from '@/contexts/CapabilitiesProvider';
 import { useDashboardNavigation } from '@/contexts/DashboardNavigationContext';
+import { useCopy } from '@/hooks/use-copy';
 import { cn } from '@/lib/utils';
 import {
   useDeleteStatusPageMutation,
@@ -105,9 +106,12 @@ export function StatusPagesClient({
 
   const [showCreateStudio, setShowCreateStudio] = useState(false);
 
-  const copyLink = (page: StatusPageListItem) => {
-    navigator.clipboard.writeText(statusPagePublicUrl(page, publicBaseUrl));
-    toast.success(t('actions.linkCopied'));
+  const { copy } = useCopy({ failedMessage: t('actions.linkCopyFailed') });
+
+  const copyLink = async (page: StatusPageListItem) => {
+    if (await copy(statusPagePublicUrl(page, publicBaseUrl))) {
+      toast.success(t('actions.linkCopied'));
+    }
   };
 
   const [deleteTarget, setDeleteTarget] = useState<StatusPageListItem | null>(null);

--- a/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(settings)/settings/mcp/McpTokenManager.tsx
+++ b/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(settings)/settings/mcp/McpTokenManager.tsx
@@ -17,6 +17,7 @@ import {
   McpTokenListItem,
 } from '@/entities/dashboard/mcpToken.entities';
 import { formatLocalDateTime } from '@/utils/dateFormatters';
+import { useCopy } from '@/hooks/use-copy';
 
 interface McpTokenManagerProps {
   dashboardId: string;
@@ -30,7 +31,7 @@ export function McpTokenManager({ dashboardId, tokens }: McpTokenManagerProps) {
   const [lifetime, setLifetime] = useState<McpTokenLifetime>(DEFAULT_MCP_TOKEN_LIFETIME);
   const [isPending, startTransition] = useTransition();
   const [newlyCreatedToken, setNewlyCreatedToken] = useState<{ id: string; plainToken: string } | null>(null);
-  const [copied, setCopied] = useState(false);
+  const { copied, copy } = useCopy();
   const [deleteTokenId, setDeleteTokenId] = useState<string | null>(null);
 
   const handleCreate = () => {
@@ -63,12 +64,6 @@ export function McpTokenManager({ dashboardId, tokens }: McpTokenManagerProps) {
     });
   };
 
-  const handleCopy = async (value: string) => {
-    await navigator.clipboard.writeText(value);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
-
   const formatDate = (date: Date) =>
     formatLocalDateTime(date, locale, { year: 'numeric', month: 'short', day: 'numeric' }) ?? '';
 
@@ -87,7 +82,7 @@ export function McpTokenManager({ dashboardId, tokens }: McpTokenManagerProps) {
               variant='ghost'
               size='icon'
               className='size-8 shrink-0 cursor-pointer'
-              onClick={() => handleCopy(newlyCreatedToken.plainToken)}
+              onClick={() => copy(newlyCreatedToken.plainToken)}
             >
               {copied ? <Check className='size-4' /> : <Copy className='size-4' />}
             </Button>

--- a/dashboard/src/app/(app)/[locale]/(onboarding)/onboarding/steps/Integration.tsx
+++ b/dashboard/src/app/(app)/[locale]/(onboarding)/onboarding/steps/Integration.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { Badge } from '@/components/ui/badge';
 import { Clipboard, Check } from 'lucide-react';
 import { usePublicEnvironmentVariablesContext } from '@/contexts/PublicEnvironmentVariablesContextProvider';
+import { useCopy } from '@/hooks/use-copy';
 import { useSessionRefresh } from '@/hooks/use-session-refresh';
 import { useTrackingVerificationWithId } from '@/hooks/use-tracking-verification';
 import { useBARouter } from '@/hooks/use-ba-router';
@@ -35,7 +36,7 @@ export default function Integration() {
   const messages = useMessages();
   const integrationTranslations = (messages as Record<string, unknown>).integration as IntegrationTranslations;
 
-  const [copiedIdentifier, setCopiedIdentifier] = useState<string | null>(null);
+  const { copied, copy } = useCopy();
   const [selectedFramework, setSelectedFramework] = useState<FrameworkId>('html');
   const { PUBLIC_ANALYTICS_BASE_URL, PUBLIC_TRACKING_SERVER_ENDPOINT } = usePublicEnvironmentVariablesContext();
   const IS_CLOUD = useClientFeatureFlags().isFeatureFlagEnabled('isCloud');
@@ -53,14 +54,6 @@ export default function Integration() {
       return () => clearInterval(interval);
     }
   }, [isVerified, verifySilently]);
-
-  const handleCopy = useCallback(async (text: string, identifier: string) => {
-    try {
-      await navigator.clipboard.writeText(text);
-      setCopiedIdentifier(identifier);
-      setTimeout(() => setCopiedIdentifier(null), 2000);
-    } catch {}
-  }, []);
 
   const handleFinishOnboarding = useCallback(async () => {
     baEvent('onboarding-integration', {
@@ -173,10 +166,10 @@ export default function Integration() {
           <Button
             variant='ghost'
             size='sm'
-            onClick={() => handleCopy(dashboard.siteId, 'siteId')}
+            onClick={() => copy(dashboard.siteId)}
             className='h-8 cursor-pointer px-2'
           >
-            {copiedIdentifier === 'siteId' ? <Check className='h-4 w-4' /> : <Clipboard className='h-4 w-4' />}
+            {copied ? <Check className='h-4 w-4' /> : <Clipboard className='h-4 w-4' />}
           </Button>
         </div>
       </CardContent>

--- a/dashboard/src/components/CopyButton.tsx
+++ b/dashboard/src/components/CopyButton.tsx
@@ -1,32 +1,8 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
 import { Check, Copy } from 'lucide-react';
 import { cn } from '@/lib/utils';
-
-function useCopyToClipboard(resetAfterMs = 1400) {
-  const [copied, setCopied] = useState(false);
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(
-    () => () => {
-      if (timeoutRef.current) clearTimeout(timeoutRef.current);
-    },
-    [],
-  );
-
-  const copy = useCallback(
-    (text: string) => {
-      navigator.clipboard.writeText(text);
-      setCopied(true);
-      if (timeoutRef.current) clearTimeout(timeoutRef.current);
-      timeoutRef.current = setTimeout(() => setCopied(false), resetAfterMs);
-    },
-    [resetAfterMs],
-  );
-
-  return { copied, copy };
-}
+import { useCopy } from '@/hooks/use-copy';
 
 type CopyButtonProps = {
   text: string;
@@ -38,7 +14,7 @@ type CopyButtonProps = {
 };
 
 export function CopyButton({ text, ariaLabel, copiedLabel, className, iconClassName }: CopyButtonProps) {
-  const { copied, copy } = useCopyToClipboard();
+  const { copied, copy } = useCopy({ resetAfterMs: 1400 });
 
   return (
     <button type='button' onClick={() => copy(text)} aria-label={ariaLabel} className={className}>

--- a/dashboard/src/components/integration/CodeBlock.tsx
+++ b/dashboard/src/components/integration/CodeBlock.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import Prism from 'prismjs';
 import 'prismjs/themes/prism-tomorrow.css'; // This provides dark-themed background for code blocks
 import 'prismjs/components/prism-javascript';
@@ -8,6 +8,7 @@ import 'prismjs/components/prism-markup';
 import 'prismjs/components/prism-bash';
 import { Copy, Check } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { useCopy } from '@/hooks/use-copy';
 
 interface CodeBlockProps {
   code: string;
@@ -16,7 +17,7 @@ interface CodeBlockProps {
 
 export function CodeBlock({ code, language }: CodeBlockProps) {
   const codeRef = useRef<HTMLPreElement>(null);
-  const [copied, setCopied] = useState(false);
+  const { copied, copy } = useCopy();
 
   useEffect(() => {
     if (codeRef.current) {
@@ -24,19 +25,13 @@ export function CodeBlock({ code, language }: CodeBlockProps) {
     }
   }, [code, language]);
 
-  const handleCopy = async () => {
-    await navigator.clipboard.writeText(code);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
-
   return (
     <div className='relative min-w-0 overflow-hidden'>
       <Button
         variant='ghost'
         size='icon'
         className='text-muted-foreground hover:text-foreground absolute top-2 right-2 h-8 w-8'
-        onClick={handleCopy}
+        onClick={() => copy(code)}
         aria-label='Copy code'
       >
         {copied ? <Check className='h-4 w-4' /> : <Copy className='h-4 w-4' />}

--- a/dashboard/src/components/integration/IntegrationSheet.tsx
+++ b/dashboard/src/components/integration/IntegrationSheet.tsx
@@ -5,8 +5,8 @@ import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { CheckCircle, Info, Clipboard, Check, RefreshCw, Circle } from 'lucide-react';
-import { toast } from 'sonner';
 import { Badge } from '@/components/ui/badge';
+import { useCopy } from '@/hooks/use-copy';
 import { useDashboardId } from '@/hooks/use-dashboard-id';
 import { useQuery } from '@tanstack/react-query';
 import { fetchSiteId } from '@/app/actions/index.actions';
@@ -33,7 +33,6 @@ interface IntegrationStatus {
 }
 
 export function IntegrationSheet({ open, onOpenChange }: IntegrationSheetProps) {
-  const [copiedIdentifier, setCopiedIdentifier] = useState<string | null>(null);
   const [selectedFramework, setSelectedFramework] = useState<FrameworkId>('html');
   const [integrationStatus, setIntegrationStatus] = useState<IntegrationStatus>({
     accountCreated: true,
@@ -41,6 +40,7 @@ export function IntegrationSheet({ open, onOpenChange }: IntegrationSheetProps) 
     dataReceiving: false,
   });
   const t = useTranslations('components.integration');
+  const { copied, copy } = useCopy({ failedMessage: t('failedToCopy') });
   const messages = useMessages();
   const integrationTranslations = (messages as Record<string, unknown>).integration as IntegrationTranslations;
 
@@ -65,16 +65,6 @@ export function IntegrationSheet({ open, onOpenChange }: IntegrationSheetProps) 
 
   const handleVerifyInstallation = async () => {
     await verify();
-  };
-
-  const handleCopy = async (text: string, identifier: string) => {
-    try {
-      await navigator.clipboard.writeText(text);
-      setCopiedIdentifier(identifier);
-      setTimeout(() => setCopiedIdentifier(null), 2000);
-    } catch {
-      toast.error(t('failedToCopy'));
-    }
   };
 
   const frameworkCode = siteId
@@ -135,9 +125,9 @@ export function IntegrationSheet({ open, onOpenChange }: IntegrationSheetProps) 
                       variant='ghost'
                       size='sm'
                       className='text-muted-foreground hover:text-foreground h-8 cursor-pointer gap-1.5 text-xs'
-                      onClick={() => handleCopy(siteId, 'siteId')}
+                      onClick={() => copy(siteId)}
                     >
-                      {copiedIdentifier === 'siteId' ? (
+                      {copied ? (
                         <>
                           <Check className='h-3.5 w-3.5' />
                           {t('copied')}

--- a/dashboard/src/components/userSettings/account/UserSecurityTotpSettings.tsx
+++ b/dashboard/src/components/userSettings/account/UserSecurityTotpSettings.tsx
@@ -19,28 +19,13 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { DisabledTooltip } from '@/components/tooltip/DisabledTooltip';
 import { Check, Clipboard, Loader2 } from 'lucide-react';
 import { authClient } from '@/lib/auth-client';
+import { useCopy } from '@/hooks/use-copy';
 import { useSessionRefresh } from '@/hooks/use-session-refresh';
 import { useEffect, useRef, useState, useTransition } from 'react';
 import QRCode from 'react-qr-code';
 import { toast } from 'sonner';
 import ExternalLink from '@/components/ExternalLink';
 import { useTranslations } from 'next-intl';
-
-function useCopy(failedMessage: string) {
-  const [copied, setCopied] = useState(false);
-
-  const copy = async (text: string) => {
-    try {
-      await navigator.clipboard.writeText(text);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      toast.error(failedMessage);
-    }
-  };
-
-  return { copied, copy };
-}
 
 function SetupTotp() {
   const t = useTranslations('components.userSettings.security.totp');
@@ -51,7 +36,7 @@ function SetupTotp() {
   const [totpSecret, setTotpSecret] = useState('');
   const [totpUrl, setTotpUrl] = useState('');
   const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const { copied: totpSecretCopied, copy: copySecret } = useCopy(t('copyFailed'));
+  const { copied: totpSecretCopied, copy: copySecret } = useCopy({ failedMessage: t('copyFailed') });
   const [isPending, startTransition] = useTransition();
 
   const handleDialogOpenChange = (open: boolean) => {

--- a/dashboard/src/hooks/use-copy.ts
+++ b/dashboard/src/hooks/use-copy.ts
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
+
+const DEFAULT_RESET_AFTER_MS = 2000;
+
+type UseCopyOptions = {
+  /** Error toast shown when the clipboard write fails. Omit to fail silently. */
+  failedMessage?: string;
+  /** How long `copied` stays true after a successful copy. (Default = 2000ms) */
+  resetAfterMs?: number;
+};
+
+/**
+ * Copies text to the clipboard, exposing a transient `copied` flag and a `copy` that resolves to
+ * whether the write succeeded — so call sites can gate their own follow-up (a success toast, say).
+ */
+export function useCopy(options: UseCopyOptions = {}) {
+  const { failedMessage, resetAfterMs = DEFAULT_RESET_AFTER_MS } = options;
+
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    },
+    [],
+  );
+
+  const copy = useCallback(
+    async (text: string) => {
+      try {
+        await navigator.clipboard.writeText(text);
+      } catch {
+        if (failedMessage) toast.error(failedMessage);
+        return false;
+      }
+
+      setCopied(true);
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(() => setCopied(false), resetAfterMs);
+      return true;
+    },
+    [failedMessage, resetAfterMs],
+  );
+
+  return { copied, copy };
+}


### PR DESCRIPTION
Eight components each had their own copy-to-clipboard code (writeText, a transient `copied` flag, a reset timer, and inconsistent error handling). They now share `useCopy` in `dashboard/src/hooks/use-copy.ts`, which takes an optional `failedMessage` (error toast, omit to fail silently) and `resetAfterMs`, and returns `{ copied, copy }` where `copy` resolves to whether the write succeeded so a call site can gate its own follow-up.

Closes betterlytics/betterlytics-internal#181

## Per call site

Mechanics only, no intended UX change. What each site shows today and after:

| Call site | Visible behavior | Change |
|---|---|---|
| `CopyButton.tsx` | icon swap, 1400ms | passes `resetAfterMs: 1400`; local `useCopyToClipboard` deleted |
| `UserSecurityTotpSettings.tsx` | icon swap 2000ms + `copyFailed` error toast | local `useCopy(failedMessage)` deleted, same message passed as an option |
| `IntegrationSheet.tsx` | Copy/Copied label swap 2000ms + `failedToCopy` error toast | keyed `copiedIdentifier` state collapsed to `copied` (the file has one copy target) |
| `CodeBlock.tsx` | icon swap, 2000ms | inline handler removed |
| `McpTokenManager.tsx` | icon swap, 2000ms | inline handler removed |
| onboarding `Integration.tsx` | icon swap 2000ms, silent on failure | keyed `copiedIdentifier` collapsed to `copied` (one copy target); still silent (no `failedMessage`) |
| `ErrorDetailHeader.tsx` | Share/Copied label + icon swap, 2000ms | inline handler removed |
| `StatusPagesClient.tsx` | `linkCopied` success toast, no transient state | see below |

## Reviewer notes

Two failure-path behaviors could not be preserved exactly, both because the old code did not wait on the clipboard promise:

- `ErrorDetailHeader` and `CopyButton` previously showed the confirmation state unconditionally, including when the write failed. They now show it only on success.
- `StatusPagesClient` previously showed the "Link copied" success toast unconditionally, again including on failure. It now shows that toast only on success, and a new `actions.linkCopyFailed` toast otherwise. That key is the only new string, added to all four locale files.

Success paths are unchanged everywhere, and `writeText` is still called synchronously inside the click handler at every site, so the browser user-gesture requirement still holds.

The hook also adds unmount cleanup of the reset timer, which four of the five inlined versions lacked.
