### PR TITLE
Locked resend verification email to the signed-in account

### DIFF
--- a/dashboard/messages/da.json
+++ b/dashboard/messages/da.json
@@ -3296,6 +3296,7 @@
     "termsOfServiceRequired": "Du skal acceptere servicevilkårene for at fortsætte.",
     "urlMustBeOnDomain": "URL skal være på {domain} eller et underdomæne",
     "monitorAlreadyExists": "En monitor for denne URL eksisterer allerede",
+    "verificationEmailCooldown": "{minutes, plural, one {Vent venligst # minut, før du anmoder om en ny bekræftelsesmail.} other {Vent venligst # minutter, før du anmoder om en ny bekræftelsesmail.}}",
     "statusPageSlugTaken": "Denne URL-slug er allerede i brug",
     "statusPageDomainTaken": "Dette domæne er allerede i brug på en anden statusside",
     "statusPageDomainReserved": "Dette domæne er reserveret",

--- a/dashboard/messages/da.json
+++ b/dashboard/messages/da.json
@@ -3296,6 +3296,7 @@
     "termsOfServiceRequired": "Du skal acceptere servicevilkårene for at fortsætte.",
     "urlMustBeOnDomain": "URL skal være på {domain} eller et underdomæne",
     "monitorAlreadyExists": "En monitor for denne URL eksisterer allerede",
+    "emailAlreadyVerified": "Din e-mail er allerede bekræftet.",
     "verificationEmailCooldown": "{minutes, plural, one {Vent venligst # minut, før du anmoder om en ny bekræftelsesmail.} other {Vent venligst # minutter, før du anmoder om en ny bekræftelsesmail.}}",
     "statusPageSlugTaken": "Denne URL-slug er allerede i brug",
     "statusPageDomainTaken": "Dette domæne er allerede i brug på en anden statusside",

--- a/dashboard/messages/en.json
+++ b/dashboard/messages/en.json
@@ -3293,6 +3293,7 @@
     "termsOfServiceRequired": "You must accept the terms of service to continue.",
     "urlMustBeOnDomain": "URL must be on {domain} or a subdomain",
     "monitorAlreadyExists": "A monitor for this URL already exists",
+    "verificationEmailCooldown": "{minutes, plural, one {Please wait # minute before requesting another verification email.} other {Please wait # minutes before requesting another verification email.}}",
     "statusPageSlugTaken": "This URL slug is already in use",
     "statusPageDomainTaken": "This domain is already in use on another status page",
     "statusPageDomainReserved": "This domain is reserved",

--- a/dashboard/messages/en.json
+++ b/dashboard/messages/en.json
@@ -3293,6 +3293,7 @@
     "termsOfServiceRequired": "You must accept the terms of service to continue.",
     "urlMustBeOnDomain": "URL must be on {domain} or a subdomain",
     "monitorAlreadyExists": "A monitor for this URL already exists",
+    "emailAlreadyVerified": "Your email is already verified.",
     "verificationEmailCooldown": "{minutes, plural, one {Please wait # minute before requesting another verification email.} other {Please wait # minutes before requesting another verification email.}}",
     "statusPageSlugTaken": "This URL slug is already in use",
     "statusPageDomainTaken": "This domain is already in use on another status page",

--- a/dashboard/messages/it.json
+++ b/dashboard/messages/it.json
@@ -3296,6 +3296,7 @@
     "termsOfServiceRequired": "Devi accettare i termini di servizio per continuare.",
     "urlMustBeOnDomain": "L'URL deve essere su {domain} o un sottodominio",
     "monitorAlreadyExists": "Esiste già un monitor per questo URL",
+    "emailAlreadyVerified": "La tua email è già verificata.",
     "verificationEmailCooldown": "{minutes, plural, one {Attendi # minuto prima di richiedere un'altra email di verifica.} other {Attendi # minuti prima di richiedere un'altra email di verifica.}}",
     "statusPageSlugTaken": "Questo slug URL è già in uso",
     "statusPageDomainTaken": "Questo dominio è già in uso su un'altra pagina di stato",

--- a/dashboard/messages/it.json
+++ b/dashboard/messages/it.json
@@ -3296,6 +3296,7 @@
     "termsOfServiceRequired": "Devi accettare i termini di servizio per continuare.",
     "urlMustBeOnDomain": "L'URL deve essere su {domain} o un sottodominio",
     "monitorAlreadyExists": "Esiste già un monitor per questo URL",
