### PR TITLE
Rate limited credential sign-in per account and surfaced throttling errors in the auth forms

### DIFF
--- a/dashboard/messages/da.json
+++ b/dashboard/messages/da.json
@@ -757,7 +757,7 @@
             "invalidOtp": "Ugyldig bekræftelseskode. Tjek dine oplysninger og prøv igen.",
             "invalidCredentials": "Ugyldig e-mail eller adgangskode. Tjek dine oplysninger og prøv igen.",
             "generic": "Der opstod en fejl under login. Prøv venligst igen.",
-            "tooManyAttempts": "For mange forsøg. Vent et par minutter og prøv igen."
+            "tooManyAttempts": "For mange forsøg. Prøv igen senere."
           },
           "twoFactor": {
             "title": "To-faktor-godkendelse",
@@ -3048,7 +3048,8 @@
           "passwordPromptDescription": "Indtast din adgangskode for at fortsætte.",
           "passwordLabel": "Adgangskode",
           "backupCodesTitle": "Backup-koder",
-          "backupCodesDescription": "Gem disse engangskoder et sikkert sted — de giver dig adgang, hvis du mister din authenticator."
+          "backupCodesDescription": "Gem disse engangskoder et sikkert sted — de giver dig adgang, hvis du mister din authenticator.",
+          "tooManyAttempts": "For mange forsøg. Vent et øjeblik og prøv igen."
         }
       },
       "sessions": {
@@ -3245,7 +3246,8 @@
         "passwordsDoNotMatch": "Adgangskoder matcher ikke",
         "registrationSuccessfulButSignInFailed": "Registrering lykkedes, men log ind mislykkedes. Prøv at logge ind manuelt.",
         "signUpError": "Der opstod en fejl under tilmelding. Prøv igen.",
-        "checkInput": "Tjek venligst dit input"
+        "checkInput": "Tjek venligst dit input",
+        "registrationSuccessfulButRateLimited": "Din konto blev oprettet, men login er midlertidigt begrænset. Prøv at logge ind igen om lidt."
       }
     },
     "website": {

--- a/dashboard/messages/da.json
+++ b/dashboard/messages/da.json
@@ -756,7 +756,8 @@
           "errors": {
             "invalidOtp": "Ugyldig bekræftelseskode. Tjek dine oplysninger og prøv igen.",
             "invalidCredentials": "Ugyldig e-mail eller adgangskode. Tjek dine oplysninger og prøv igen.",
-            "generic": "Der opstod en fejl under login. Prøv venligst igen."
+            "generic": "Der opstod en fejl under login. Prøv venligst igen.",
+            "tooManyAttempts": "For mange forsøg. Vent et par minutter og prøv igen."
           },
           "twoFactor": {
             "title": "To-faktor-godkendelse",

--- a/dashboard/messages/en.json
+++ b/dashboard/messages/en.json
@@ -756,7 +756,8 @@
           "errors": {
             "invalidOtp": "Invalid verification code. Please check your credentials and try again.",
             "invalidCredentials": "Invalid email or password. Please check your credentials and try again.",
-            "generic": "An error occurred during sign in. Please try again."
+            "generic": "An error occurred during sign in. Please try again.",
+            "tooManyAttempts": "Too many attempts. Please wait a few minutes and try again."
           },
           "twoFactor": {
             "title": "Two-factor authentication",

--- a/dashboard/messages/en.json
+++ b/dashboard/messages/en.json
@@ -757,7 +757,7 @@
             "invalidOtp": "Invalid verification code. Please check your credentials and try again.",
             "invalidCredentials": "Invalid email or password. Please check your credentials and try again.",
             "generic": "An error occurred during sign in. Please try again.",
-            "tooManyAttempts": "Too many attempts. Please wait a few minutes and try again."
+            "tooManyAttempts": "Too many attempts. Please try again later."
           },
           "twoFactor": {
             "title": "Two-factor authentication",
@@ -3045,7 +3045,8 @@
           "passwordPromptDescription": "Enter your account password to continue.",
           "passwordLabel": "Password",
           "backupCodesTitle": "Backup codes",
-          "backupCodesDescription": "Store these one-time codes somewhere safe — they let you sign in if you lose your authenticator."
+          "backupCodesDescription": "Store these one-time codes somewhere safe — they let you sign in if you lose your authenticator.",
+          "tooManyAttempts": "Too many attempts. Please wait a moment and try again."
         }
       },
       "sessions": {
@@ -3242,7 +3243,8 @@
         "passwordsDoNotMatch": "Passwords do not match",
         "registrationSuccessfulButSignInFailed": "Registration successful, but sign in failed. Please try signing in manually.",
         "signUpError": "An error occurred during sign up. Please try again.",
-        "checkInput": "Please check your input"
+        "checkInput": "Please check your input",
+        "registrationSuccessfulButRateLimited": "Your account was created, but sign-in is temporarily rate limited. Please try signing in again shortly."
       }
     },
     "website": {

--- a/dashboard/messages/it.json
+++ b/dashboard/messages/it.json
@@ -756,7 +756,8 @@
           "errors": {
             "invalidOtp": "Codice di verifica non valido. Controlla le tue credenziali e riprova.",
             "invalidCredentials": "Email o password non validi. Controlla le tue credenziali e riprova.",
-            "generic": "Si è verificato un errore durante l'accesso. Riprova."
+            "generic": "Si è verificato un errore durante l'accesso. Riprova.",
+            "tooManyAttempts": "Troppi tentativi. Attendi qualche minuto e riprova."
           },
           "twoFactor": {
             "title": "Autenticazione a due fattori",

--- a/dashboard/messages/it.json
+++ b/dashboard/messages/it.json
@@ -757,7 +757,7 @@
             "invalidOtp": "Codice di verifica non valido. Controlla le tue credenziali e riprova.",
             "invalidCredentials": "Email o password non validi. Controlla le tue credenziali e riprova.",
             "generic": "Si è verificato un errore durante l'accesso. Riprova.",
-            "tooManyAttempts": "Troppi tentativi. Attendi qualche minuto e riprova."
+            "tooManyAttempts": "Troppi tentativi. Riprova più tardi."
           },
           "twoFactor": {
             "title": "Autenticazione a due fattori",
@@ -3048,7 +3048,8 @@
           "passwordPromptDescription": "Inserisci la password del tuo account per continuare.",
           "passwordLabel": "Password",
           "backupCodesTitle": "Codici di backup",
-          "backupCodesDescription": "Conserva questi codici monouso in un luogo sicuro: ti permettono di accedere se perdi la tua app di autenticazione."
+          "backupCodesDescription": "Conserva questi codici monouso in un luogo sicuro: ti permettono di accedere se perdi la tua app di autenticazione.",
+          "tooManyAttempts": "Troppi tentativi. Attendi un momento e riprova."
         }
       },
       "sessions": {
@@ -3245,7 +3246,8 @@
         "passwordsDoNotMatch": "Le password non corrispondono",
         "registrationSuccessfulButSignInFailed": "Registrazione riuscita, ma accesso fallito. Prova ad accedere manualmente.",
         "signUpError": "Si è verificato un errore durante la registrazione. Riprova.",
-        "checkInput": "Controlla il tuo input"
+        "checkInput": "Controlla il tuo input",
+        "registrationSuccessfulButRateLimited": "Il tuo account è stato creato, ma l'accesso è temporaneamente limitato. Riprova ad accedere tra poco."
       }
     },
     "website": {

--- a/dashboard/messages/nb.json
+++ b/dashboard/messages/nb.json
@@ -757,7 +757,7 @@
             "invalidOtp": "Ugyldig verifiseringskode. Sjekk innloggingsdetaljene dine og prøv igjen.",
             "invalidCredentials": "Ugyldig e-post eller passord. Sjekk innloggingsdetaljene dine og prøv igjen.",
             "generic": "Det oppstod en feil under innlogging. Prøv igjen.",
-            "tooManyAttempts": "For mange forsøk. Vent noen minutter og prøv igjen."
+            "tooManyAttempts": "For mange forsøk. Prøv igjen senere."
           },
           "twoFactor": {
             "title": "Tofaktorautentisering",
@@ -3048,7 +3048,8 @@
           "passwordPromptDescription": "Skriv inn passordet ditt for å fortsette.",
           "passwordLabel": "Passord",
           "backupCodesTitle": "Sikkerhetskoder",
-          "backupCodesDescription": "Oppbevar disse engangskodene på et trygt sted — de lar deg logge inn hvis du mister autentiseringsappen."
+          "backupCodesDescription": "Oppbevar disse engangskodene på et trygt sted — de lar deg logge inn hvis du mister autentiseringsappen.",
+          "tooManyAttempts": "For mange forsøk. Vent et øyeblikk og prøv igjen."
         }
       },
       "sessions": {
@@ -3245,7 +3246,8 @@
         "passwordsDoNotMatch": "Passordene samsvarer ikke",
         "registrationSuccessfulButSignInFailed": "Registrering vellykket, men innlogging feilet. Prøv å logge inn manuelt.",
         "signUpError": "Det oppstod en feil under registrering. Prøv igjen.",
-        "checkInput": "Vennligst sjekk inndataene dine"
+        "checkInput": "Vennligst sjekk inndataene dine",
+        "registrationSuccessfulButRateLimited": "Kontoen din ble opprettet, men innlogging er midlertidig begrenset. Prøv å logge inn igjen om litt."
       }
     },
     "website": {

--- a/dashboard/messages/nb.json
+++ b/dashboard/messages/nb.json
@@ -756,7 +756,8 @@
           "errors": {
             "invalidOtp": "Ugyldig verifiseringskode. Sjekk innloggingsdetaljene dine og prøv igjen.",
             "invalidCredentials": "Ugyldig e-post eller passord. Sjekk innloggingsdetaljene dine og prøv igjen.",
-            "generic": "Det oppstod en feil under innlogging. Prøv igjen."
+            "generic": "Det oppstod en feil under innlogging. Prøv igjen.",
+            "tooManyAttempts": "For mange forsøk. Vent noen minutter og prøv igjen."
           },
           "twoFactor": {
             "title": "Tofaktorautentisering",

--- a/dashboard/src/app/(app)/[locale]/(signup)/signup/SignupForm.tsx
+++ b/dashboard/src/app/(app)/[locale]/(signup)/signup/SignupForm.tsx
@@ -117,7 +117,13 @@ export default function SignupForm({ providers }: SignupFormProps) {
           });
 
           if (signInError) {
-            setError(t('form.registrationSuccessfulButSignInFailed'));
+            setError(
+              t(
+                signInError.status === 429
+                  ? 'form.registrationSuccessfulButRateLimited'
+                  : 'form.registrationSuccessfulButSignInFailed',
+              ),
+            );
             return;
           }
 

--- a/dashboard/src/components/auth/LoginForm.tsx
+++ b/dashboard/src/components/auth/LoginForm.tsx
@@ -84,7 +84,7 @@ export default function LoginForm({
           const { error: totpError } = await authClient.twoFactor.verifyTotp({ code: totp });
           if (totpError) {
             setTotp('');
-            setError(totpError.status === 429 ? t('errors.tooManyAttempts') : t('errors.invalidOtp'));
+            setError(t(totpError.status === 429 ? 'errors.tooManyAttempts' : 'errors.invalidOtp'));
             return;
           }
           router.push('/dashboards');
@@ -93,7 +93,7 @@ export default function LoginForm({
 
         const { data, error: signInError } = await authClient.signIn.email({ email, password });
         if (signInError) {
-          setError(signInError.status === 429 ? t('errors.tooManyAttempts') : t('errors.invalidCredentials'));
+          setError(t(signInError.status === 429 ? 'errors.tooManyAttempts' : 'errors.invalidCredentials'));
           return;
         }
         if (data && 'twoFactorRedirect' in data && data.twoFactorRedirect) {

--- a/dashboard/src/components/auth/LoginForm.tsx
+++ b/dashboard/src/components/auth/LoginForm.tsx
@@ -84,7 +84,7 @@ export default function LoginForm({
           const { error: totpError } = await authClient.twoFactor.verifyTotp({ code: totp });
           if (totpError) {
             setTotp('');
-            setError(t('errors.invalidOtp'));
+            setError(totpError.status === 429 ? t('errors.tooManyAttempts') : t('errors.invalidOtp'));
             return;
           }
           router.push('/dashboards');
@@ -93,7 +93,7 @@ export default function LoginForm({
 
         const { data, error: signInError } = await authClient.signIn.email({ email, password });
         if (signInError) {
-          setError(t('errors.invalidCredentials'));
+          setError(signInError.status === 429 ? t('errors.tooManyAttempts') : t('errors.invalidCredentials'));
           return;
         }
         if (data && 'twoFactorRedirect' in data && data.twoFactorRedirect) {

--- a/dashboard/src/components/userSettings/account/UserSecurityTotpSettings.tsx
+++ b/dashboard/src/components/userSettings/account/UserSecurityTotpSettings.tsx
@@ -73,7 +73,7 @@ function SetupTotp() {
       const { data, error } = await authClient.twoFactor.enable({ password });
       if (error || !data) {
         setPassword('');
-        toast.error(t('setupFailed'));
+        toast.error(t(error?.status === 429 ? 'tooManyAttempts' : 'setupFailed'));
         return;
       }
       // data.backupCodes stays hidden: sign-in has no backup code entry yet, so
@@ -90,7 +90,7 @@ function SetupTotp() {
       if (error) {
         setTotp('');
         totpInputRef.current?.focus();
-        toast.error(t('enableFailed'));
+        toast.error(t(error.status === 429 ? 'tooManyAttempts' : 'enableFailed'));
         return;
       }
       await refreshSession();
@@ -216,7 +216,7 @@ function DisableTotp() {
       const { error } = await authClient.twoFactor.disable({ password });
       if (error) {
         setPassword('');
-        toast.error(t('disableFailed'));
+        toast.error(t(error.status === 429 ? 'tooManyAttempts' : 'disableFailed'));
         return;
       }
       await refreshSession();

--- a/dashboard/src/lib/auth-rate-limit.ts
+++ b/dashboard/src/lib/auth-rate-limit.ts
@@ -1,0 +1,14 @@
+import { createSlidingWindowLimiter } from '@/lib/rate-limit';
+
+// Per-email throttle for credential sign-in, complementing better-auth's built-in
+// per-IP limits (3/10s on /sign-in/* in production): an attacker rotating IPs still
+// gets at most this many attempts against a single account. Counts attempts, not
+// failures, so keep it loose enough for a legitimate user retrying a password.
+const SIGN_IN_WINDOW_MS = 10 * 60_000;
+const SIGN_IN_MAX_ATTEMPTS = 10;
+
+const signInEmailLimiter = createSlidingWindowLimiter(SIGN_IN_WINDOW_MS, SIGN_IN_MAX_ATTEMPTS);
+
+export function checkSignInEmailRateLimit(email: string) {
+  return signInEmailLimiter(email.trim().toLowerCase());
+}

--- a/dashboard/src/lib/auth-rate-limit.ts
+++ b/dashboard/src/lib/auth-rate-limit.ts
@@ -1,14 +1,44 @@
-import { createSlidingWindowLimiter } from '@/lib/rate-limit';
+// Per-account sign-in throttle. Attempts are cleared on successful session creation
+// (see the session.create hook in better-auth.ts), so only sustained failures block.
+const WINDOW_MS = 10 * 60_000;
+const MAX_ATTEMPTS = 10;
+const MAX_TRACKED_KEYS = 10_000;
+const MAX_EMAIL_LENGTH = 254;
 
-// Per-email throttle for credential sign-in, complementing better-auth's built-in
-// per-IP limits (3/10s on /sign-in/* in production): an attacker rotating IPs still
-// gets at most this many attempts against a single account. Counts attempts, not
-// failures, so keep it loose enough for a legitimate user retrying a password.
-const SIGN_IN_WINDOW_MS = 10 * 60_000;
-const SIGN_IN_MAX_ATTEMPTS = 10;
+const attempts = new Map<string, number[]>();
 
-const signInEmailLimiter = createSlidingWindowLimiter(SIGN_IN_WINDOW_MS, SIGN_IN_MAX_ATTEMPTS);
+function keyFor(email: unknown): string | null {
+  if (typeof email !== 'string') return null;
+  const key = email.trim().toLowerCase();
+  return key && key.length <= MAX_EMAIL_LENGTH ? key : null;
+}
 
-export function checkSignInEmailRateLimit(email: string) {
-  return signInEmailLimiter(email.trim().toLowerCase());
+export type SignInAttemptResult = { allowed: true } | { allowed: false; retryAfterMs: number };
+
+export function consumeSignInAttempt(email: unknown): SignInAttemptResult {
+  const key = keyFor(email);
+  if (!key) return { allowed: true };
+
+  const now = Date.now();
+  const cutoff = now - WINDOW_MS;
+  const timestamps = (attempts.get(key) ?? []).filter((t) => t > cutoff);
+
+  if (timestamps.length >= MAX_ATTEMPTS) {
+    attempts.set(key, timestamps);
+    return { allowed: false, retryAfterMs: timestamps[0]! + WINDOW_MS - now };
+  }
+
+  if (!attempts.has(key) && attempts.size >= MAX_TRACKED_KEYS) {
+    attempts.delete(attempts.keys().next().value!);
+  }
+  timestamps.push(now);
+  attempts.set(key, timestamps);
+  return { allowed: true };
+}
+
+export function clearSignInAttempts(email: unknown): void {
+  const key = keyFor(email);
+  if (key) {
+    attempts.delete(key);
+  }
 }

--- a/dashboard/src/lib/better-auth-config.test.ts
+++ b/dashboard/src/lib/better-auth-config.test.ts
@@ -214,6 +214,60 @@ describe('before hook (closed better-auth endpoints)', () => {
   it('leaves the live endpoints alone', async () => {
     await expect(runBeforeHook('/sign-in/email', { email: 'user@example.com' })).resolves.toBeUndefined();
   });
+
+  describe('per-email sign-in throttle', () => {
+    it('throws 429 once one email exhausts its attempts, counting case-insensitively', async () => {
+      for (let i = 0; i < 10; i++) {
+        await expect(
+          runBeforeHook('/sign-in/email', { email: i % 2 ? 'Throttled@Example.com' : 'throttled@example.com' }),
+        ).resolves.toBeUndefined();
+      }
+
+      await expect(runBeforeHook('/sign-in/email', { email: 'throttled@example.com' })).rejects.toMatchObject({
+        statusCode: 429,
+      });
+    });
+
+    it('does not throttle other accounts', async () => {
+      await expect(runBeforeHook('/sign-in/email', { email: 'other@example.com' })).resolves.toBeUndefined();
+    });
+
+    it('ignores requests without a usable email (better-auth validates those)', async () => {
+      await expect(runBeforeHook('/sign-in/email', { email: 42 })).resolves.toBeUndefined();
+      await expect(runBeforeHook('/sign-in/email', {})).resolves.toBeUndefined();
+    });
+  });
+});
+
+describe('built-in rate limiting (upstream characterization)', () => {
+  it('throttles credential sign-in per IP at 3 attempts per 10s when enabled', async () => {
+    // Standalone instance (memory adapter): pins the strict special rule better-auth
+    // ships for /sign-in/* — the production posture our auth endpoints rely on.
+    const { betterAuth } = await import('better-auth');
+    const testAuth = betterAuth({
+      baseURL: 'http://localhost:3000',
+      secret: 'test-secret',
+      emailAndPassword: { enabled: true },
+      rateLimit: { enabled: true },
+    });
+
+    const signIn = () =>
+      testAuth.handler(
+        new Request('http://localhost:3000/api/auth/sign-in/email', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email: 'nobody@example.com', password: 'wrong-password-1' }),
+        }),
+      );
+
+    const statuses = [];
+    for (let i = 0; i < 4; i++) {
+      statuses.push((await signIn()).status);
+    }
+
+    expect(statuses.slice(0, 3)).not.toContain(429);
+    expect(statuses[3]).toBe(429);
+  });
 });
 
 describe('user update hook (2FA change notifications)', () => {

--- a/dashboard/src/lib/better-auth-config.test.ts
+++ b/dashboard/src/lib/better-auth-config.test.ts
@@ -215,58 +215,53 @@ describe('before hook (closed better-auth endpoints)', () => {
     await expect(runBeforeHook('/sign-in/email', { email: 'user@example.com' })).resolves.toBeUndefined();
   });
 
-  describe('per-email sign-in throttle', () => {
-    it('throws 429 once one email exhausts its attempts, counting case-insensitively', async () => {
+  describe('per-account sign-in throttle', () => {
+    let emailCounter = 0;
+    const uniqueEmail = () => `throttle-${++emailCounter}@example.com`;
+
+    const exhaustAttempts = async (email: string) => {
       for (let i = 0; i < 10; i++) {
         await expect(
-          runBeforeHook('/sign-in/email', { email: i % 2 ? 'Throttled@Example.com' : 'throttled@example.com' }),
+          runBeforeHook('/sign-in/email', { email: i % 2 ? email.toUpperCase() : email }),
         ).resolves.toBeUndefined();
       }
+    };
 
-      await expect(runBeforeHook('/sign-in/email', { email: 'throttled@example.com' })).rejects.toMatchObject({
-        statusCode: 429,
-      });
+    it('throws 429 with a Retry-After once one email exhausts its attempts, counting case-insensitively', async () => {
+      const email = uniqueEmail();
+      await exhaustAttempts(email);
+
+      const error = (await runBeforeHook('/sign-in/email', { email }).catch((e) => e)) as {
+        statusCode: number;
+        headers?: HeadersInit;
+      };
+      expect(error).toMatchObject({ statusCode: 429 });
+      expect(new Headers(error.headers).get('Retry-After')).toMatch(/^\d+$/);
     });
 
     it('does not throttle other accounts', async () => {
-      await expect(runBeforeHook('/sign-in/email', { email: 'other@example.com' })).resolves.toBeUndefined();
+      await exhaustAttempts(uniqueEmail());
+      await expect(runBeforeHook('/sign-in/email', { email: uniqueEmail() })).resolves.toBeUndefined();
+    });
+
+    it('clears the budget when a session is created for the account', async () => {
+      const email = uniqueEmail();
+      await exhaustAttempts(email);
+      await expect(runBeforeHook('/sign-in/email', { email })).rejects.toMatchObject({ statusCode: 429 });
+
+      vi.mocked(findUserById).mockResolvedValue(makeUser({ email }));
+      await auth.options.databaseHooks!.session!.create!.after!({ userId: 'user-1' } as never);
+
+      await expect(runBeforeHook('/sign-in/email', { email })).resolves.toBeUndefined();
     });
 
     it('ignores requests without a usable email (better-auth validates those)', async () => {
       await expect(runBeforeHook('/sign-in/email', { email: 42 })).resolves.toBeUndefined();
       await expect(runBeforeHook('/sign-in/email', {})).resolves.toBeUndefined();
+      await expect(
+        runBeforeHook('/sign-in/email', { email: `${'x'.repeat(300)}@example.com` }),
+      ).resolves.toBeUndefined();
     });
-  });
-});
-
-describe('built-in rate limiting (upstream characterization)', () => {
-  it('throttles credential sign-in per IP at 3 attempts per 10s when enabled', async () => {
-    // Standalone instance (memory adapter): pins the strict special rule better-auth
-    // ships for /sign-in/* — the production posture our auth endpoints rely on.
-    const { betterAuth } = await import('better-auth');
-    const testAuth = betterAuth({
-      baseURL: 'http://localhost:3000',
-      secret: 'test-secret',
-      emailAndPassword: { enabled: true },
-      rateLimit: { enabled: true },
-    });
-
-    const signIn = () =>
-      testAuth.handler(
-        new Request('http://localhost:3000/api/auth/sign-in/email', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ email: 'nobody@example.com', password: 'wrong-password-1' }),
-        }),
-      );
-
-    const statuses = [];
-    for (let i = 0; i < 4; i++) {
-      statuses.push((await signIn()).status);
-    }
-
-    expect(statuses.slice(0, 3)).not.toContain(429);
-    expect(statuses[3]).toBe(429);
   });
 });
 

--- a/dashboard/src/lib/better-auth.ts
+++ b/dashboard/src/lib/better-auth.ts
@@ -15,6 +15,7 @@ import { createUserRecipientKey } from '@/services/email/recipient-key.service';
 import { setLocaleCookie } from '@/constants/cookies';
 import { isFeatureEnabled } from '@/lib/feature-flags';
 import { findUserById } from '@/repositories/postgres/user.repository';
+import { checkSignInEmailRateLimit } from '@/lib/auth-rate-limit';
 
 // A session created this soon after the user row is their first sign-in; skip the
 // locale sync there so default settings don't overwrite the locale they signed up in.
@@ -81,6 +82,17 @@ export const auth = betterAuth({
         ctx.path === '/update-user'
       ) {
         throw new APIError('NOT_FOUND');
+      }
+
+      // better-auth's built-in rate limiting is keyed per IP only; this adds the
+      // per-account dimension so IP rotation doesn't buy unlimited attempts.
+      if (ctx.path === '/sign-in/email') {
+        const email = typeof ctx.body?.email === 'string' ? ctx.body.email : '';
+        if (email && !checkSignInEmailRateLimit(email).allowed) {
+          throw new APIError('TOO_MANY_REQUESTS', {
+            message: 'Too many sign-in attempts. Please try again later.',
+          });
+        }
       }
     }),
   },

--- a/dashboard/src/lib/better-auth.ts
+++ b/dashboard/src/lib/better-auth.ts
@@ -15,7 +15,7 @@ import { createUserRecipientKey } from '@/services/email/recipient-key.service';
 import { setLocaleCookie } from '@/constants/cookies';
 import { isFeatureEnabled } from '@/lib/feature-flags';
 import { findUserById } from '@/repositories/postgres/user.repository';
-import { checkSignInEmailRateLimit } from '@/lib/auth-rate-limit';
+import { consumeSignInAttempt, clearSignInAttempts } from '@/lib/auth-rate-limit';
 
 // A session created this soon after the user row is their first sign-in; skip the
 // locale sync there so default settings don't overwrite the locale they signed up in.
@@ -84,14 +84,16 @@ export const auth = betterAuth({
         throw new APIError('NOT_FOUND');
       }
 
-      // better-auth's built-in rate limiting is keyed per IP only; this adds the
-      // per-account dimension so IP rotation doesn't buy unlimited attempts.
+      // Per-account complement to better-auth's per-IP limits, so IP rotation
+      // doesn't buy unlimited attempts against one account.
       if (ctx.path === '/sign-in/email') {
-        const email = typeof ctx.body?.email === 'string' ? ctx.body.email : '';
-        if (email && !checkSignInEmailRateLimit(email).allowed) {
-          throw new APIError('TOO_MANY_REQUESTS', {
-            message: 'Too many sign-in attempts. Please try again later.',
-          });
+        const attempt = consumeSignInAttempt(ctx.body?.email);
+        if (!attempt.allowed) {
+          throw new APIError(
+            'TOO_MANY_REQUESTS',
+            { message: 'Too many sign-in attempts. Please try again later.' },
+            { 'Retry-After': String(Math.ceil(attempt.retryAfterMs / 1000)) },
+          );
         }
       }
     }),
@@ -152,6 +154,7 @@ export const auth = betterAuth({
         after: async (session) => {
           try {
             const user = await findUserById(session.userId);
+            clearSignInAttempts(user?.email);
             if (!user?.createdAt) return;
             if (Date.now() - user.createdAt.getTime() < FIRST_SIGN_IN_WINDOW_MS) return;
 


### PR DESCRIPTION
better-auth already rate limits its own endpoints per IP in production (sign-in and sign-up at 3 per 10s, password reset and verification email requests at 3 per 60s, 2FA at 3 per 10s, in-memory, on by default). This PR adds the dimension it cannot give us: a per-account throttle on credential sign-in (10 attempts per 10 minutes, sliding window), so rotating IPs no longer buys unlimited guesses against one account. The budget is cleared whenever a session is created for the account, so only sustained failures ever block a legitimate user. The 429 carries a Retry-After header, and the login form, signup auto-sign-in, and 2FA settings dialogs now show a "too many attempts" message instead of "invalid credentials" when throttled (all four locales).

Part of betterlytics/betterlytics-internal#12. The registration, password reset, and verification actions named there are covered by the stacked follow-up PRs that migrate those flows into better-auth (part of betterlytics/betterlytics-internal#55). PR 1 of 5 in that stack.

Reviewer notes:

- The limiter is in-process and bounded (10k keys, oldest evicted, no sweep timer), per the "in-memory per-process is acceptable" call in the ticket.
- Accepted residual: an attacker actively spraying failures at a known email can hold that account's password login closed while the spray lasts (window is 10 minutes, OAuth unaffected). That is inherent to any per-account limiter; clearing on success confines it to active attacks.
- Deploy caveat, pre-existing and independent of this PR: better-auth resolves the client IP from x-forwarded-for and deliberately ignores multi-value headers unless advanced.ipAddress.trustedProxies is configured. If the production proxy appends to XFF rather than overwriting it, every built-in per-IP limit collapses into one shared site-wide bucket (3 shared sign-in attempts per 10s). Worth verifying the prod nginx sets a single-value XFF before this posture is relied on.
- Follow-up candidate, not in this PR: the 2FA verify endpoints only have the per-IP 3/10s plugin rule, so TOTP/backup-code guessing per account is unbounded across IPs. Needs cookie- or user-keyed limiting and touches the backup-codes work in betterlytics/betterlytics-internal#54.

Verified live against a worktree stack: 10 wrong passwords then 429 with Retry-After; and 5 failures, 1 success, 6 failures produces no 429 (the success cleared the budget).
