### PR TITLE
Migrated signup to better-auth

### DIFF
--- a/dashboard/messages/da.json
+++ b/dashboard/messages/da.json
@@ -3252,7 +3252,7 @@
         "googleButton": "Google",
         "gitHubButton": "GitHub",
         "passwordsDoNotMatch": "Adgangskoder matcher ikke",
-        "registrationSuccessfulButSignInFailed": "Registrering lykkedes, men log ind mislykkedes. Prøv at logge ind manuelt.",
+        "emailAlreadyExists": "Der findes allerede en bruger med den e-mail.",
         "signUpError": "Der opstod en fejl under tilmelding. Prøv igen.",
         "checkInput": "Tjek venligst dit input"
       }

--- a/dashboard/messages/da.json
+++ b/dashboard/messages/da.json
@@ -3253,7 +3253,7 @@
         "googleButton": "Google",
         "gitHubButton": "GitHub",
         "passwordsDoNotMatch": "Adgangskoder matcher ikke",
-        "registrationSuccessfulButSignInFailed": "Registrering lykkedes, men log ind mislykkedes. Prøv at logge ind manuelt.",
+        "emailAlreadyExists": "Der findes allerede en bruger med den e-mail.",
         "signUpError": "Der opstod en fejl under tilmelding. Prøv igen.",
         "checkInput": "Tjek venligst dit input"
       }

--- a/dashboard/messages/en.json
+++ b/dashboard/messages/en.json
@@ -3249,7 +3249,7 @@
         "googleButton": "Google",
         "gitHubButton": "GitHub",
         "passwordsDoNotMatch": "Passwords do not match",
-        "registrationSuccessfulButSignInFailed": "Registration successful, but sign in failed. Please try signing in manually.",
+        "emailAlreadyExists": "User with that email already exists.",
         "signUpError": "An error occurred during sign up. Please try again.",
         "checkInput": "Please check your input"
       }

--- a/dashboard/messages/en.json
+++ b/dashboard/messages/en.json
@@ -3250,7 +3250,7 @@
         "googleButton": "Google",
         "gitHubButton": "GitHub",
         "passwordsDoNotMatch": "Passwords do not match",
-        "registrationSuccessfulButSignInFailed": "Registration successful, but sign in failed. Please try signing in manually.",
+        "emailAlreadyExists": "User with that email already exists.",
         "signUpError": "An error occurred during sign up. Please try again.",
         "checkInput": "Please check your input"
       }

--- a/dashboard/messages/it.json
+++ b/dashboard/messages/it.json
@@ -3253,7 +3253,7 @@
         "googleButton": "Google",
         "gitHubButton": "GitHub",
         "passwordsDoNotMatch": "Le password non corrispondono",
-        "registrationSuccessfulButSignInFailed": "Registrazione riuscita, ma accesso fallito. Prova ad accedere manualmente.",
+        "emailAlreadyExists": "Esiste già un utente con questa email.",
         "signUpError": "Si è verificato un errore durante la registrazione. Riprova.",
         "checkInput": "Controlla il tuo input"
       }

--- a/dashboard/messages/it.json
+++ b/dashboard/messages/it.json
@@ -3252,7 +3252,7 @@
         "googleButton": "Google",
         "gitHubButton": "GitHub",
         "passwordsDoNotMatch": "Le password non corrispondono",
-        "registrationSuccessfulButSignInFailed": "Registrazione riuscita, ma accesso fallito. Prova ad accedere manualmente.",
+        "emailAlreadyExists": "Esiste già un utente con questa email.",
         "signUpError": "Si è verificato un errore durante la registrazione. Riprova.",
         "checkInput": "Controlla il tuo input"
       }

--- a/dashboard/messages/nb.json
+++ b/dashboard/messages/nb.json
@@ -3253,7 +3253,7 @@
         "googleButton": "Google-konto",
         "gitHubButton": "GitHub-konto",
         "passwordsDoNotMatch": "Passordene samsvarer ikke",
-        "registrationSuccessfulButSignInFailed": "Registrering vellykket, men innlogging feilet. Prøv å logge inn manuelt.",
+        "emailAlreadyExists": "Det finnes allerede en bruker med den e-postadressen.",
         "signUpError": "Det oppstod en feil under registrering. Prøv igjen.",
         "checkInput": "Vennligst sjekk inndataene dine"
       }

--- a/dashboard/messages/nb.json
+++ b/dashboard/messages/nb.json
@@ -3252,7 +3252,7 @@
         "googleButton": "Google-konto",
         "gitHubButton": "GitHub-konto",
         "passwordsDoNotMatch": "Passordene samsvarer ikke",
-        "registrationSuccessfulButSignInFailed": "Registrering vellykket, men innlogging feilet. Prøv å logge inn manuelt.",
+        "emailAlreadyExists": "Det finnes allerede en bruker med den e-postadressen.",
         "signUpError": "Det oppstod en feil under registrering. Prøv igjen.",
         "checkInput": "Vennligst sjekk inndataene dine"
       }

--- a/dashboard/src/app/(app)/[locale]/(signup)/signup/SignupForm.tsx
+++ b/dashboard/src/app/(app)/[locale]/(signup)/signup/SignupForm.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
-import { isUserInvitedDashboardMemberAction, registerUserAction } from '@/app/actions/index.actions';
+import { isUserInvitedDashboardMemberAction } from '@/app/actions/index.actions';
 import { RegisterUserSchema } from '@/entities/auth/user.entities';
 import { authClient } from '@/lib/auth-client';
 import type { getEnabledOAuthProviders } from '@/lib/better-auth';
