### PR TITLE
Removed the unused Prisma Accelerate extension

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -32,7 +32,6 @@
     "@number-flow/react": "^0.5.11",
     "@opentelemetry/api": "^1.9.1",
     "@prisma/client": "^6.8.2",
-    "@prisma/extension-accelerate": "^1.3.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-avatar": "^1.1.10",

--- a/dashboard/src/lib/postgres.ts
+++ b/dashboard/src/lib/postgres.ts
@@ -1,10 +1,9 @@
 import { PrismaClient } from '@prisma/client'
-import { withAccelerate } from '@prisma/extension-accelerate'
 
-const globalForPrisma = global as unknown as { prisma: unknown }
+const globalForPrisma = global as unknown as { prisma?: PrismaClient }
 
-const prisma = globalForPrisma.prisma || new PrismaClient().$extends(withAccelerate())
+const prisma = globalForPrisma.prisma || new PrismaClient()
 
 if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
 
-export default prisma as PrismaClient
+export default prisma

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,9 +71,6 @@ importers:
       '@prisma/client':
         specifier: ^6.8.2
         version: 6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3)
-      '@prisma/extension-accelerate':
-        specifier: ^1.3.0
-        version: 1.3.0(@prisma/client@6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3))
       '@radix-ui/react-accordion':
         specifier: ^1.2.12
         version: 1.2.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1804,12 +1801,6 @@ packages:
 
   '@prisma/engines@6.19.3':
     resolution: {integrity: sha512-RSYxtlYFl5pJ8ZePgMv0lZ9IzVCOdTPOegrs2qcbAEFrBI1G33h6wyC9kjQvo0DnYEhEVY0X4LsuFHXLKQk88g==}
-
-  '@prisma/extension-accelerate@1.3.0':
-    resolution: {integrity: sha512-W41D+kWejVJvMFEh45oYIU0VY+lIE3hh5vyHLHxgpyOfF+EHzSr8EIPT9kPRJg1FTYR7WGutXi64nyaNFUJ06A==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      '@prisma/client': '>=4.16.1'
 
   '@prisma/fetch-engine@6.19.3':
     resolution: {integrity: sha512-tKtl/qco9Nt7LU5iKhpultD8O4vMCZcU2CHjNTnRrL1QvSUr5W/GcyFPjNL87GtRrwBc7ubXXD9xy4EvLvt8JA==}
@@ -8360,10 +8351,6 @@ snapshots:
       '@prisma/engines-version': 7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7
       '@prisma/fetch-engine': 6.19.3
       '@prisma/get-platform': 6.19.3
-
-  '@prisma/extension-accelerate@1.3.0(@prisma/client@6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3))':
-    dependencies:
-      '@prisma/client': 6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3)
 
   '@prisma/fetch-engine@6.19.3':
     dependencies:


### PR DESCRIPTION
## Summary

The Prisma client was wrapped in the Accelerate extension, which only engages on a `prisma://` connection string. We connect straight to our own Postgres over `postgresql://`, and nothing in the codebase uses `cacheStrategy`, so the extension was a per-query pass-through plus an eager engine start. With it gone the exported client is a plain `PrismaClient` again, so the `as PrismaClient` cast that existed only to hide the extension's modified type is removed and the dev global cache is typed instead of `unknown`.

Closes betterlytics/betterlytics-internal#67

## Reviewer notes

No self-host impact. Routing to Accelerate is decided by the connection string in Prisma core, not by this extension, and the stack cannot boot on an Accelerate-only URL anyway (`prisma migrate deploy`, role provisioning and the Rust backend all need the raw Postgres wire protocol). Prisma's hosted Postgres hands out direct `postgresql://` URLs, which a plain client handles fine.

## Verification

Unit tests, lint and build pass, and a read plus an update through the exported client succeed against a dev worktree Postgres. Sign-in was not exercised through the browser in this run.
