### PR TITLE
Add CI check for duplicate ClickHouse migration versions

### DIFF
--- a/.github/workflows/main-migration-check.yml
+++ b/.github/workflows/main-migration-check.yml
@@ -1,0 +1,28 @@
+name: Main Migration Check
+
+# Backstop for stale merges: a PR's own check runs against main as it stood at
+# check time, so a migration merged to main afterwards can collide unnoticed.
+# This re-runs the check on main's actual state after every merge that touches
+# migrations, turning main red immediately instead of failing at deploy time.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "migrations/**"
+
+permissions:
+  contents: read
+
+jobs:
+  check-migrations:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Verify migration version numbers are unique
+        run: node scripts/check-migration-versions.js

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -17,6 +17,7 @@ jobs:
       docs: ${{ steps.changes.outputs.docs }}
       tracking-script: ${{ steps.changes.outputs.tracking-script }}
       translations: ${{ steps.changes.outputs.translations }}
+      migrations: ${{ steps.changes.outputs.migrations }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -35,6 +36,8 @@ jobs:
               - 'static/analytics.js'
             translations:
               - 'dashboard/messages/*.json'
+            migrations:
+              - 'migrations/**'
 
   check-dashboard:
     needs: detect-changes
@@ -230,3 +233,17 @@ jobs:
 
       - name: Verify translation keys against en.json
         run: node scripts/check-translations.js
+
+  check-migrations:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.migrations == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Verify migration version numbers are unique
+        run: node scripts/check-migration-versions.js

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "simulate": "node simulate-events.js",
     "performance": "k6 run -e TARGET_URL=http://localhost:3001/event -e VUS=100 -e DURATION=30s k6-perf-test.js",
     "unit-tests": "pnpm --filter dashboard unit-tests",
-    "check-translations": "node scripts/check-translations.js"
+    "check-translations": "node scripts/check-translations.js",
+    "check-migration-versions": "node scripts/check-migration-versions.js"
   },
   "packageManager": "pnpm@10.34.5",
   "dependencies": {

--- a/scripts/check-migration-versions.js
+++ b/scripts/check-migration-versions.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+
+// Mirrors how clickhouse-migrations derives a version from a file name, since that
+// is what ends up as the primary key in the _migrations table.
+function parseVersion(file) {
+  return Number(file.split("_")[0]);
+}
+
+function main() {
+  const repoRoot = path.resolve(__dirname, "..");
+  const migrationsDir = path.join(repoRoot, "migrations");
+
+  if (!fs.existsSync(migrationsDir)) {
+    console.error("Migrations directory not found:", migrationsDir);
+    process.exit(1);
+  }
+
+  const files = fs
+    .readdirSync(migrationsDir)
+    .filter((f) => f.endsWith(".sql"))
+    .sort();
+
+  if (files.length === 0) {
+    console.error("No .sql migrations found in:", migrationsDir);
+    process.exit(1);
+  }
+
+  const byVersion = new Map();
+  const unparseable = [];
+
+  for (const file of files) {
+    const version = parseVersion(file);
+    if (!Number.isInteger(version) || version <= 0) {
+      unparseable.push(file);
+      continue;
+    }
+    const existing = byVersion.get(version);
+    if (existing) {
+      existing.push(file);
+    } else {
+      byVersion.set(version, [file]);
+    }
+  }
+
+  let failed = false;
+
+  if (unparseable.length > 0) {
+    failed = true;
+    console.error(
+      `\n${unparseable.length} migration file(s) do not start with a positive version number:`
+    );
+    for (const file of unparseable) console.error(`  - migrations/${file}`);
+    console.error(
+      "Migrations must be named <version>_<description>.sql, for example 40_add_widget.sql."
+    );
+  }
+
+  const duplicates = [...byVersion.entries()]
+    .filter(([, group]) => group.length > 1)
+    .sort(([a], [b]) => a - b);
+
+  for (const [version, group] of duplicates) {
+    failed = true;
+    console.error(`\nDuplicate migration version ${version}:`);
+    for (const file of group) console.error(`  - migrations/${file}`);
+  }
+
+  if (failed) {
+    if (duplicates.length > 0) {
+      console.error(
+        "\nThe migration runner keys applied migrations by version alone, so two files sharing" +
+          "\na version make it treat one as a modified copy of the other and abort every later run." +
+          "\nRenumber the newer migration to the next unused version."
+      );
+    }
+    process.exit(1);
+  }
+
+  const versions = [...byVersion.keys()].sort((a, b) => a - b);
+  console.log(
+    `Checked ${files.length} migration(s), versions ${versions[0]}-${
+      versions[versions.length - 1]
+    }: no duplicate version numbers.`
+  );
+}
+
+main();


### PR DESCRIPTION
Closes betterlytics/betterlytics-internal#185

## What

Adds a CI check that fails a PR when two ClickHouse migrations in the repo-root `migrations/` directory share a version-number prefix.

## Why

We shipped two migrations both numbered 37 (`37_events_insert_dedup_window.sql` and `37_usage_daily_by_type.sql`) and both applied in production. The migration runner (`clickhouse-migrations`) keys applied migrations by version alone, so the next run saw a checksum mismatch for version 37 and aborted — blocking every subsequent migration. A duplicate-prefix check at PR time catches this before merge.

## How

- `scripts/check-migration-versions.js` — a plain Node script in the same shape as the existing `scripts/check-translations.js`. It derives the version with `Number(file.split('_')[0])`, the exact rule the runner uses (`clickhouse-migrations/lib/migrate.js`), so what it considers a collision is what the runner considers a collision. It fails loudly, printing the colliding version and every filename that claims it, plus a one-line explanation of the consequence. It also rejects `.sql` files that do not start with a positive integer, since the runner refuses those too and they would otherwise slip past the duplicate check unexamined.
- `.github/workflows/pr-checks.yml` — adds a `migrations` path filter to the existing `detect-changes` job and a `check-migrations` job gated on it, mirroring the `check-translations` job (checkout, `setup-node@v4`, run the script; no `pnpm install`, since the script only uses `fs` and `path`).
- `package.json` — `pnpm check-migration-versions` for running it locally.

## Verification

- Ran the check against the clean tree: exits 0, `Checked 39 migration(s), versions 1-39: no duplicate version numbers.`
- Copied a migration to a colliding version 37, re-ran: exits 1, naming version 37 and both filenames. Deleted the temp file, re-ran: exits 0, `git status --porcelain` clean.
- Added a `.sql` file with an unparseable name: exits 1, naming the file. Removed.
- Parsed `pr-checks.yml` (and the nested `paths-filter` `filters` block) with a YAML parser — both parse, all 8 jobs and the new `migrations` output present.
- Nothing under `dashboard/` is touched, so the dashboard lint was not run.
