### PR TITLE
Extracted shared BASiteQuery builder for MCP tools

### DIFF
--- a/dashboard/src/mcp/tools/errors.ts
+++ b/dashboard/src/mcp/tools/errors.ts
@@ -6,6 +6,7 @@ import {
   dateOrderRefinement,
 } from '@/mcp/entities/mcp.entities';
 import { resolveTimeRange } from '@/mcp/utils/resolveTimeRange';
+import { buildSiteQuery } from '@/mcp/utils/buildSiteQuery';
 import {
   getErrorGroupForSite,
   getErrorGroupsForSite,
@@ -13,7 +14,6 @@ import {
   getErrorOccurrenceForSite,
   getSessionTrailForSite,
 } from '@/services/analytics/errors.service';
-import type { BASiteQuery } from '@/entities/analytics/analyticsQuery.entities';
 import type { ErrorGroupRow } from '@/entities/analytics/errors.entities';
 
 export const McpListErrorsInputBaseSchema = McpDateRangeSchema.extend({
@@ -73,20 +73,15 @@ export async function executeListErrors(rawInput: unknown, siteId: string, dashb
     return lookupByFingerprint(siteId, dashboardId, input.fingerprint);
   }
 
-  const { startDateTime, endDateTime, start, end } = resolveTimeRange(input);
+  const timeRange = resolveTimeRange(input);
   const filters = (input.filters ?? []).map((f, i) => ({ ...f, id: `mcp_filter_${i}` }));
 
-  const siteQuery: BASiteQuery = {
+  const siteQuery = buildSiteQuery({
     siteId,
-    startDate: start,
-    endDate: end,
-    startDateTime,
-    endDateTime,
-    granularity: 'day',
-    queryFilters: filters,
+    timeRange,
     timezone: input.timezone,
-    userJourney: { numberOfSteps: 3, numberOfJourneys: 50 },
-  };
+    queryFilters: filters,
+  });
 
   let groups = await getErrorGroupsForSite(siteQuery, dashboardId);
 

--- a/dashboard/src/mcp/tools/globalProperties.ts
+++ b/dashboard/src/mcp/tools/globalProperties.ts
@@ -5,13 +5,13 @@ import {
   dateOrderRefinement,
 } from '@/mcp/entities/mcp.entities';
 import { resolveTimeRange } from '@/mcp/utils/resolveTimeRange';
+import { buildSiteQuery } from '@/mcp/utils/buildSiteQuery';
 import {
   getTopGlobalPropertyKeys,
   getTopGlobalPropertyValuesForKeys,
 } from '@/repositories/clickhouse/globalProperties.repository';
 import { FilterColumnSchema } from '@/entities/analytics/filter.entities';
 import { PROPERTY_SOURCES } from '@/entities/analytics/propertySources';
-import type { BASiteQuery } from '@/entities/analytics/analyticsQuery.entities';
 
 const GP_PREFIX = PROPERTY_SOURCES.gp.prefix;
 
@@ -35,19 +35,9 @@ export const McpListGlobalPropertiesInputSchema = McpListGlobalPropertiesInputBa
 
 export async function executeListGlobalProperties(rawInput: unknown, siteId: string) {
   const input = McpListGlobalPropertiesInputSchema.parse(rawInput);
-  const { startDateTime, endDateTime, start, end } = resolveTimeRange(input);
+  const timeRange = resolveTimeRange(input);
 
-  const siteQuery: BASiteQuery = {
-    siteId,
-    startDate: start,
-    endDate: end,
-    startDateTime,
-    endDateTime,
-    granularity: 'day',
-    queryFilters: [],
-    timezone: input.timezone ?? 'UTC',
-    userJourney: { numberOfSteps: 1, numberOfJourneys: 1 },
-  };
+  const siteQuery = buildSiteQuery({ siteId, timeRange, timezone: input.timezone });
 
   if (input.key) {
     const bareKey = input.key.startsWith(GP_PREFIX) ? input.key.slice(GP_PREFIX.length) : input.key;

--- a/dashboard/src/mcp/tools/userJourneys.ts
+++ b/dashboard/src/mcp/tools/userJourneys.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 import { McpDateRangeSchema, McpFiltersSchema, customDateRangeRefinement, dateOrderRefinement } from '@/mcp/entities/mcp.entities';
 import { resolveTimeRange } from '@/mcp/utils/resolveTimeRange';
+import { buildSiteQuery } from '@/mcp/utils/buildSiteQuery';
 import { getUserJourneyForSankeyDiagram } from '@/services/analytics/userJourney.service';
-import { BASiteQuery } from '@/entities/analytics/analyticsQuery.entities';
 
 export const McpUserJourneysInputBaseSchema = McpDateRangeSchema.extend({
   filters: McpFiltersSchema,
@@ -30,21 +30,17 @@ export const McpUserJourneysInputSchema = McpUserJourneysInputBaseSchema
 
 export async function executeUserJourneys(rawInput: unknown, siteId: string) {
   const input = McpUserJourneysInputSchema.parse(rawInput);
-  const { startDateTime, endDateTime, start, end } = resolveTimeRange(input);
+  const timeRange = resolveTimeRange(input);
 
   const filters = (input.filters ?? []).map((f, i) => ({ ...f, id: `mcp_filter_${i}` }));
 
-  const siteQuery: BASiteQuery = {
+  const siteQuery = buildSiteQuery({
     siteId,
-    startDate: start,
-    endDate: end,
-    startDateTime,
-    endDateTime,
-    granularity: 'day',
-    queryFilters: filters,
+    timeRange,
     timezone: input.timezone,
+    queryFilters: filters,
     userJourney: { numberOfSteps: input.maxSteps, numberOfJourneys: input.limit },
-  };
+  });
 
   return getUserJourneyForSankeyDiagram(siteQuery, input.maxSteps, input.limit);
 }

--- a/dashboard/src/mcp/utils/buildSiteQuery.test.ts
+++ b/dashboard/src/mcp/utils/buildSiteQuery.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { buildSiteQuery } from '@/mcp/utils/buildSiteQuery';
+import type { ResolvedTimeRange } from '@/mcp/utils/resolveTimeRange';
+import type { QueryFilter } from '@/entities/analytics/filter.entities';
+
+const timeRange: ResolvedTimeRange = {
+  start: new Date('2026-01-01T00:00:00Z'),
+  end: new Date('2026-01-31T23:59:59Z'),
+  startDateTime: '2026-01-01 00:00:00',
+  endDateTime: '2026-01-31 23:59:59',
+};
+
+describe('buildSiteQuery', () => {
+  it('maps site id and resolved time range onto the query', () => {
+    const query = buildSiteQuery({ siteId: 'site-1', timeRange, timezone: 'Europe/Berlin' });
+
+    expect(query).toMatchObject({
+      siteId: 'site-1',
+      startDate: timeRange.start,
+      endDate: timeRange.end,
+      startDateTime: '2026-01-01 00:00:00',
+      endDateTime: '2026-01-31 23:59:59',
+      timezone: 'Europe/Berlin',
+    });
+  });
+
+  it('defaults granularity, filters and user journey', () => {
+    const query = buildSiteQuery({ siteId: 'site-1', timeRange, timezone: 'UTC' });
+
+    expect(query.granularity).toBe('day');
+    expect(query.queryFilters).toEqual([]);
+    expect(query.userJourney).toEqual({ numberOfSteps: 3, numberOfJourneys: 50 });
+  });
+
+  it('defaults timezone to UTC when omitted', () => {
+    expect(buildSiteQuery({ siteId: 'site-1', timeRange }).timezone).toBe('UTC');
+  });
+
+  it('applies overrides for fields the caller genuinely uses', () => {
+    const queryFilters: QueryFilter[] = [
+      { id: 'mcp_filter_0', column: 'url', operator: '=', values: ['/pricing'] },
+    ];
+
+    const query = buildSiteQuery({
+      siteId: 'site-1',
+      timeRange,
+      timezone: 'UTC',
+      granularity: 'hour',
+      queryFilters,
+      userJourney: { numberOfSteps: 5, numberOfJourneys: 100 },
+    });
+
+    expect(query.granularity).toBe('hour');
+    expect(query.queryFilters).toEqual(queryFilters);
+    expect(query.userJourney).toEqual({ numberOfSteps: 5, numberOfJourneys: 100 });
+  });
+
+  it('does not share the default user journey object between queries', () => {
+    const first = buildSiteQuery({ siteId: 'site-1', timeRange });
+    const second = buildSiteQuery({ siteId: 'site-2', timeRange });
+
+    expect(first.userJourney).not.toBe(second.userJourney);
+  });
+});

--- a/dashboard/src/mcp/utils/buildSiteQuery.ts
+++ b/dashboard/src/mcp/utils/buildSiteQuery.ts
@@ -1,0 +1,39 @@
+import type { BASiteQuery } from '@/entities/analytics/analyticsQuery.entities';
+import type { ResolvedTimeRange } from '@/mcp/utils/resolveTimeRange';
+
+type BuildSiteQueryInput = {
+  siteId: string;
+  timeRange: ResolvedTimeRange;
+  timezone?: string;
+  granularity?: BASiteQuery['granularity'];
+  queryFilters?: BASiteQuery['queryFilters'];
+  userJourney?: BASiteQuery['userJourney'];
+};
+
+const DEFAULT_GRANULARITY: BASiteQuery['granularity'] = 'day';
+const DEFAULT_TIMEZONE = 'UTC';
+
+// BASiteQuery requires userJourney, but only the user_journeys tool reads it. Every other
+// tool gets this filler, so the dummy values live here instead of in each tool.
+const DEFAULT_USER_JOURNEY: BASiteQuery['userJourney'] = { numberOfSteps: 3, numberOfJourneys: 50 };
+
+export function buildSiteQuery({
+  siteId,
+  timeRange,
+  timezone,
+  granularity,
+  queryFilters,
+  userJourney,
+}: BuildSiteQueryInput): BASiteQuery {
+  return {
+    siteId,
+    startDate: timeRange.start,
+    endDate: timeRange.end,
+    startDateTime: timeRange.startDateTime,
+    endDateTime: timeRange.endDateTime,
+    granularity: granularity ?? DEFAULT_GRANULARITY,
+    queryFilters: queryFilters ?? [],
+    timezone: timezone ?? DEFAULT_TIMEZONE,
+    userJourney: userJourney ?? { ...DEFAULT_USER_JOURNEY },
+  };
+}

--- a/dashboard/src/mcp/utils/resolveTimeRange.ts
+++ b/dashboard/src/mcp/utils/resolveTimeRange.ts
@@ -9,7 +9,7 @@ type ResolveTimeRangeInput = {
   timezone?: string;
 };
 
-type ResolvedTimeRange = {
+export type ResolvedTimeRange = {
   startDateTime: string;
   endDateTime: string;
   start: Date;


### PR DESCRIPTION
MCP tools each hand-built a `BASiteQuery` and filled dummy values for the fields they never read. `buildSiteQuery` in `src/mcp/utils/` now owns those defaults (granularity, queryFilters, userJourney, timezone), and `errors.ts`, `globalProperties.ts` and `userJourneys.ts` call it instead. New tools no longer copy the boilerplate, and a `BASiteQuery` field change touches one place.

Closes betterlytics/betterlytics-internal#8

Spec item 4 (making `userJourney` optional on `BASiteQuery` itself) was left out on purpose. It was flagged as an optional follow-up in the ticket and is a wider entity change than this cleanup.

Reviewer notes: no effective query values change. `user_journeys` still passes its real `maxSteps` and `limit`. The only literal difference is `list_global_properties`, whose filler `userJourney` goes from `{1, 1}` to the shared default `{3, 50}`; neither the global-properties repository nor the errors service reads `userJourney`, so the emitted queries are identical.