+    "verificationEmailCooldown": "{minutes, plural, one {Attendi # minuto prima di richiedere un'altra email di verifica.} other {Attendi # minuti prima di richiedere un'altra email di verifica.}}",
     "statusPageSlugTaken": "Questo slug URL è già in uso",
     "statusPageDomainTaken": "Questo dominio è già in uso su un'altra pagina di stato",
     "statusPageDomainReserved": "Questo dominio è riservato",

--- a/dashboard/messages/nb.json
+++ b/dashboard/messages/nb.json
@@ -3296,6 +3296,7 @@
     "termsOfServiceRequired": "Du må godta vilkårene for å fortsette.",
     "urlMustBeOnDomain": "URL-en må være på {domain} eller et underdomene",
     "monitorAlreadyExists": "En monitor for denne URL-en finnes allerede",
+    "verificationEmailCooldown": "{minutes, plural, one {Vent # minutt før du ber om en ny bekreftelses-e-post.} other {Vent # minutter før du ber om en ny bekreftelses-e-post.}}",
     "statusPageSlugTaken": "Denne URL-sluggen er allerede i bruk",
     "statusPageDomainTaken": "Dette domenet er allerede i bruk på en annen statusside",
     "statusPageDomainReserved": "Dette domenet er reservert",

--- a/dashboard/messages/nb.json
+++ b/dashboard/messages/nb.json
@@ -3296,6 +3296,7 @@
     "termsOfServiceRequired": "Du må godta vilkårene for å fortsette.",
     "urlMustBeOnDomain": "URL-en må være på {domain} eller et underdomene",
     "monitorAlreadyExists": "En monitor for denne URL-en finnes allerede",
+    "emailAlreadyVerified": "E-posten din er allerede bekreftet.",
     "verificationEmailCooldown": "{minutes, plural, one {Vent # minutt før du ber om en ny bekreftelses-e-post.} other {Vent # minutter før du ber om en ny bekreftelses-e-post.}}",
     "statusPageSlugTaken": "Denne URL-sluggen er allerede i bruk",
     "statusPageDomainTaken": "Dette domenet er allerede i bruk på en annen statusside",

