### PR TITLE
Fail fast at boot when an enabled GeoIP or ASN database cannot be obtained

### DIFF
--- a/backend/src/asn/mod.rs
+++ b/backend/src/asn/mod.rs
@@ -1,7 +1,6 @@
-use crate::config::Config;
 use crate::geoip_updater::{GeoIpWatchRx, MmdbSource};
 use crate::ip_parser::anonymize_ip;
-use maxminddb::geoip2;
+use maxminddb::{geoip2, Reader};
 use moka::sync::Cache;
 use std::net::IpAddr;
 use std::sync::Arc;
@@ -25,9 +24,9 @@ pub struct AsnService {
 }
 
 impl AsnService {
-    pub fn new(config: Arc<Config>, watch_rx: GeoIpWatchRx) -> Self {
+    pub fn new(initial_reader: Option<Arc<Reader<Vec<u8>>>>, watch_rx: GeoIpWatchRx) -> Self {
         Self {
-            source: MmdbSource::new(Some(&config.asn_db_path), "ASN", watch_rx, READER_UPDATE_CHECK_INTERVAL),
+            source: MmdbSource::new(initial_reader, watch_rx, READER_UPDATE_CHECK_INTERVAL),
             cache: Cache::builder().max_capacity(CACHE_SIZE).time_to_idle(CACHE_TTI).build(),
         }
     }
@@ -52,11 +51,7 @@ impl AsnService {
 
         let reader = match self.source.reader() {
             Some(reader) => reader,
-            None => {
-                let result = AsnInfo::default();
-                self.cache.insert(anonymized, result.clone());
-                return result;
-            }
+            None => return AsnInfo::default(),
         };
 
         let ip: IpAddr = match anonymized.parse() {

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -115,8 +115,8 @@ impl Config {
                 .unwrap_or_else(|_| "password".to_string()),
             // GeoIP configuration
             geolocation_mode,
-            maxmind_account_id: env::var("MAXMIND_ACCOUNT_ID").ok(),
-            maxmind_license_key: env::var("MAXMIND_LICENSE_KEY").ok(),
+            maxmind_account_id: env::var("MAXMIND_ACCOUNT_ID").ok().filter(|v| !v.is_empty()),
+            maxmind_license_key: env::var("MAXMIND_LICENSE_KEY").ok().filter(|v| !v.is_empty()),
             geoip_db_path: env::var("GEOIP_DB_PATH")
                 .map(PathBuf::from)
                 .unwrap_or_else(|_| if geolocation_mode.has_subdivisions() {

--- a/backend/src/geoip/mod.rs
+++ b/backend/src/geoip/mod.rs
@@ -1,4 +1,4 @@
-use maxminddb::geoip2;
+use maxminddb::{geoip2, Reader};
 use std::net::IpAddr;
 use std::sync::Arc;
 use tracing::{info, warn, debug};
@@ -27,13 +27,12 @@ pub struct GeoIpService {
 }
 
 impl GeoIpService {
-    pub fn new(config: Arc<Config>, geoip_watch_rx: GeoIpWatchRx) -> Self {
+    pub fn new(config: Arc<Config>, initial_reader: Option<Arc<Reader<Vec<u8>>>>, geoip_watch_rx: GeoIpWatchRx) -> Self {
         if !config.geolocation_mode.is_enabled() {
             info!("Geolocation is disabled via config.");
         }
-        let db_path = config.geolocation_mode.is_enabled().then(|| config.geoip_db_path.as_path());
         Self {
-            source: MmdbSource::new(db_path, "GeoIP", geoip_watch_rx, READER_UPDATE_CHECK_INTERVAL),
+            source: MmdbSource::new(initial_reader, geoip_watch_rx, READER_UPDATE_CHECK_INTERVAL),
             cache: Cache::builder().max_capacity(CACHE_SIZE).time_to_idle(CACHE_TTI).build(),
             geolocation_mode: config.geolocation_mode,
         }
@@ -64,11 +63,7 @@ impl GeoIpService {
 
         let reader = match self.source.reader() {
             Some(r) => r,
-            None => {
-                let result = GeoLocation::default();
-                self.cache.insert(anonymized, result.clone());
-                return result;
-            }
+            None => return GeoLocation::default(),
         };
 
         let ip: IpAddr = match anonymized.parse() {
@@ -134,5 +129,38 @@ impl GeoIpService {
         self.cache.insert(anonymized, result.clone());
 
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::geoip_updater::tests::minimal_mmdb;
+    use tokio::sync::watch;
+
+    fn service(initial: Option<Arc<Reader<Vec<u8>>>>) -> (GeoIpService, watch::Sender<Option<Arc<Reader<Vec<u8>>>>>) {
+        let (tx, rx) = watch::channel(None);
+        let service = GeoIpService {
+            source: MmdbSource::new(initial, rx, READER_UPDATE_CHECK_INTERVAL),
+            cache: Cache::builder().max_capacity(CACHE_SIZE).build(),
+            geolocation_mode: GeolocationMode::Countries,
+        };
+        (service, tx)
+    }
+
+    #[test]
+    fn lookup_without_database_is_not_cached_and_recovers_after_update() {
+        let (service, tx) = service(None);
+
+        assert!(service.lookup("8.8.8.8").country_code.is_none());
+        service.cache.run_pending_tasks();
+        assert_eq!(service.cache.entry_count(), 0);
+
+        tx.send(Some(Arc::new(Reader::from_source(minimal_mmdb()).unwrap()))).unwrap();
+
+        service.lookup("8.8.8.8");
+        service.cache.run_pending_tasks();
+        assert_eq!(service.cache.entry_count(), 1);
+        assert!(service.source.reader().is_some());
     }
 }

--- a/backend/src/geoip_updater/mod.rs
+++ b/backend/src/geoip_updater/mod.rs
@@ -33,26 +33,9 @@ pub struct MmdbSource {
 }
 
 impl MmdbSource {
-    /// `db_path: None` skips the initial load (feature disabled); the source then
-    /// only ever serves a reader if the watch channel publishes one
-    pub fn new(db_path: Option<&std::path::Path>, label: &str, watch_rx: GeoIpWatchRx, check_interval: Duration) -> Self {
-        let mut initial_reader = None;
-        if let Some(db_path) = db_path {
-            if db_path.exists() {
-                match Reader::open_readfile(db_path) {
-                    Ok(reader) => {
-                        info!("Initial {} database loaded from: {:?}", label, db_path);
-                        initial_reader = Some(Arc::new(reader));
-                    }
-                    Err(e) => {
-                        error!("Failed to load initial {} database from {:?}: {}. Lookups delayed until first update.", label, db_path, e);
-                    }
-                }
-            } else {
-                warn!("{} database not found at {:?}. Lookups disabled until first update.", label, db_path);
-            }
-        }
-
+    /// `initial_reader: None` means no database was available at boot; the source
+    /// then only serves a reader once the watch channel publishes one
+    pub fn new(initial_reader: Option<Arc<Reader<Vec<u8>>>>, watch_rx: GeoIpWatchRx, check_interval: Duration) -> Self {
         let rx_mutex = Arc::new(std::sync::Mutex::new(watch_rx));
         let reader_to_use = rx_mutex.lock().unwrap().borrow().clone().or(initial_reader);
         let now_secs = std::time::SystemTime::now()
@@ -84,14 +67,16 @@ impl MmdbSource {
             .as_secs();
 
         let last_check_secs = self.last_check.load(Ordering::Relaxed);
-        if now_secs.saturating_sub(last_check_secs) < self.check_interval.as_secs() {
-            return false;
-        }
-        if self.last_check
-            .compare_exchange_weak(last_check_secs, now_secs, Ordering::Relaxed, Ordering::Relaxed)
-            .is_err()
-        {
-            return false;
+        if self.reader().is_some() {
+            if now_secs.saturating_sub(last_check_secs) < self.check_interval.as_secs() {
+                return false;
+            }
+            if self.last_check
+                .compare_exchange_weak(last_check_secs, now_secs, Ordering::Relaxed, Ordering::Relaxed)
+                .is_err()
+            {
+                return false;
+            }
         }
 
         let mut rx_guard = match self.watch_rx.try_lock() {
@@ -118,13 +103,14 @@ impl MmdbSource {
 pub type GeoIpWatchTx = watch::Sender<Option<Arc<Reader<Vec<u8>>>>>;
 
 pub struct GeoIpUpdater {
-    config: Arc<Config>,
+    credentials: Option<(String, String)>,
     client: Client,
+    label: &'static str,
     db_path: PathBuf,
     database_url: &'static str,
     update_interval: Duration,
     watch_tx: GeoIpWatchTx,
-    enabled: bool,
+    feature_enabled: bool,
 }
 
 impl GeoIpUpdater {
@@ -136,46 +122,79 @@ impl GeoIpUpdater {
             GEOIP_COUNTRY_DATABASE_URL
         };
 
-        let enabled = config.geolocation_mode.is_enabled() && Self::has_credentials(&config);
+        let feature_enabled = config.geolocation_mode.is_enabled();
         let db_path = config.geoip_db_path.clone();
-        Self::with_database(config, database_url, db_path, enabled)
+        Self::with_database(&config, "GeoIP", database_url, db_path, feature_enabled)
     }
 
     /// Creates an updater for the ASN database. Independent of geolocation mode:
     /// ASN data drives bot detection, not geo reports.
     pub fn new_asn(config: Arc<Config>) -> Result<(Self, GeoIpWatchRx)> {
-        let enabled = config.enable_asn_lookup && Self::has_credentials(&config);
         let db_path = config.asn_db_path.clone();
-        Self::with_database(config, GEOIP_ASN_DATABASE_URL, db_path, enabled)
-    }
-
-    fn has_credentials(config: &Config) -> bool {
-        config.maxmind_account_id.is_some() && config.maxmind_license_key.is_some()
+        let feature_enabled = config.enable_asn_lookup;
+        Self::with_database(&config, "ASN", GEOIP_ASN_DATABASE_URL, db_path, feature_enabled)
     }
 
     fn with_database(
-        config: Arc<Config>,
+        config: &Config,
+        label: &'static str,
         database_url: &'static str,
         db_path: PathBuf,
-        enabled: bool,
+        feature_enabled: bool,
     ) -> Result<(Self, GeoIpWatchRx)> {
         let (watch_tx, watch_rx) = watch::channel(None);
 
         let updater = Self {
             client: Client::builder().user_agent("betterlytics-updater/0.1").build()?,
+            label,
             db_path,
             database_url,
             update_interval: config.geoip_update_interval,
-            config,
+            credentials: config.maxmind_account_id.clone().zip(config.maxmind_license_key.clone()),
             watch_tx,
-            enabled,
+            feature_enabled,
         };
         Ok((updater, watch_rx))
     }
 
+    /// Obtains the database before the server binds: the local file when present,
+    /// otherwise a fresh download. `Ok(None)` only when the feature is disabled.
+    pub async fn bootstrap(&self) -> Result<Option<Arc<Reader<Vec<u8>>>>> {
+        if !self.feature_enabled {
+            return Ok(None);
+        }
+
+        match Reader::open_readfile(&self.db_path) {
+            Ok(reader) => {
+                info!("{} database loaded from {:?}", self.label, self.db_path);
+                return Ok(Some(Arc::new(reader)));
+            }
+            Err(maxminddb::MaxMindDbError::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => {
+                info!("{} database not found at {:?}, downloading", self.label, self.db_path);
+            }
+            Err(e) => {
+                warn!("{} database at {:?} is unreadable ({}), downloading a fresh copy", self.label, self.db_path, e);
+            }
+        }
+
+        if self.credentials.is_none() {
+            anyhow::bail!(
+                "{} database not found at {:?} and MAXMIND_ACCOUNT_ID/MAXMIND_LICENSE_KEY are not set; \
+                 provide the file or the credentials, or disable the feature",
+                self.label, self.db_path
+            );
+        }
+
+        let reader = self
+            .download_and_replace()
+            .await
+            .with_context(|| format!("{} database download failed", self.label))?;
+        Ok(Some(Arc::new(reader)))
+    }
+
     /// Starts the background update check loop.
     pub async fn run(self: Arc<Self>) {
-        if !self.enabled {
+        if !self.feature_enabled || self.credentials.is_none() {
             info!("Auto-update disabled for {} (feature disabled or credentials missing).", self.database_url);
             return;
         }
@@ -220,8 +239,7 @@ impl GeoIpUpdater {
 
     /// Checks remote Last-Modified header against local file modified time.
     async fn is_update_needed(&self) -> Result<bool> {
-        let account_id = self.config.maxmind_account_id.as_ref().unwrap();
-        let license_key = self.config.maxmind_license_key.as_ref().unwrap();
+        let (account_id, license_key) = self.credentials.as_ref().unwrap();
 
         debug!("Sending HEAD request to {}", self.database_url);
         let response = self.client
@@ -281,8 +299,7 @@ impl GeoIpUpdater {
 
     /// Performs the actual download GET request.
     async fn download_archive(&self) -> Result<Bytes> {
-        let account_id = self.config.maxmind_account_id.as_ref().unwrap();
-        let license_key = self.config.maxmind_license_key.as_ref().unwrap();
+        let (account_id, license_key) = self.credentials.as_ref().unwrap();
 
         debug!("Downloading database archive from {}", self.database_url);
         let response = self.client
@@ -347,3 +364,186 @@ impl GeoIpUpdater {
         Ok(())
     }
 } 
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use std::io::Write;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    pub(crate) fn minimal_mmdb() -> Vec<u8> {
+        let mut db = Vec::new();
+        db.extend_from_slice(&[0, 0, 1, 0, 0, 1]);
+        db.extend_from_slice(&[0u8; 16]);
+        db.extend_from_slice(b"\xab\xcd\xefMaxMind.com");
+        let key = |db: &mut Vec<u8>, k: &str| {
+            db.push(0x40 | k.len() as u8);
+            db.extend_from_slice(k.as_bytes());
+        };
+        db.push(0xE9);
+        key(&mut db, "binary_format_major_version"); db.extend_from_slice(&[0xA1, 2]);
+        key(&mut db, "binary_format_minor_version"); db.extend_from_slice(&[0xA0]);
+        key(&mut db, "build_epoch"); db.extend_from_slice(&[0x00, 0x02]);
+        key(&mut db, "database_type"); db.extend_from_slice(b"\x44Test");
+        key(&mut db, "description"); db.push(0xE0);
+        key(&mut db, "ip_version"); db.extend_from_slice(&[0xA1, 6]);
+        key(&mut db, "languages"); db.extend_from_slice(&[0x00, 0x04]);
+        key(&mut db, "node_count"); db.extend_from_slice(&[0xC1, 1]);
+        key(&mut db, "record_size"); db.extend_from_slice(&[0xA1, 24]);
+        db
+    }
+
+    fn mmdb_tar_gz() -> Vec<u8> {
+        let mmdb = minimal_mmdb();
+        let mut header = tar::Header::new_gnu();
+        header.set_size(mmdb.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        let mut tar = tar::Builder::new(Vec::new());
+        tar.append_data(&mut header, "GeoLite2-Test_20260101/GeoLite2-Test.mmdb", mmdb.as_slice()).unwrap();
+        let tar = tar.into_inner().unwrap();
+        let mut gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+        gz.write_all(&tar).unwrap();
+        gz.finish().unwrap()
+    }
+
+    /// Answers exactly one HTTP request with the given status and body.
+    async fn serve_once(status: &'static str, body: Vec<u8>) -> &'static str {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}/download", listener.local_addr().unwrap());
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut buf = [0u8; 4096];
+            let _ = socket.read(&mut buf).await;
+            let head = format!(
+                "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            socket.write_all(head.as_bytes()).await.unwrap();
+            socket.write_all(&body).await.unwrap();
+            socket.shutdown().await.unwrap();
+        });
+        Box::leak(url.into_boxed_str())
+    }
+
+    fn temp_db_path(name: &str) -> PathBuf {
+        std::env::temp_dir()
+            .join(format!("betterlytics-geoip-test-{}-{}", std::process::id(), name))
+            .join("db.mmdb")
+    }
+
+    fn updater(
+        db_path: PathBuf,
+        database_url: &'static str,
+        credentials: Option<(String, String)>,
+        feature_enabled: bool,
+    ) -> (GeoIpUpdater, GeoIpWatchRx) {
+        let (watch_tx, watch_rx) = watch::channel(None);
+        let updater = GeoIpUpdater {
+            credentials,
+            client: Client::new(),
+            label: "Test",
+            db_path,
+            database_url,
+            update_interval: Duration::from_secs(3600),
+            watch_tx,
+            feature_enabled,
+        };
+        (updater, watch_rx)
+    }
+
+    fn creds() -> Option<(String, String)> {
+        Some(("id".to_string(), "key".to_string()))
+    }
+
+    #[test]
+    fn minimal_mmdb_is_a_valid_database() {
+        let reader = Reader::from_source(minimal_mmdb()).unwrap();
+        let found = reader.lookup::<maxminddb::geoip2::Country>("8.8.8.8".parse().unwrap()).unwrap();
+        assert!(found.is_none());
+    }
+
+    #[tokio::test]
+    async fn bootstrap_returns_none_when_feature_disabled() {
+        let (updater, _rx) = updater(temp_db_path("disabled"), "http://127.0.0.1:9/", None, false);
+        assert!(updater.bootstrap().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn bootstrap_loads_local_file_without_network() {
+        let path = temp_db_path("local");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, minimal_mmdb()).unwrap();
+        let (updater, _rx) = updater(path, "http://127.0.0.1:9/", None, true);
+        assert!(updater.bootstrap().await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn bootstrap_fails_without_file_or_credentials() {
+        let (updater, _rx) = updater(temp_db_path("nocreds"), "http://127.0.0.1:9/", None, true);
+        let err = updater.bootstrap().await.unwrap_err().to_string();
+        assert!(err.contains("MAXMIND_ACCOUNT_ID"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn bootstrap_downloads_when_file_missing() {
+        let path = temp_db_path("download");
+        let _ = fs::remove_dir_all(path.parent().unwrap());
+        let url = serve_once("200 OK", mmdb_tar_gz()).await;
+        let (updater, _rx) = updater(path.clone(), url, creds(), true);
+        assert!(updater.bootstrap().await.unwrap().is_some());
+        assert_eq!(fs::read(&path).unwrap(), minimal_mmdb());
+    }
+
+    #[tokio::test]
+    async fn bootstrap_fails_when_download_rejected() {
+        let path = temp_db_path("rejected");
+        let _ = fs::remove_dir_all(path.parent().unwrap());
+        let url = serve_once("401 Unauthorized", b"bad credentials".to_vec()).await;
+        let (updater, _rx) = updater(path.clone(), url, creds(), true);
+        let err = format!("{:#}", updater.bootstrap().await.unwrap_err());
+        assert!(err.contains("401"), "{err}");
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn bootstrap_fails_when_server_unreachable() {
+        let path = temp_db_path("unreachable");
+        let _ = fs::remove_dir_all(path.parent().unwrap());
+        let (updater, _rx) = updater(path, "http://127.0.0.1:9/download", creds(), true);
+        assert!(updater.bootstrap().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn bootstrap_replaces_corrupt_local_file() {
+        let path = temp_db_path("corrupt");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, b"not an mmdb").unwrap();
+        let url = serve_once("200 OK", mmdb_tar_gz()).await;
+        let (updater, _rx) = updater(path.clone(), url, creds(), true);
+        assert!(updater.bootstrap().await.unwrap().is_some());
+        assert_eq!(fs::read(&path).unwrap(), minimal_mmdb());
+    }
+
+    #[test]
+    fn source_without_reader_adopts_published_database_immediately() {
+        let (tx, rx) = watch::channel(None);
+        let source = MmdbSource::new(None, rx, Duration::from_secs(3600));
+        assert!(!source.refresh_if_due());
+        assert!(source.reader().is_none());
+
+        tx.send(Some(Arc::new(Reader::from_source(minimal_mmdb()).unwrap()))).unwrap();
+        assert!(source.refresh_if_due());
+        assert!(source.reader().is_some());
+    }
+
+    #[test]
+    fn source_with_reader_waits_for_check_interval() {
+        let initial = Arc::new(Reader::from_source(minimal_mmdb()).unwrap());
+        let (tx, rx) = watch::channel(None);
+        let source = MmdbSource::new(Some(initial), rx, Duration::from_secs(3600));
+
+        tx.send(Some(Arc::new(Reader::from_source(minimal_mmdb()).unwrap()))).unwrap();
+        assert!(!source.refresh_if_due());
+    }
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -100,17 +100,24 @@ async fn main() {
 
     let (updater, geoip_watch_rx) =
         GeoIpUpdater::new(config.clone()).expect("Failed to create GeoIP updater");
-    let updater = Arc::new(updater);
-
-    let geoip_service = GeoIpService::new(config.clone(), geoip_watch_rx);
-
-    let _updater_handle = tokio::spawn(Arc::clone(&updater).run());
+    let geoip_reader = updater
+        .bootstrap()
+        .await
+        .map_err(|e| format!("{e:#}"))
+        .expect("Geolocation is enabled but no GeoIP database could be obtained");
+    let geoip_service = GeoIpService::new(config.clone(), geoip_reader, geoip_watch_rx);
+    let _updater_handle = tokio::spawn(Arc::new(updater).run());
 
     let asn_service = if config.enable_asn_lookup {
         let (asn_updater, asn_watch_rx) =
             GeoIpUpdater::new_asn(config.clone()).expect("Failed to create ASN updater");
+        let asn_reader = asn_updater
+            .bootstrap()
+            .await
+            .map_err(|e| format!("{e:#}"))
+            .expect("ASN lookup is enabled but no ASN database could be obtained");
         tokio::spawn(Arc::new(asn_updater).run());
-        Some(asn::AsnService::new(config.clone(), asn_watch_rx))
+        Some(asn::AsnService::new(asn_reader, asn_watch_rx))
     } else {
         info!("ASN lookup disabled (set ENABLE_ASN_LOOKUP=true to enable)");
         None


### PR DESCRIPTION
The backend now loads the local MaxMind database or downloads it before binding, and exits with an actionable error if neither is possible. Lookups no longer cache empty results while no database is loaded, so a later update takes effect immediately.

Closes betterlytics/betterlytics-internal#86

ASN is treated the same as geolocation (fatal when enabled but unobtainable) rather than best-effort as the ticket implied.