@@ -104,20 +104,21 @@ export default function SignupForm({ providers }: SignupFormProps) {
         });
 
         startTransition(async () => {
-          const result = await registerUserAction(validatedData);
-
-          if (!result.success) {
-            setError(result.error.message);
-            return;
-          }
-
-          const { error: signInError } = await authClient.signIn.email({
+          const signUpBody = {
             email: validatedData.email,
             password: validatedData.password,
-          });
+            name: validatedData.name ?? '',
+            acceptedTerms: validatedData.acceptedTerms,
+            language: validatedData.language,
+          };
+          const { error: signUpError } = await authClient.signUp.email(signUpBody);
 
-          if (signInError) {
-            setError(t('form.registrationSuccessfulButSignInFailed'));
+          if (signUpError) {
+            setError(
+              signUpError.code?.startsWith('USER_ALREADY_EXISTS')
+                ? t('form.emailAlreadyExists')
+                : t('form.signUpError'),
+            );
             return;
           }
 

--- a/dashboard/src/app/actions/auth/auth.action.ts
+++ b/dashboard/src/app/actions/auth/auth.action.ts
@@ -1,35 +1,8 @@
 'use server';
 
-import { RegisterUserData, RegisterUserSchema } from '@/entities/auth/user.entities';
-import { registerNewUser } from '@/services/auth/auth.service';
-import { isFeatureEnabled } from '@/lib/feature-flags';
-import { sendVerificationEmail } from '@/services/account/verification.service';
-import { withServerAction } from '@/middlewares/serverActionHandler';
-import { UserException } from '@/lib/exceptions';
 import { withUserAuth } from '@/auth/auth-actions';
 import { isUserDashboardMember } from '@/services/dashboard/members.service';
 import { isUserInvited } from '@/services/dashboard/invitation.service';
-
-export const registerUserAction = withServerAction(async (registrationData: RegisterUserData) => {
-  if (!isFeatureEnabled('enableRegistration')) {
-    throw new UserException('Registration is disabled');
-  }
-
-  const validatedData = RegisterUserSchema.parse(registrationData);
-  const newUser = await registerNewUser(validatedData);
-
-  if (isFeatureEnabled('enableAccountVerification')) {
-    try {
-      await sendVerificationEmail({
-        email: newUser.email,
-      });
-    } catch (emailError) {
-      console.error('Failed to send verification email:', emailError);
-    }
-  }
-
-  return newUser;
-});
 
 export const isUserInvitedDashboardMemberAction = withUserAuth(async (user): Promise<boolean> => {
   const [isMember, isInvited] = await Promise.all([isUserDashboardMember(user.id), isUserInvited(user.email)]);

--- a/dashboard/src/entities/auth/user.entities.ts
+++ b/dashboard/src/entities/auth/user.entities.ts
@@ -44,7 +44,6 @@ export const RegisterUserSchema = z.object({
   acceptedTerms: z.literal(true, {
     errorMap: () => ({ message: 'onboarding.account.termsOfServiceRequired' }),
   }),
-  role: z.nativeEnum(UserRole).optional(),
   language: z.preprocess(
     (val) => (SUPPORTED_LANGUAGES.includes(val as SupportedLanguages) ? val : 'en'),
     z.enum(SUPPORTED_LANGUAGES).default('en'),
@@ -66,6 +65,5 @@ export type User = z.infer<typeof UserSchema>;
 export type CreateUserData = z.infer<typeof CreateUserSchema>;
 export type UpdateUserData = z.infer<typeof UpdateUserSchema>;
 export type UpdateUserNameData = z.infer<typeof UpdateUserNameSchema>;
-export type RegisterUserData = z.infer<typeof RegisterUserSchema>;
 export type AuthenticatedUser = z.infer<typeof AuthenticatedUserSchema>;
 export type UserWithoutDashboardCandidate = z.infer<typeof UserWithoutDashboardCandidateSchema>;

--- a/dashboard/src/entities/auth/user.entities.ts
+++ b/dashboard/src/entities/auth/user.entities.ts
@@ -37,9 +37,15 @@ export const UpdateUserNameSchema = z.object({
   name: z.string().min(1).max(64),
 });
 
+export const MAX_EMAIL_LENGTH = 254;
+
 export const RegisterUserSchema = z.object({
   name: z.string().nullable().optional(),
-  email: z.string().email('Please enter a valid email address').max(254, 'Email address is too long').toLowerCase(),
+  email: z
+    .string()
+    .email('Please enter a valid email address')
+    .max(MAX_EMAIL_LENGTH, 'Email address is too long')
+    .toLowerCase(),
   password: PasswordSchema,
   acceptedTerms: z.literal(true, {
     errorMap: () => ({ message: 'onboarding.account.termsOfServiceRequired' }),

--- a/dashboard/src/lib/better-auth-config.test.ts
+++ b/dashboard/src/lib/better-auth-config.test.ts
@@ -9,6 +9,7 @@ import { setLocaleCookie } from '@/constants/cookies';
 import { isFeatureEnabled } from '@/lib/feature-flags';
 import { findUserById, findUserByEmail, findCredentialAccount } from '@/repositories/postgres/user.repository';
 import { makeUser, hashPassword } from '@/test/auth-fixtures';
+import { CURRENT_TERMS_VERSION } from '@/constants/legal';
 import { resetTokenStoredIdentifier } from '@/services/auth/passwordReset.service';
 import { deleteUserResetTokens, findResetTokenUserId } from '@/repositories/postgres/resetToken.repository';
 
@@ -134,11 +135,49 @@ describe('plugins and providers', () => {
   });
 });
 
+describe('user create before hook (sign-up field stamping)', () => {
+  type BeforeHook = (user: unknown, ctx?: unknown) => Promise<{ data: Record<string, unknown> } | undefined>;
+  const runBeforeCreateHook = (user: unknown, ctx?: unknown) =>
+    (auth.options.databaseHooks!.user!.create!.before as unknown as BeforeHook)(user, ctx);
+
+  it('stamps terms acceptance on email/password sign-ups', async () => {
+    const result = await runBeforeCreateHook(
+      { ...makeUser(), emailVerified: false },
+      { path: '/sign-up/email', body: { acceptedTerms: true } },
+    );
+
+    expect(result!.data.termsAcceptedAt).toBeInstanceOf(Date);
+    expect(result!.data.termsAcceptedVersion).toBe(CURRENT_TERMS_VERSION);
+  });
+
+  it('normalizes a blank sign-up name to null', async () => {
+    const result = await runBeforeCreateHook(
+      { ...makeUser(), name: '  ', emailVerified: false },
+      { path: '/sign-up/email', body: { acceptedTerms: true } },
+    );
+
+    expect(result!.data.name).toBeNull();
+  });
+
+  it('mirrors provider-verified emails into emailVerifiedAt (OAuth)', async () => {
+    const oauthUser = { id: 'user-1', email: 'user@example.com', name: 'Test User', emailVerified: true };
+
+    const result = await runBeforeCreateHook(oauthUser, { path: '/callback/github' });
+
+    expect(result!.data.emailVerifiedAt).toBeInstanceOf(Date);
+    expect(result!.data.termsAcceptedAt).toBeUndefined();
+  });
+
+  it('leaves unverified OAuth users untouched', async () => {
+    expect(await runBeforeCreateHook({ ...makeUser(), emailVerified: false }, { path: '/callback/github' })).toBeUndefined();
+  });
+});
+
 describe('user create hook (onboarding side effects)', () => {
   const hookUser = { ...makeUser(), emailVerified: false } as never;
 
-  function runCreateHook(user = hookUser) {
-    return auth.options.databaseHooks!.user!.create!.after!(user);
+  function runCreateHook(user = hookUser, ctx?: unknown) {
+    return auth.options.databaseHooks!.user!.create!.after!(user, ctx as never);
   }
 
   it('provisions a starter subscription and default settings for new users', async () => {
@@ -147,7 +186,23 @@ describe('user create hook (onboarding side effects)', () => {
     await runCreateHook();
 
     expect(createStarterSubscriptionForUser).toHaveBeenCalledWith('user-1');
-    expect(createDefaultUserSettings).toHaveBeenCalledWith('user-1');
+    expect(createDefaultUserSettings).toHaveBeenCalledWith('user-1', undefined);
+  });
+
+  it('creates settings with the language the user signed up in', async () => {
+    vi.mocked(isFeatureEnabled).mockReturnValue(false);
+
+    await runCreateHook(hookUser, { path: '/sign-up/email', body: { acceptedTerms: true, language: 'da' } });
+
+    expect(createDefaultUserSettings).toHaveBeenCalledWith('user-1', 'da');
+  });
+
+  it('falls back to the default language when the sign-up language is unsupported', async () => {
+    vi.mocked(isFeatureEnabled).mockReturnValue(false);
+
+    await runCreateHook(hookUser, { path: '/sign-up/email', body: { acceptedTerms: true, language: 'xx' } });
+
+    expect(createDefaultUserSettings).toHaveBeenCalledWith('user-1', undefined);
   });
 
   it('sends a verification email to new unverified users when verification is enabled', async () => {
@@ -287,12 +342,30 @@ describe('before hook (closed better-auth endpoints)', () => {
 
   it.each([
     ['/change-password', { newPassword: 'no-uppercase-1' }],
-    ['/sign-up/email', { password: 'no-uppercase-1' }],
+    ['/sign-up/email', { password: 'no-uppercase-1', acceptedTerms: true }],
     ['/reset-password', { newPassword: 'no-uppercase-1' }],
   ])('rejects weak passwords on %s when the client-side schema is bypassed', async (path, body) => {
     await expect(runBeforeHook(path, body)).rejects.toMatchObject({
       statusCode: 400,
       body: { code: 'WEAK_PASSWORD' },
+    });
+  });
+
+  describe('sign-up terms gate', () => {
+    it('rejects sign-ups that do not accept the terms of service', async () => {
+      await expect(runBeforeHook('/sign-up/email', { password: 'Correct-horse-1' })).rejects.toMatchObject({
+        statusCode: 400,
+        body: { code: 'TERMS_NOT_ACCEPTED' },
+      });
+      await expect(
+        runBeforeHook('/sign-up/email', { password: 'Correct-horse-1', acceptedTerms: false }),
+      ).rejects.toMatchObject({ body: { code: 'TERMS_NOT_ACCEPTED' } });
+    });
+
+    it('lets sign-ups through once the terms are accepted', async () => {
+      await expect(
+        runBeforeHook('/sign-up/email', { password: 'Correct-horse-1', acceptedTerms: true }),
+      ).resolves.toBeUndefined();
     });
   });
 });

--- a/dashboard/src/lib/better-auth-config.test.ts
+++ b/dashboard/src/lib/better-auth-config.test.ts
@@ -168,8 +168,14 @@ describe('user create before hook (sign-up field stamping)', () => {
     expect(result!.data.termsAcceptedAt).toBeUndefined();
   });
 
-  it('leaves unverified OAuth users untouched', async () => {
-    expect(await runBeforeCreateHook({ ...makeUser(), emailVerified: false }, { path: '/callback/github' })).toBeUndefined();
+  it('stamps neither emailVerifiedAt nor terms on unverified OAuth users', async () => {
+    const oauthUser = { id: 'user-1', email: 'user@example.com', name: 'Test User', emailVerified: false };
+
+    const result = await runBeforeCreateHook(oauthUser, { path: '/callback/github' });
+
+    expect(result!.data.emailVerifiedAt).toBeUndefined();
+    expect(result!.data.termsAcceptedAt).toBeUndefined();
+    expect(result!.data.createdAt).toBeInstanceOf(Date);
   });
 });
 
@@ -179,6 +185,24 @@ describe('user create hook (onboarding side effects)', () => {
   function runCreateHook(user = hookUser, ctx?: unknown) {
     return auth.options.databaseHooks!.user!.create!.after!(user, ctx as never);
   }
+
+  beforeEach(() => {
+    vi.mocked(findUserById).mockResolvedValue(makeUser());
+  });
+
+  it('does nothing when the user row was rolled back with the sign-up transaction', async () => {
+    vi.mocked(findUserById).mockResolvedValue(null);
+    vi.mocked(isFeatureEnabled).mockReturnValue(true);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await runCreateHook();
+
+    expect(createStarterSubscriptionForUser).not.toHaveBeenCalled();
+    expect(createDefaultUserSettings).not.toHaveBeenCalled();
+    expect(sendVerificationEmail).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('rolled back'), { userId: 'user-1' });
+    warn.mockRestore();
+  });
 
   it('provisions a starter subscription and default settings for new users', async () => {
     vi.mocked(isFeatureEnabled).mockReturnValue(false);

--- a/dashboard/src/lib/better-auth-config.test.ts
+++ b/dashboard/src/lib/better-auth-config.test.ts
@@ -9,6 +9,7 @@ import { setLocaleCookie } from '@/constants/cookies';
 import { isFeatureEnabled } from '@/lib/feature-flags';
 import { findUserById, findCredentialAccount } from '@/repositories/postgres/user.repository';
 import { makeUser, hashPassword } from '@/test/auth-fixtures';
+import { CURRENT_TERMS_VERSION } from '@/constants/legal';
 import { resetTokenStoredIdentifier } from '@/services/auth/passwordReset.service';
 import { deleteUserResetTokens, findResetTokenUserId } from '@/repositories/postgres/resetToken.repository';
 
@@ -133,11 +134,49 @@ describe('plugins and providers', () => {
   });
 });
 
+describe('user create before hook (sign-up field stamping)', () => {
+  type BeforeHook = (user: unknown, ctx?: unknown) => Promise<{ data: Record<string, unknown> } | undefined>;
+  const runBeforeCreateHook = (user: unknown, ctx?: unknown) =>
+    (auth.options.databaseHooks!.user!.create!.before as unknown as BeforeHook)(user, ctx);
+
+  it('stamps terms acceptance on email/password sign-ups', async () => {
+    const result = await runBeforeCreateHook(
+      { ...makeUser(), emailVerified: false },
+      { path: '/sign-up/email', body: { acceptedTerms: true } },
+    );
+
+    expect(result!.data.termsAcceptedAt).toBeInstanceOf(Date);
+    expect(result!.data.termsAcceptedVersion).toBe(CURRENT_TERMS_VERSION);
+  });
+
+  it('normalizes a blank sign-up name to null', async () => {
+    const result = await runBeforeCreateHook(
+      { ...makeUser(), name: '  ', emailVerified: false },
+      { path: '/sign-up/email', body: { acceptedTerms: true } },
+    );
+
+    expect(result!.data.name).toBeNull();
+  });
+
+  it('mirrors provider-verified emails into emailVerifiedAt (OAuth)', async () => {
+    const oauthUser = { id: 'user-1', email: 'user@example.com', name: 'Test User', emailVerified: true };
+
+    const result = await runBeforeCreateHook(oauthUser, { path: '/callback/github' });
+
+    expect(result!.data.emailVerifiedAt).toBeInstanceOf(Date);
+    expect(result!.data.termsAcceptedAt).toBeUndefined();
+  });
+
+  it('leaves unverified OAuth users untouched', async () => {
+    expect(await runBeforeCreateHook({ ...makeUser(), emailVerified: false }, { path: '/callback/github' })).toBeUndefined();
+  });
+});
+
 describe('user create hook (onboarding side effects)', () => {
   const hookUser = { ...makeUser(), emailVerified: false } as never;
 
-  function runCreateHook(user = hookUser) {
-    return auth.options.databaseHooks!.user!.create!.after!(user);
+  function runCreateHook(user = hookUser, ctx?: unknown) {
+    return auth.options.databaseHooks!.user!.create!.after!(user, ctx as never);
   }
 
   it('provisions a starter subscription and default settings for new users', async () => {
@@ -146,7 +185,23 @@ describe('user create hook (onboarding side effects)', () => {
     await runCreateHook();
 
     expect(createStarterSubscriptionForUser).toHaveBeenCalledWith('user-1');
-    expect(createDefaultUserSettings).toHaveBeenCalledWith('user-1');
+    expect(createDefaultUserSettings).toHaveBeenCalledWith('user-1', undefined);
+  });
+
+  it('creates settings with the language the user signed up in', async () => {
+    vi.mocked(isFeatureEnabled).mockReturnValue(false);
+
+    await runCreateHook(hookUser, { path: '/sign-up/email', body: { acceptedTerms: true, language: 'da' } });
+
+    expect(createDefaultUserSettings).toHaveBeenCalledWith('user-1', 'da');
+  });
+
+  it('falls back to the default language when the sign-up language is unsupported', async () => {
+    vi.mocked(isFeatureEnabled).mockReturnValue(false);
+
+    await runCreateHook(hookUser, { path: '/sign-up/email', body: { acceptedTerms: true, language: 'xx' } });
+
+    expect(createDefaultUserSettings).toHaveBeenCalledWith('user-1', undefined);
   });
 
   it('sends a verification email to new unverified users when verification is enabled', async () => {
@@ -251,12 +306,30 @@ describe('before hook (closed better-auth endpoints)', () => {
 
   it.each([
     ['/change-password', { newPassword: 'no-uppercase-1' }],
-    ['/sign-up/email', { password: 'no-uppercase-1' }],
+    ['/sign-up/email', { password: 'no-uppercase-1', acceptedTerms: true }],
     ['/reset-password', { newPassword: 'no-uppercase-1' }],
   ])('rejects weak passwords on %s when the client-side schema is bypassed', async (path, body) => {
     await expect(runBeforeHook(path, body)).rejects.toMatchObject({
       statusCode: 400,
       body: { code: 'WEAK_PASSWORD' },
+    });
+  });
+
+  describe('sign-up terms gate', () => {
+    it('rejects sign-ups that do not accept the terms of service', async () => {
+      await expect(runBeforeHook('/sign-up/email', { password: 'Correct-horse-1' })).rejects.toMatchObject({
+        statusCode: 400,
+        body: { code: 'TERMS_NOT_ACCEPTED' },
+      });
+      await expect(
+        runBeforeHook('/sign-up/email', { password: 'Correct-horse-1', acceptedTerms: false }),
+      ).rejects.toMatchObject({ body: { code: 'TERMS_NOT_ACCEPTED' } });
+    });
+
+    it('lets sign-ups through once the terms are accepted', async () => {
+      await expect(
+        runBeforeHook('/sign-up/email', { password: 'Correct-horse-1', acceptedTerms: true }),
+      ).resolves.toBeUndefined();
     });
   });
 });

--- a/dashboard/src/lib/better-auth.ts
+++ b/dashboard/src/lib/better-auth.ts
@@ -186,8 +186,7 @@ export const auth = betterAuth({
             extra.termsAcceptedAt = new Date();
             extra.termsAcceptedVersion = CURRENT_TERMS_VERSION;
           }
-          if (Object.keys(extra).length === 0) return;
-          return { data: { ...user, ...extra } };
+          return { data: { ...user, ...extra, createdAt: new Date(), updatedAt: new Date() } };
         },
         after: async (user, ctx) => {
           try {

--- a/dashboard/src/lib/better-auth.ts
+++ b/dashboard/src/lib/better-auth.ts
@@ -16,6 +16,8 @@ import { setLocaleCookie } from '@/constants/cookies';
 import { isFeatureEnabled } from '@/lib/feature-flags';
 import { findUserById, findCredentialAccount } from '@/repositories/postgres/user.repository';
 import { PasswordSchema } from '@/entities/auth/password.entities';
+import { CURRENT_TERMS_VERSION } from '@/constants/legal';
+import { SUPPORTED_LANGUAGES, type SupportedLanguages } from '@/constants/i18n';
 import {
   RESET_TOKEN_EXPIRY_SECONDS,
   resetTokenStoredIdentifier,
@@ -35,15 +37,19 @@ const PASSWORD_POLICY_FIELDS: Record<string, string> = {
 // locale sync there so default settings don't overwrite the locale they signed up in.
 const FIRST_SIGN_IN_WINDOW_MS = 60_000;
 
+function signupLanguage(body: unknown): SupportedLanguages | undefined {
+  const language = (body as { language?: unknown } | undefined)?.language;
+  return SUPPORTED_LANGUAGES.includes(language as SupportedLanguages) ? (language as SupportedLanguages) : undefined;
+}
+
 export const auth = betterAuth({
   appName: 'Betterlytics',
   baseURL: env.AUTH_URL,
   secret: env.AUTH_SECRET,
-  database: prismaAdapter(prisma, { provider: 'postgresql' }),
+  database: prismaAdapter(prisma, { provider: 'postgresql', transaction: true }),
   emailAndPassword: {
     enabled: true,
-    // Registration goes through registerUserAction
-    disableSignUp: true,
+    disableSignUp: !isFeatureEnabled('enableRegistration'),
     minPasswordLength: 8,
     maxPasswordLength: 100,
     password: {
@@ -121,6 +127,13 @@ export const auth = betterAuth({
         }
       }
 
+      if (ctx.path === '/sign-up/email' && ctx.body?.acceptedTerms !== true) {
+        throw new APIError('BAD_REQUEST', {
+          message: 'Terms of service must be accepted',
+          code: 'TERMS_NOT_ACCEPTED',
+        });
+      }
+
       const passwordField = PASSWORD_POLICY_FIELDS[ctx.path];
       if (passwordField) {
         const strength = PasswordSchema.safeParse(ctx.body?.[passwordField]);
@@ -136,12 +149,20 @@ export const auth = betterAuth({
   databaseHooks: {
     user: {
       create: {
-        // Only runs for Oauth because email/password users are created through our own actions
-        before: async (user) => {
-          if (!user.emailVerified) return;
-          return { data: { ...user, emailVerifiedAt: new Date() } };
+        before: async (user, ctx) => {
+          const extra: Record<string, unknown> = {};
+          if (user.emailVerified) {
+            extra.emailVerifiedAt = new Date();
+          }
+          if (ctx?.path === '/sign-up/email') {
+            extra.name = user.name?.trim() || null;
+            extra.termsAcceptedAt = new Date();
+            extra.termsAcceptedVersion = CURRENT_TERMS_VERSION;
+          }
+          if (Object.keys(extra).length === 0) return;
+          return { data: { ...user, ...extra } };
         },
-        after: async (user) => {
+        after: async (user, ctx) => {
           try {
             await createStarterSubscriptionForUser(user.id);
           } catch (error) {
@@ -149,7 +170,8 @@ export const auth = betterAuth({
           }
 
           try {
-            await createDefaultUserSettings(user.id);
+            const language = ctx?.path === '/sign-up/email' ? signupLanguage(ctx.body) : undefined;
+            await createDefaultUserSettings(user.id, language);
           } catch (error) {
             console.error('Failed to create initial user settings for new user:', error);
           }

--- a/dashboard/src/lib/better-auth.ts
+++ b/dashboard/src/lib/better-auth.ts
@@ -189,6 +189,11 @@ export const auth = betterAuth({
           return { data: { ...user, ...extra, createdAt: new Date(), updatedAt: new Date() } };
         },
         after: async (user, ctx) => {
+          if (!(await findUserById(user.id))) {
+            console.warn('Skipped onboarding side effects: user row was rolled back', { userId: user.id });
+            return;
+          }
+
           try {
             await createStarterSubscriptionForUser(user.id);
           } catch (error) {

--- a/dashboard/src/lib/better-auth.ts
+++ b/dashboard/src/lib/better-auth.ts
@@ -16,6 +16,7 @@ import { setLocaleCookie } from '@/constants/cookies';
 import { isFeatureEnabled } from '@/lib/feature-flags';
 import { findUserById, findUserByEmail, findCredentialAccount } from '@/repositories/postgres/user.repository';
 import { PasswordSchema } from '@/entities/auth/password.entities';
+import { MAX_EMAIL_LENGTH } from '@/entities/auth/user.entities';
 import { CURRENT_TERMS_VERSION } from '@/constants/legal';
 import { SUPPORTED_LANGUAGES, type SupportedLanguages } from '@/constants/i18n';
 import {
@@ -140,6 +141,13 @@ export const auth = betterAuth({
             throw new APIError('BAD_REQUEST', { message: 'Invalid token', code: 'INVALID_TOKEN' });
           }
         }
+      }
+
+      if (ctx.path === '/sign-up/email' && String(ctx.body?.email ?? '').length > MAX_EMAIL_LENGTH) {
+        throw new APIError('BAD_REQUEST', {
+          message: 'Email address is too long',
+          code: 'EMAIL_TOO_LONG',
+        });
       }
 
       if (ctx.path === '/sign-up/email' && ctx.body?.acceptedTerms !== true) {

--- a/dashboard/src/lib/better-auth.ts
+++ b/dashboard/src/lib/better-auth.ts
@@ -16,6 +16,8 @@ import { setLocaleCookie } from '@/constants/cookies';
 import { isFeatureEnabled } from '@/lib/feature-flags';
 import { findUserById, findUserByEmail, findCredentialAccount } from '@/repositories/postgres/user.repository';
 import { PasswordSchema } from '@/entities/auth/password.entities';
+import { CURRENT_TERMS_VERSION } from '@/constants/legal';
+import { SUPPORTED_LANGUAGES, type SupportedLanguages } from '@/constants/i18n';
 import {
   RESET_TOKEN_EXPIRY_SECONDS,
   resetTokenStoredIdentifier,
@@ -35,15 +37,19 @@ const PASSWORD_POLICY_FIELDS: Record<string, string> = {
 // locale sync there so default settings don't overwrite the locale they signed up in.
 const FIRST_SIGN_IN_WINDOW_MS = 60_000;
 
+function signupLanguage(body: unknown): SupportedLanguages | undefined {
+  const language = (body as { language?: unknown } | undefined)?.language;
+  return SUPPORTED_LANGUAGES.includes(language as SupportedLanguages) ? (language as SupportedLanguages) : undefined;
+}
+
 export const auth = betterAuth({
   appName: 'Betterlytics',
   baseURL: env.AUTH_URL,
   secret: env.AUTH_SECRET,
-  database: prismaAdapter(prisma, { provider: 'postgresql' }),
+  database: prismaAdapter(prisma, { provider: 'postgresql', transaction: true }),
   emailAndPassword: {
     enabled: true,
-    // Registration goes through registerUserAction
-    disableSignUp: true,
+    disableSignUp: !isFeatureEnabled('enableRegistration'),
     minPasswordLength: 8,
     maxPasswordLength: 100,
     password: {
@@ -136,6 +142,13 @@ export const auth = betterAuth({
         }
       }
 
+      if (ctx.path === '/sign-up/email' && ctx.body?.acceptedTerms !== true) {
+        throw new APIError('BAD_REQUEST', {
+          message: 'Terms of service must be accepted',
+          code: 'TERMS_NOT_ACCEPTED',
+        });
+      }
+
       const passwordField = PASSWORD_POLICY_FIELDS[ctx.path];
       if (passwordField) {
         const strength = PasswordSchema.safeParse(ctx.body?.[passwordField]);
@@ -155,12 +168,20 @@ export const auth = betterAuth({
   databaseHooks: {
     user: {
       create: {
-        // Only runs for Oauth because email/password users are created through our own actions
-        before: async (user) => {
-          if (!user.emailVerified) return;
-          return { data: { ...user, emailVerifiedAt: new Date() } };
+        before: async (user, ctx) => {
+          const extra: Record<string, unknown> = {};
+          if (user.emailVerified) {
+            extra.emailVerifiedAt = new Date();
+          }
+          if (ctx?.path === '/sign-up/email') {
+            extra.name = user.name?.trim() || null;
+            extra.termsAcceptedAt = new Date();
+            extra.termsAcceptedVersion = CURRENT_TERMS_VERSION;
+          }
+          if (Object.keys(extra).length === 0) return;
+          return { data: { ...user, ...extra } };
         },
-        after: async (user) => {
+        after: async (user, ctx) => {
           try {
             await createStarterSubscriptionForUser(user.id);
           } catch (error) {
@@ -168,7 +189,8 @@ export const auth = betterAuth({
           }
 
           try {
-            await createDefaultUserSettings(user.id);
+            const language = ctx?.path === '/sign-up/email' ? signupLanguage(ctx.body) : undefined;
+            await createDefaultUserSettings(user.id, language);
           } catch (error) {
             console.error('Failed to create initial user settings for new user:', error);
           }

--- a/dashboard/src/lib/better-auth.ts
+++ b/dashboard/src/lib/better-auth.ts
@@ -16,6 +16,7 @@ import { setLocaleCookie } from '@/constants/cookies';
 import { isFeatureEnabled } from '@/lib/feature-flags';
 import { findUserById, findCredentialAccount } from '@/repositories/postgres/user.repository';
 import { PasswordSchema } from '@/entities/auth/password.entities';
+import { MAX_EMAIL_LENGTH } from '@/entities/auth/user.entities';
 import { CURRENT_TERMS_VERSION } from '@/constants/legal';
 import { SUPPORTED_LANGUAGES, type SupportedLanguages } from '@/constants/i18n';
 import {
@@ -125,6 +126,13 @@ export const auth = betterAuth({
             throw new APIError('BAD_REQUEST', { message: 'Invalid token', code: 'INVALID_TOKEN' });
           }
         }
+      }
+
+      if (ctx.path === '/sign-up/email' && String(ctx.body?.email ?? '').length > MAX_EMAIL_LENGTH) {
+        throw new APIError('BAD_REQUEST', {
+          message: 'Email address is too long',
+          code: 'EMAIL_TOO_LONG',
+        });
       }
 
       if (ctx.path === '/sign-up/email' && ctx.body?.acceptedTerms !== true) {

--- a/dashboard/src/lib/better-auth.ts
+++ b/dashboard/src/lib/better-auth.ts
@@ -167,8 +167,7 @@ export const auth = betterAuth({
             extra.termsAcceptedAt = new Date();
             extra.termsAcceptedVersion = CURRENT_TERMS_VERSION;
           }
-          if (Object.keys(extra).length === 0) return;
-          return { data: { ...user, ...extra } };
+          return { data: { ...user, ...extra, createdAt: new Date(), updatedAt: new Date() } };
         },
         after: async (user, ctx) => {
           try {

--- a/dashboard/src/repositories/postgres/user.repository.test.ts
+++ b/dashboard/src/repositories/postgres/user.repository.test.ts
@@ -5,11 +5,9 @@ import {
   findUserByEmail,
   findCredentialAccount,
   createUser,
-  registerUser,
   updateUserPassword,
   anonymizeUser,
 } from '@/repositories/postgres/user.repository';
-import { CURRENT_TERMS_VERSION } from '@/constants/legal';
 import { makeUser } from '@/test/auth-fixtures';
 
 const prismaMock = vi.hoisted(() => {
@@ -83,21 +81,19 @@ describe('findUserById / findUserByEmail', () => {
   });
 });
 
-describe('registerUser', () => {
-  const registration = {
+describe('createUser', () => {
+  const creation = {
     email: 'new@example.com',
     name: 'New User',
-    password: 'Valid-password-1',
-    acceptedTerms: true as const,
-    language: 'en' as const,
+    passwordHash: '$2b$10$fixture-hash',
   };
 
   beforeEach(() => {
-    prismaMock.user.create.mockResolvedValue(makeUser({ email: registration.email }));
+    prismaMock.user.create.mockResolvedValue(makeUser({ email: creation.email }));
   });
 
-  it('stores a bcrypt hash on the credential account — never the plaintext, never on the user', async () => {
-    await registerUser(registration);
+  it('stores the hash on the credential account — never on the user', async () => {
+    await createUser(creation);
 
     const userData = prismaMock.user.create.mock.calls[0][0].data;
     expect(userData.passwordHash).toBeUndefined();
@@ -105,12 +101,11 @@ describe('registerUser', () => {
 
     const accountData = prismaMock.account.create.mock.calls[0][0].data;
     expect(accountData.providerId).toBe('credential');
-    expect(accountData.password).not.toBe(registration.password);
-    expect(await bcrypt.compare(registration.password, accountData.password)).toBe(true);
+    expect(accountData.password).toBe(creation.passwordHash);
   });
 
   it('links the credential account to the created user with accountId = user id', async () => {
-    await registerUser(registration);
+    await createUser(creation);
 
     const accountData = prismaMock.account.create.mock.calls[0][0].data;
     expect(accountData.userId).toBe('user-1');
@@ -118,41 +113,20 @@ describe('registerUser', () => {
   });
 
   it('creates the user and credential account in one transaction', async () => {
-    await registerUser(registration);
+    await createUser(creation);
 
     expect(prismaMock.$transaction).toHaveBeenCalledTimes(1);
     expect(typeof prismaMock.$transaction.mock.calls[0][0]).toBe('function');
   });
 
-  it('records terms acceptance with the current terms version', async () => {
-    await registerUser(registration);
-
-    const createData = prismaMock.user.create.mock.calls[0][0].data;
-    expect(createData.termsAcceptedVersion).toBe(CURRENT_TERMS_VERSION);
-    expect(createData.termsAcceptedAt).toBeInstanceOf(Date);
-  });
-
-  it('defaults the role to admin', async () => {
-    await registerUser(registration);
-
-    expect(prismaMock.user.create.mock.calls[0][0].data.role).toBe('admin');
-  });
-
-  it('provisions a starter subscription and default settings alongside the user', async () => {
-    await registerUser(registration);
+  it('provisions a starter subscription and settings with the given language alongside the user', async () => {
+    await createUser(creation, { language: 'da' });
 
     const createData = prismaMock.user.create.mock.calls[0][0].data;
     expect(createData.subscription.create).toBeDefined();
-    expect(createData.settings.create).toMatchObject({ language: 'en' });
+    expect(createData.settings.create).toMatchObject({ language: 'da' });
   });
 
-  it('rejects a password that violates the policy before touching the database', async () => {
-    await expect(registerUser({ ...registration, password: 'short' })).rejects.toThrow();
-    expect(prismaMock.user.create).not.toHaveBeenCalled();
-  });
-});
-
-describe('createUser', () => {
   it('wraps validation failures in a generic error', async () => {
     await expect(createUser({ email: 'not-an-email', passwordHash: 'hash' })).rejects.toThrow(
       'Failed to create user.',

--- a/dashboard/src/repositories/postgres/user.repository.ts
+++ b/dashboard/src/repositories/postgres/user.repository.ts
@@ -8,13 +8,10 @@ import {
   UserSchema,
   CreateUserData,
   CreateUserSchema,
-  RegisterUserSchema,
-  RegisterUserData,
   UpdateUserData,
   UserWithoutDashboardCandidate,
   UserWithoutDashboardCandidateSchema,
 } from '@/entities/auth/user.entities';
-import { CURRENT_TERMS_VERSION } from '@/constants/legal';
 import { buildStarterSubscription } from '@/entities/billing/billing.entities';
 import { DEFAULT_USER_SETTINGS } from '@/entities/account/userSettings.entities';
 import type { SupportedLanguages } from '@/constants/i18n';
@@ -112,29 +109,6 @@ export async function createUser(
   } catch (error) {
     console.error('Error creating user:', error);
     throw new Error('Failed to create user.');
-  }
-}
-
-export async function registerUser(data: RegisterUserData): Promise<User> {
-  try {
-    const validatedData = RegisterUserSchema.parse(data);
-
-    const passwordHash = await hashPassword(validatedData.password);
-
-    return await createUser(
-      {
-        email: validatedData.email,
-        name: validatedData.name,
-        passwordHash,
-        role: validatedData.role || 'admin',
-        termsAcceptedVersion: CURRENT_TERMS_VERSION,
-        termsAcceptedAt: data.acceptedTerms ? new Date() : null,
-      },
-      { language: validatedData.language },
-    );
-  } catch (error) {
-    console.error('Error registering user:', error);
-    throw error;
   }
 }
 

--- a/dashboard/src/services/account/userSettings.service.ts
+++ b/dashboard/src/services/account/userSettings.service.ts
@@ -7,6 +7,7 @@ import * as UserSettingsRepository from '@/repositories/postgres/userSettings.re
 import * as UserRepository from '@/repositories/postgres/user.repository';
 import * as DashboardRepository from '@/repositories/postgres/dashboard.repository';
 import * as InvitationRepository from '@/repositories/postgres/invitation.repository';
+import type { SupportedLanguages } from '@/constants/i18n';
 
 export async function getUserSettings(userId: string): Promise<UserSettings> {
   try {
@@ -25,9 +26,15 @@ export async function getUserSettings(userId: string): Promise<UserSettings> {
 
 export const getCachedUserSettings = cache(getUserSettings);
 
-export async function createDefaultUserSettings(userId: string): Promise<UserSettings> {
+export async function createDefaultUserSettings(
+  userId: string,
+  language?: SupportedLanguages,
+): Promise<UserSettings> {
   try {
-    return await UserSettingsRepository.createUserSettings(userId, DEFAULT_USER_SETTINGS);
+    return await UserSettingsRepository.createUserSettings(userId, {
+      ...DEFAULT_USER_SETTINGS,
+      ...(language && { language }),
+    });
   } catch (error) {
     console.error('Error creating default user settings:', error);
     throw new Error('Failed to create default user settings');

--- a/dashboard/src/services/auth/auth.service.test.ts
+++ b/dashboard/src/services/auth/auth.service.test.ts
@@ -1,12 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import {
-  registerNewUser,
-  getAuthorizedDashboardContextOrNull,
-  assertPublicDashboardAccess,
-} from '@/services/auth/auth.service';
-import { findUserByEmail, registerUser } from '@/repositories/postgres/user.repository';
+import { getAuthorizedDashboardContextOrNull, assertPublicDashboardAccess } from '@/services/auth/auth.service';
 import { findUserDashboardWithDashboardOrNull } from '@/repositories/postgres/dashboard.repository';
-import { makeUser } from '@/test/auth-fixtures';
 
 vi.mock('@/lib/env', () => ({
   env: {
@@ -14,12 +8,6 @@ vi.mock('@/lib/env', () => ({
     ADMIN_PASSWORD: 'admin-Password-1',
     DEMO_DASHBOARD_ID: 'demo-dashboard-id',
   },
-}));
-vi.mock('@/repositories/postgres/user.repository', () => ({
-  findUserByEmail: vi.fn(),
-  createUser: vi.fn(),
-  registerUser: vi.fn(),
-  findCredentialAccount: vi.fn(),
 }));
 vi.mock('@/repositories/postgres/dashboard.repository', () => ({
   findUserDashboardWithDashboardOrNull: vi.fn(),
@@ -30,36 +18,6 @@ vi.mock('@/services/email/email.service', () => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
-});
-
-describe('registerNewUser', () => {
-  const registration = {
-    email: 'new@example.com',
-    name: 'New User',
-    password: 'Valid-password-1',
-    acceptedTerms: true as const,
-    language: 'en' as const,
-  };
-
-  it('throws a UserException when the email is already taken', async () => {
-    vi.mocked(findUserByEmail).mockResolvedValue(makeUser({ email: registration.email }));
-
-    await expect(registerNewUser(registration)).rejects.toMatchObject({
-      name: 'UserException',
-      message: 'User with that email already exists.',
-    });
-    expect(registerUser).not.toHaveBeenCalled();
-  });
-
-  it('registers and returns the new user when the email is free', async () => {
-    vi.mocked(findUserByEmail).mockResolvedValue(null);
-    vi.mocked(registerUser).mockResolvedValue(makeUser({ email: registration.email }));
-
-    const result = await registerNewUser(registration);
-
-    expect(registerUser).toHaveBeenCalledWith(registration);
-    expect(result.email).toBe(registration.email);
-  });
 });
 
 describe('getAuthorizedDashboardContextOrNull', () => {

--- a/dashboard/src/services/auth/auth.service.ts
+++ b/dashboard/src/services/auth/auth.service.ts
@@ -1,26 +1,10 @@
 'server-only';
 
-import { findUserByEmail, registerUser } from '@/repositories/postgres/user.repository';
 import { findUserDashboardWithDashboardOrNull } from '@/repositories/postgres/dashboard.repository';
 import { env } from '@/lib/env';
-import { RegisterUserData, User, UserSchema } from '@/entities/auth/user.entities';
 import { AuthContextSchema } from '@/entities/auth/authContext.entities';
-import { UserException } from '@/lib/exceptions';
 import { notFound } from 'next/navigation';
 import { DashboardFindByUserData } from '@/entities/dashboard/dashboard.entities';
-
-export async function registerNewUser(registrationData: RegisterUserData): Promise<User> {
-  const existingUser = await findUserByEmail(registrationData.email);
-
-  if (existingUser) {
-    throw new UserException(`User with that email already exists.`);
-  }
-
-  const newUser = await registerUser(registrationData);
-  const user = UserSchema.parse(newUser);
-
-  return user;
-}
 
 export async function getAuthorizedDashboardContextOrNull(data: DashboardFindByUserData) {
   const result = await findUserDashboardWithDashboardOrNull(data);


### PR DESCRIPTION
Email/password signup now goes through better-auth's `/sign-up/email`: SignupForm calls `authClient.signUp.email`, and `registerUserAction`, `registerNewUser`, and `registerUser` are deleted. The user-create hooks are now the single provisioning path for credential and OAuth users alike: the before hook rejects sign-ups without terms acceptance and stamps `termsAcceptedAt`/`termsAcceptedVersion`, and the after hook creates the starter subscription and the settings row with the signup language, and sends the verification email when `enableAccountVerification` is on.

Sign-up is gated on `enableRegistration` inside better-auth (`disableSignUp`), so self-host deploys with registration off refuse at the endpoint. The prisma adapter gains `transaction: true`, so the user and credential account commit atomically; subscription and settings stay best-effort in the after hook, same as OAuth signups today.

Closes betterlytics/betterlytics-internal#195. Part of betterlytics/betterlytics-internal#55. PR 3 of 4.