--- a/dashboard/src/app/actions/auth/verification.action.test.ts
+++ b/dashboard/src/app/actions/auth/verification.action.test.ts
@@ -35,9 +35,9 @@ vi.mock('@/services/dashboard/verification.service', () => ({
 const SESSION_EMAIL = 'owner@example.com';
 const OTHER_EMAIL = 'victim@example.com';
 
-function signIn(email = SESSION_EMAIL) {
+function signIn(emailVerified = false) {
   vi.mocked(getCachedSession).mockResolvedValue({
-    user: makeUser({ email, emailVerified: false }),
+    user: makeUser({ email: SESSION_EMAIL, emailVerified }),
     session: { token: 'token', expiresAt: new Date(Date.now() + 60_000) },
   } as never);
 }
@@ -80,6 +80,19 @@ describe('resendVerificationEmailAction', () => {
 
     expect(checkRateLimit).toHaveBeenCalledWith(SESSION_EMAIL);
     expect(sendVerificationEmail).toHaveBeenCalledWith({ email: SESSION_EMAIL });
+  });
+
+  it('tells an already verified user instead of sending', async () => {
+    signIn(true);
+
+    const result = await resendVerificationEmailAction();
+
+    expect(result).toMatchObject({
+      success: false,
+      error: { message: 'emailAlreadyVerified' },
+    });
+    expect(checkRateLimit).not.toHaveBeenCalled();
+    expect(sendVerificationEmail).not.toHaveBeenCalled();
   });
 
   it('reports the remaining cooldown instead of sending', async () => {

--- a/dashboard/src/app/actions/auth/verification.action.test.ts
+++ b/dashboard/src/app/actions/auth/verification.action.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { addMinutes } from 'date-fns';
+import { getCachedSession } from '@/auth/api-auth';
+import { checkRateLimit, sendVerificationEmail } from '@/services/account/verification.service';
+import { resendVerificationEmailAction } from '@/app/actions/auth/verification.action';
+import { makeUser } from '@/test/auth-fixtures';
+
+vi.mock('@/lib/env', () => ({
+  env: {
+    DEMO_DASHBOARD_ID: undefined,
+  },
+}));
+vi.mock('@/auth/api-auth', () => ({
+  getCachedSession: vi.fn(),
+  getCachedAuthorizedContext: vi.fn(),
+  resolveDemoDashboardContext: vi.fn(),
+  executeWithDemoCache: vi.fn(),
+  getFnSignature: vi.fn(() => 'test-signature'),
+}));
+vi.mock('@/services/account/verification.service', () => ({
+  checkRateLimit: vi.fn(),
+  sendVerificationEmail: vi.fn(),
+  verifyEmail: vi.fn(),
+}));
+vi.mock('@/services/dashboard/verification.service', () => ({
+  checkTrackingDataExists: vi.fn(),
+}));
+
+const SESSION_EMAIL = 'owner@example.com';
+const OTHER_EMAIL = 'victim@example.com';
+
+function signIn(email = SESSION_EMAIL) {
+  vi.mocked(getCachedSession).mockResolvedValue({
+    user: makeUser({ email, emailVerified: false }),
+    session: { token: 'token', expiresAt: new Date(Date.now() + 60_000) },
+  } as never);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.mocked(checkRateLimit).mockResolvedValue({ allowed: true });
+});
+
+describe('resendVerificationEmailAction', () => {
+  it('redirects to sign-in without a session, revealing nothing about any account', async () => {
+    vi.mocked(getCachedSession).mockResolvedValue(null);
+
+    const error = await resendVerificationEmailAction().then(
+      () => null,
+      (e: { digest?: string }) => e,
+    );
+
+    expect(error?.digest).toContain('NEXT_REDIRECT');
+    expect(error?.digest).toContain('/signin');
+    expect(checkRateLimit).not.toHaveBeenCalled();
+    expect(sendVerificationEmail).not.toHaveBeenCalled();
+  });
+
+  it('mails the session user', async () => {
+    signIn();
+
+    const result = await resendVerificationEmailAction();
+
+    expect(result.success).toBe(true);
+    expect(checkRateLimit).toHaveBeenCalledWith(SESSION_EMAIL);
+    expect(sendVerificationEmail).toHaveBeenCalledWith({ email: SESSION_EMAIL });
+  });
+
+  it('ignores a client-supplied email', async () => {
+    signIn();
+
+    await Reflect.apply(resendVerificationEmailAction, undefined, [{ email: OTHER_EMAIL }]);
+
+    expect(checkRateLimit).toHaveBeenCalledWith(SESSION_EMAIL);
+    expect(sendVerificationEmail).toHaveBeenCalledWith({ email: SESSION_EMAIL });
+  });
+
+  it('reports the remaining cooldown instead of sending', async () => {
+    signIn();
+    vi.mocked(checkRateLimit).mockResolvedValue({
+      allowed: false,
+      nextAllowedAt: addMinutes(new Date(), 3),
+    });
+
+    const result = await resendVerificationEmailAction();
+
+    expect(result).toMatchObject({
+      success: false,
+      error: { message: 'Please wait 3 minutes before requesting another verification email.' },
+    });
+    expect(sendVerificationEmail).not.toHaveBeenCalled();
+  });
+
+  it('keeps send failures out of the client response', async () => {
+    signIn();
+    vi.mocked(sendVerificationEmail).mockRejectedValue(new Error('User not found'));
+
+    const result = await resendVerificationEmailAction();
+
+    expect(result.success).toBe(false);
+    expect(JSON.stringify(result)).not.toContain('User not found');
+  });
+});

--- a/dashboard/src/app/actions/auth/verification.action.test.ts
+++ b/dashboard/src/app/actions/auth/verification.action.test.ts
@@ -5,6 +5,12 @@ import { checkRateLimit, sendVerificationEmail } from '@/services/account/verifi
 import { resendVerificationEmailAction } from '@/app/actions/auth/verification.action';
 import { makeUser } from '@/test/auth-fixtures';
 
+vi.mock('next-intl/server', () => ({
+  getTranslations: vi.fn(
+    async () => (key: string, values?: Record<string, unknown>) =>
+      values ? `${key} ${JSON.stringify(values)}` : key,
+  ),
+}));
 vi.mock('@/lib/env', () => ({
   env: {
     DEMO_DASHBOARD_ID: undefined,
@@ -87,7 +93,7 @@ describe('resendVerificationEmailAction', () => {
 
     expect(result).toMatchObject({
       success: false,
-      error: { message: 'Please wait 3 minutes before requesting another verification email.' },
+      error: { message: 'verificationEmailCooldown {"minutes":3}' },
     });
     expect(sendVerificationEmail).not.toHaveBeenCalled();
   });

--- a/dashboard/src/app/actions/auth/verification.action.test.ts
+++ b/dashboard/src/app/actions/auth/verification.action.test.ts
@@ -76,7 +76,8 @@ describe('resendVerificationEmailAction', () => {
   it('ignores a client-supplied email', async () => {
     signIn();
 
-    await Reflect.apply(resendVerificationEmailAction, undefined, [{ email: OTHER_EMAIL }]);
+    // @ts-expect-error the action must ignore a client-supplied email
+    await resendVerificationEmailAction({ email: OTHER_EMAIL });
 
     expect(checkRateLimit).toHaveBeenCalledWith(SESSION_EMAIL);
     expect(sendVerificationEmail).toHaveBeenCalledWith({ email: SESSION_EMAIL });

--- a/dashboard/src/app/actions/auth/verification.action.ts
+++ b/dashboard/src/app/actions/auth/verification.action.ts
@@ -34,6 +34,10 @@ export async function verifyEmailAction(data: VerifyEmailData): Promise<Verifica
 }
 
 export const resendVerificationEmailAction = withUserAuth(async (user: User): Promise<void> => {
+  if (user.emailVerified) {
+    throw new UserException((await getTranslations('validation'))('emailAlreadyVerified'));
+  }
+
   const rateLimitCheck = await checkRateLimit(user.email);
 
   if (!rateLimitCheck.allowed && rateLimitCheck.nextAllowedAt) {

--- a/dashboard/src/app/actions/auth/verification.action.ts
+++ b/dashboard/src/app/actions/auth/verification.action.ts
@@ -1,5 +1,6 @@
 'use server';
 
+import { getTranslations } from 'next-intl/server';
 import { withDashboardAuthContext, withUserAuth } from '@/auth/auth-actions';
 import { AuthContext } from '@/entities/auth/authContext.entities';
 import type { User } from '@/entities/auth/session.entities';
@@ -37,7 +38,7 @@ export const resendVerificationEmailAction = withUserAuth(async (user: User): Pr
 
   if (!rateLimitCheck.allowed && rateLimitCheck.nextAllowedAt) {
     const waitTime = Math.max(1, Math.ceil((rateLimitCheck.nextAllowedAt.getTime() - Date.now()) / 60000));
-    throw new UserException(`Please wait ${waitTime} minutes before requesting another verification email.`);
+    throw new UserException((await getTranslations('validation'))('verificationEmailCooldown', { minutes: waitTime }));
   }
 
   await sendVerificationEmail({ email: user.email });

--- a/dashboard/src/app/actions/auth/verification.action.ts
+++ b/dashboard/src/app/actions/auth/verification.action.ts
@@ -1,17 +1,12 @@
 'use server';
 
-import { withDashboardAuthContext } from '@/auth/auth-actions';
+import { withDashboardAuthContext, withUserAuth } from '@/auth/auth-actions';
 import { AuthContext } from '@/entities/auth/authContext.entities';
+import type { User } from '@/entities/auth/session.entities';
+import { UserException } from '@/lib/exceptions';
 import { checkTrackingDataExists } from '@/services/dashboard/verification.service';
-import { checkRateLimit } from '@/services/account/verification.service';
-import {
-  SendVerificationEmailData,
-  SendVerificationEmailSchema,
-  VerifyEmailData,
-  VerifyEmailSchema,
-  VerificationResult,
-} from '@/entities/account/verification.entities';
-import { sendVerificationEmail, verifyEmail } from '@/services/account/verification.service';
+import { VerifyEmailData, VerifyEmailSchema, VerificationResult } from '@/entities/account/verification.entities';
+import { checkRateLimit, sendVerificationEmail, verifyEmail } from '@/services/account/verification.service';
 
 export const verifyTrackingInstallation = withDashboardAuthContext(async (ctx: AuthContext): Promise<boolean> => {
   const { siteId } = ctx;
@@ -37,28 +32,17 @@ export async function verifyEmailAction(data: VerifyEmailData): Promise<Verifica
   }
 }
 
-export async function resendVerificationEmailAction(formData: SendVerificationEmailData) {
-  try {
-    const validatedData = SendVerificationEmailSchema.parse(formData);
-    const { email } = validatedData;
+/**
+ * The target address always comes from the session, never from the client. A client-chosen
+ * address would turn the per-address responses into an account-enumeration oracle.
+ */
+export const resendVerificationEmailAction = withUserAuth(async (user: User): Promise<void> => {
+  const rateLimitCheck = await checkRateLimit(user.email);
 
-    const rateLimitCheck = await checkRateLimit(email);
-
-    if (!rateLimitCheck.allowed && rateLimitCheck.nextAllowedAt) {
-      const waitTime = Math.ceil((rateLimitCheck.nextAllowedAt.getTime() - Date.now()) / 60000);
-      return {
-        success: false,
-        error: `Please wait ${waitTime} minutes before requesting another verification email.`,
-      };
-    }
-
-    await sendVerificationEmail({ email });
-    return { success: true };
-  } catch (error) {
-    console.error('Resend verification email action error:', error);
-    return {
-      success: false,
-      error: 'Failed to resend verification email',
-    };
+  if (!rateLimitCheck.allowed && rateLimitCheck.nextAllowedAt) {
+    const waitTime = Math.max(1, Math.ceil((rateLimitCheck.nextAllowedAt.getTime() - Date.now()) / 60000));
+    throw new UserException(`Please wait ${waitTime} minutes before requesting another verification email.`);
   }
-}
+
+  await sendVerificationEmail({ email: user.email });
+});

--- a/dashboard/src/app/actions/auth/verification.action.ts
+++ b/dashboard/src/app/actions/auth/verification.action.ts
@@ -32,10 +32,6 @@ export async function verifyEmailAction(data: VerifyEmailData): Promise<Verifica
   }
 }
 
-/**
- * The target address always comes from the session, never from the client. A client-chosen
- * address would turn the per-address responses into an account-enumeration oracle.
- */
 export const resendVerificationEmailAction = withUserAuth(async (user: User): Promise<void> => {
   const rateLimitCheck = await checkRateLimit(user.email);
 

--- a/dashboard/src/components/accountVerification/VerificationBanner.tsx
+++ b/dashboard/src/components/accountVerification/VerificationBanner.tsx
@@ -5,6 +5,7 @@ import { useBannerContext } from '@/contexts/BannerProvider';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
 import { resendVerificationEmailAction } from '@/app/actions/auth/verification.action';
+import { getUserFacingErrorMessage } from '@/middlewares/serverActionHandler';
 import { toast } from 'sonner';
 
 type VerificationBannerProps = {
@@ -46,7 +47,7 @@ export function VerificationBanner({ email, isVerified, showDismiss = true, id }
       if (result.success) {
         toast.success(t('success'));
       } else {
-        toast.error(result.error.name === 'UserException' ? result.error.message : t('failure'));
+        toast.error(getUserFacingErrorMessage(result.error, t('failure')));
       }
     } catch (error) {
       toast.error(t('failure'));

--- a/dashboard/src/components/accountVerification/VerificationBanner.tsx
+++ b/dashboard/src/components/accountVerification/VerificationBanner.tsx
@@ -46,8 +46,6 @@ export function VerificationBanner({ email, isVerified, showDismiss = true, id }
       if (result.success) {
         toast.success(t('success'));
       } else {
-        // Only user-safe exceptions carry a message worth showing; anything else is a
-        // masked internal error, so fall back to the localized copy.
         toast.error(result.error.name === 'UserException' ? result.error.message : t('failure'));
       }
     } catch (error) {

--- a/dashboard/src/components/accountVerification/VerificationBanner.tsx
+++ b/dashboard/src/components/accountVerification/VerificationBanner.tsx
@@ -42,11 +42,13 @@ export function VerificationBanner({ email, isVerified, showDismiss = true, id }
   const handleResendVerification = async () => {
     setIsSending(true);
     try {
-      const result = await resendVerificationEmailAction({ email });
+      const result = await resendVerificationEmailAction();
       if (result.success) {
         toast.success(t('success'));
       } else {
-        toast.error(result.error);
+        // Only user-safe exceptions carry a message worth showing; anything else is a
+        // masked internal error, so fall back to the localized copy.
+        toast.error(result.error.name === 'UserException' ? result.error.message : t('failure'));
       }
     } catch (error) {
       toast.error(t('failure'));

--- a/dashboard/src/components/accountVerification/VerificationRequiredModal.tsx
+++ b/dashboard/src/components/accountVerification/VerificationRequiredModal.tsx
@@ -35,8 +35,6 @@ export function VerificationRequiredModal({
           toast.success(t('toastSuccess'));
           setEmailSent(true);
         } else {
-          // Only user-safe exceptions carry a message worth showing; anything else is a
-          // masked internal error, so fall back to the localized copy.
           toast.error(result.error.name === 'UserException' ? result.error.message : t('toastFailure'));
         }
       } catch (error) {

--- a/dashboard/src/components/accountVerification/VerificationRequiredModal.tsx
+++ b/dashboard/src/components/accountVerification/VerificationRequiredModal.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition } from 'react';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { resendVerificationEmailAction } from '@/app/actions/auth/verification.action';
+import { getUserFacingErrorMessage } from '@/middlewares/serverActionHandler';
 import { toast } from 'sonner';
 import { ShieldCheck, Mail, CheckCircle } from 'lucide-react';
 import { getDisplayName } from '@/utils/userUtils';
@@ -35,7 +36,7 @@ export function VerificationRequiredModal({
           toast.success(t('toastSuccess'));
           setEmailSent(true);
         } else {
-          toast.error(result.error.name === 'UserException' ? result.error.message : t('toastFailure'));
+          toast.error(getUserFacingErrorMessage(result.error, t('toastFailure')));
         }
       } catch (error) {
         toast.error(t('toastFailure'));

--- a/dashboard/src/components/accountVerification/VerificationRequiredModal.tsx
+++ b/dashboard/src/components/accountVerification/VerificationRequiredModal.tsx
@@ -29,13 +29,15 @@ export function VerificationRequiredModal({
   const handleResendVerification = () => {
     startTransition(async () => {
       try {
-        const result = await resendVerificationEmailAction({ email: userEmail });
+        const result = await resendVerificationEmailAction();
 
         if (result.success) {
           toast.success(t('toastSuccess'));
           setEmailSent(true);
         } else {
-          toast.error(result.error);
+          // Only user-safe exceptions carry a message worth showing; anything else is a
+          // masked internal error, so fall back to the localized copy.
+          toast.error(result.error.name === 'UserException' ? result.error.message : t('toastFailure'));
         }
       } catch (error) {
         toast.error(t('toastFailure'));

--- a/dashboard/src/middlewares/serverActionHandler.ts
+++ b/dashboard/src/middlewares/serverActionHandler.ts
@@ -75,3 +75,14 @@ export function withServerAction<T, Args extends unknown[]>(handler: (...args: A
 function isUserException(error: unknown): error is UserException {
   return error instanceof UserException;
 }
+
+/**
+ * Only UserException messages are safe to show verbatim; anything else is a masked
+ * internal error, so callers get their localized fallback instead.
+ */
+export function getUserFacingErrorMessage(
+  error: Extract<ServerActionResponse, { success: false }>['error'],
+  fallback: string,
+): string {
+  return error.name === 'UserException' ? error.message : fallback;
+}


### PR DESCRIPTION
`resendVerificationEmailAction` now runs through `withUserAuth` and mails the session user's own address, ignoring anything the client sends. Before this it was callable with no session and with any email, and its replies (success vs. generic failure vs. "wait N minutes") told the caller whether an account existed and whether it was already verified.

Closes betterlytics/betterlytics-internal#82

Reviewer notes:

- The action's return type changed to the standard `ServerActionResponse` envelope, so both callers now read `result.error.message` instead of `result.error`. They only surface it when `error.name === 'UserException'`; anything else falls back to the existing localized copy, so masked internal errors never reach a toast in raw English.
- The 5 minute cooldown and its "wait N minutes" text are unchanged in behaviour, just delivered as a `UserException` (the only user-safe message left; every other failure is logged server side and comes back generic). One side effect worth knowing: `withActionSpan` treats every `UserException` as an errored span and logs it, so ordinary cooldown hits will now appear as error-level logs and errored `action.resendVerificationEmailAction` spans in Grafana. That is the existing convention for `UserException` across the codebase (same as `assertRoleAuthorized`), so it was left alone rather than special-cased here.
- Unauthenticated callers hit `requireAuth`'s redirect to /signin before any account lookup runs. That redirect is thrown outside `withActionSpan` and re-thrown by `unstable_rethrow`, so it reaches the client as a real redirect rather than a masked error.
- New colocated test at `dashboard/src/app/actions/auth/verification.action.test.ts` exercises the real `withUserAuth` chain (only `@/auth/api-auth` and the service layer are mocked), including the no-session case and the "a client-supplied email is ignored" regression guard.