### PR TITLE
Told selfhosters in-app when a feature is not enabled on their instance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -125,7 +125,7 @@ GITHUB_SECRET=
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 
-# Required outside development: emails, data retention purges and scheduled reports all run as background jobs
+# Emails, data retention purges and scheduled reports all run as background jobs, so keep this on outside development
 BACKGROUND_JOBS_ENABLED=true
 
 # Integrations - Register an app at https://pushover.net/apps to get an API token

--- a/.env.example
+++ b/.env.example
@@ -125,7 +125,8 @@ GITHUB_SECRET=
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 
-BACKGROUND_JOBS_ENABLED=false
+# Required outside development: emails, data retention purges and scheduled reports all run as background jobs
+BACKGROUND_JOBS_ENABLED=true
 
 # Integrations - Register an app at https://pushover.net/apps to get an API token
 PUSHOVER_APP_TOKEN=

--- a/.env.production.example
+++ b/.env.production.example
@@ -107,3 +107,6 @@ PUSHOVER_APP_TOKEN=
 STATUS_PAGE_DOMAIN=status.betterlytics.io
 STATUS_PAGE_ASK_SECRET=
 ENABLE_PUBLIC_STATUS_PAGES=true
+
+# Emails, data retention purges and scheduled reports all run as background jobs
+BACKGROUND_JOBS_ENABLED=true

--- a/dashboard/messages/da.json
+++ b/dashboard/messages/da.json
@@ -3764,7 +3764,7 @@
     },
     "monitoringNotConfigured": {
       "title": "Notifikationer er ikke aktive på denne instans",
-      "description": "Integrationer sender kun oppetidsovervågningsalarmer, og oppetidsovervågning er slået fra (ENABLE_UPTIME_MONITORING). Integrationer kan stadig sættes op, men intet bliver sendt, før det er aktiveret."
+      "description": "Integrationer sender kun oppetidsovervågningsalarmer, og oppetidsovervågning er slået fra på denne instans. Integrationer kan stadig sættes op, men intet bliver sendt, før det er aktiveret."
     },
     "integrations": {
       "pushover": {

--- a/dashboard/messages/da.json
+++ b/dashboard/messages/da.json
@@ -2065,6 +2065,12 @@
       "onSslExpiry": "Advarsel ved SSL-udløb",
       "onSslExpiryDescription": "Send en alarm, når SSL-certifikatet er ved at udløbe",
       "sslExpiryDisabledTooltip": "Aktivér SSL-overvågning i Avancerede indstillinger først",
+      "emailsNotConfigured": {
+        "badge": "E-mail ikke konfigureret",
+        "title": "Alarm-e-mails kan ikke leveres",
+        "description": "E-mail-afsendelse er ikke konfigureret på denne instans, så alarm-e-mails fra oppetidsovervågning bliver ikke sendt. Indstillingerne gemmes og træder i kraft, når e-mail er konfigureret.",
+        "tooltip": "Konfigurer e-mail-afsendelse på denne instans for at aktivere alarmer"
+      },
       "failureThreshold": "Fejlgrænse",
       "failureThresholdDescription": "Antal fejl i træk før der sendes en alarm",
       "failureCount": "{count, plural, one {{count} fejl} other {{count} fejl}}",
@@ -3755,6 +3761,10 @@
     "title": "Integrationer",
     "section": {
       "description": "Forbind tredjepartstjenester for at modtage uptimeovervågningsnotifikationer, når din hjemmeside går ned eller kommer op igen."
+    },
+    "monitoringNotConfigured": {
+      "title": "Notifikationer er ikke aktive på denne instans",
+      "description": "Integrationer sender kun oppetidsovervågningsalarmer, og oppetidsovervågning er slået fra (ENABLE_UPTIME_MONITORING). Integrationer kan stadig sættes op, men intet bliver sendt, før det er aktiveret."
     },
     "integrations": {
       "pushover": {

--- a/dashboard/messages/da.json
+++ b/dashboard/messages/da.json
@@ -3363,6 +3363,29 @@
       "title": "Ingen Core Web Vitals data endnu",
       "description": "Tjek at tracking er aktiveret.",
       "action": "Læs mere"
+    },
+    "featureNotEnabled": {
+      "action": "Selfhosting-guide",
+      "monitoring": {
+        "title": "Oppetidsovervågning er ikke aktiveret på denne instans",
+        "description": "Monitorer kan sættes op, men de tjekkes ikke, og der sendes ingen alarmer, før det er aktiveret."
+      },
+      "statusPages": {
+        "title": "Statussider er ikke aktiveret på denne instans",
+        "description": "Statussider kan sættes op, men de udgives ikke, før funktionen er aktiveret."
+      },
+      "statusPagesRequireMonitoring": {
+        "title": "Statussider kræver oppetidsovervågning, som ikke er aktiveret på denne instans",
+        "description": "Statussider kan sættes op, men de udgives ikke, før oppetidsovervågning er aktiveret."
+      },
+      "sessionReplay": {
+        "title": "Sessionsafspilning er ikke aktiveret på denne instans",
+        "description": "Der optages ingen sessioner, før det er aktiveret."
+      },
+      "geography": {
+        "title": "Geolokation er ikke aktiveret på denne instans",
+        "description": "Besøgendes placering indsamles ikke, før det er aktiveret."
+      }
     }
   },
   "githubStar": {

--- a/dashboard/messages/da.json
+++ b/dashboard/messages/da.json
@@ -3832,7 +3832,8 @@
     },
     "status": {
       "connected": "Forbundet",
-      "disabled": "Deaktiveret"
+      "disabled": "Deaktiveret",
+      "unavailable": "Ikke tilgængelig på denne instans"
     },
     "actions": {
       "configure": "Konfigurer",
@@ -3922,6 +3923,9 @@
       "invalidSlackWebhook": "Ugyldig Slack webhook URL",
       "invalidTeamsWebhook": "Ugyldig Teams webhook URL",
       "invalidWebhookUrl": "Ugyldig webhook URL"
+    },
+    "unavailable": {
+      "description": "{name} kræver et app-token konfigureret på denne instans, før den kan tilsluttes."
     }
   },
   "errors": {

--- a/dashboard/messages/en.json
+++ b/dashboard/messages/en.json
@@ -2065,6 +2065,12 @@
       "onSslExpiry": "Alert on SSL expiry",
       "onSslExpiryDescription": "Send an alert when the SSL certificate is about to expire",
       "sslExpiryDisabledTooltip": "Enable SSL monitoring in Advanced Settings first",
+      "emailsNotConfigured": {
+        "badge": "Email not configured",
+        "title": "Alert emails cannot be delivered",
+        "description": "Email delivery is not configured on this instance, so uptime monitoring alert emails will not be sent. These settings are kept and take effect once email is configured.",
+        "tooltip": "Configure email delivery on this instance to enable alerts"
+      },
       "failureThreshold": "Failure threshold",
       "failureThresholdDescription": "Number of consecutive failures before sending an alert",
       "failureCount": "{count, plural, one {{count} failure} other {{count} failures}}",
@@ -3752,6 +3758,10 @@
     "title": "Integrations",
     "section": {
       "description": "Connect third-party services to receive uptime monitoring notifications when your website goes down or recovers."
+    },
+    "monitoringNotConfigured": {
+      "title": "Notifications are not active on this instance",
+      "description": "Integrations only deliver uptime monitoring alerts, and uptime monitoring is disabled (ENABLE_UPTIME_MONITORING). Integrations can still be set up, but nothing will be sent until it is enabled."
     },
     "integrations": {
       "pushover": {

--- a/dashboard/messages/en.json
+++ b/dashboard/messages/en.json
@@ -3761,7 +3761,7 @@
     },
     "monitoringNotConfigured": {
       "title": "Notifications are not active on this instance",
-      "description": "Integrations only deliver uptime monitoring alerts, and uptime monitoring is disabled (ENABLE_UPTIME_MONITORING). Integrations can still be set up, but nothing will be sent until it is enabled."
+      "description": "Integrations only deliver uptime monitoring alerts, and uptime monitoring is disabled on this instance. Integrations can still be set up, but nothing will be sent until it is enabled."
     },
     "integrations": {
       "pushover": {

--- a/dashboard/messages/en.json
+++ b/dashboard/messages/en.json
@@ -3829,7 +3829,8 @@
     },
     "status": {
       "connected": "Connected",
-      "disabled": "Disabled"
+      "disabled": "Disabled",
+      "unavailable": "Not available on this instance"
     },
     "actions": {
       "configure": "Configure",
@@ -3919,6 +3920,9 @@
       "invalidSlackWebhook": "Invalid Slack webhook URL",
       "invalidTeamsWebhook": "Invalid Teams webhook URL",
       "invalidWebhookUrl": "Invalid webhook URL"
+    },
+    "unavailable": {
+      "description": "{name} needs an app token configured on this instance before it can be connected."
     }
   },
   "errors": {

--- a/dashboard/messages/en.json
+++ b/dashboard/messages/en.json
@@ -3360,6 +3360,29 @@
       "title": "No Core Web Vitals data yet",
       "description": "Make sure tracking is enabled.",
       "action": "Learn more"
+    },
+    "featureNotEnabled": {
+      "action": "Self-hosting guide",
+      "monitoring": {
+        "title": "Uptime monitoring is not enabled on this instance",
+        "description": "Monitors can be set up, but they are not checked and no alerts are sent until it is enabled."
+      },
+      "statusPages": {
+        "title": "Status pages are not enabled on this instance",
+        "description": "Status pages can be set up, but they are not published until the feature is enabled."
+      },
+      "statusPagesRequireMonitoring": {
+        "title": "Status pages need uptime monitoring, which is not enabled on this instance",
+        "description": "Status pages can be set up, but they are not published until uptime monitoring is enabled."
+      },
+      "sessionReplay": {
+        "title": "Session replay is not enabled on this instance",
+        "description": "No sessions are recorded until it is enabled."
+      },
+      "geography": {
+        "title": "Geolocation is not enabled on this instance",
+        "description": "Visitor locations are not collected until it is enabled."
+      }
     }
   },
   "githubStar": {

--- a/dashboard/messages/it.json
+++ b/dashboard/messages/it.json
@@ -3832,7 +3832,8 @@
     },
     "status": {
       "connected": "Connesso",
-      "disabled": "Disabilitato"
+      "disabled": "Disabilitato",
+      "unavailable": "Non disponibile su questa istanza"
     },
     "actions": {
       "configure": "Configura",
@@ -3922,6 +3923,9 @@
       "invalidSlackWebhook": "Webhook URL Slack non valido",
       "invalidTeamsWebhook": "Webhook URL Teams non valido",
       "invalidWebhookUrl": "Webhook URL non valido"
+    },
+    "unavailable": {
+      "description": "{name} richiede un token app configurato su questa istanza prima di poter essere collegato."
     }
   },
   "errors": {

--- a/dashboard/messages/it.json
+++ b/dashboard/messages/it.json
@@ -3363,6 +3363,29 @@
       "title": "Nessun dato Core Web Vitals",
       "description": "Assicurati che il tracciamento sia abilitato.",
       "action": "Scopri di più"
+    },
+    "featureNotEnabled": {
+      "action": "Guida al self-hosting",
+      "monitoring": {
+        "title": "Il monitoraggio uptime non è abilitato su questa istanza",
+        "description": "I monitor possono essere configurati, ma non vengono controllati e non viene inviato alcun avviso finché non è abilitato."
+      },
+      "statusPages": {
+        "title": "Le pagine di stato non sono abilitate su questa istanza",
+        "description": "Le pagine di stato possono essere configurate, ma non vengono pubblicate finché la funzione non è abilitata."
+      },
+      "statusPagesRequireMonitoring": {
+        "title": "Le pagine di stato richiedono il monitoraggio uptime, che non è abilitato su questa istanza",
+        "description": "Le pagine di stato possono essere configurate, ma non vengono pubblicate finché il monitoraggio uptime non è abilitato."
+      },
+      "sessionReplay": {
+        "title": "Il replay delle sessioni non è abilitato su questa istanza",
+        "description": "Nessuna sessione viene registrata finché non è abilitato."
+      },
+      "geography": {
+        "title": "La geolocalizzazione non è abilitata su questa istanza",
+        "description": "La posizione dei visitatori non viene raccolta finché non è abilitata."
+      }
     }
   },
   "githubStar": {

--- a/dashboard/messages/it.json
+++ b/dashboard/messages/it.json
@@ -3764,7 +3764,7 @@
     },
     "monitoringNotConfigured": {
       "title": "Le notifiche non sono attive su questa istanza",
-      "description": "Le integrazioni inviano solo avvisi del monitoraggio uptime, e il monitoraggio uptime è disabilitato (ENABLE_UPTIME_MONITORING). Le integrazioni possono comunque essere configurate, ma non verrà inviato nulla finché non sarà abilitato."
+      "description": "Le integrazioni inviano solo avvisi del monitoraggio uptime, e il monitoraggio uptime è disabilitato su questa istanza. Le integrazioni possono comunque essere configurate, ma non verrà inviato nulla finché non sarà abilitato."
     },
     "integrations": {
       "pushover": {

--- a/dashboard/messages/it.json
+++ b/dashboard/messages/it.json
@@ -2065,6 +2065,12 @@
       "onSslExpiry": "Avviso scadenza SSL",
       "onSslExpiryDescription": "Invia un avviso quando il certificato SSL sta per scadere",
       "sslExpiryDisabledTooltip": "Abilita il monitoraggio SSL nelle Impostazioni avanzate",
+      "emailsNotConfigured": {
+        "badge": "Email non configurata",
+        "title": "Le email di avviso non possono essere recapitate",
+        "description": "L'invio di email non è configurato su questa istanza, quindi le email di avviso del monitoraggio uptime non verranno inviate. Queste impostazioni vengono conservate e avranno effetto una volta configurata l'email.",
+        "tooltip": "Configura l'invio di email su questa istanza per abilitare gli avvisi"
+      },
       "failureThreshold": "Soglia di errore",
       "failureThresholdDescription": "Numero di errori consecutivi prima dell'invio di un avviso",
       "failureCount": "{count, plural, one {{count} errore} other {{count} errori}}",
@@ -3755,6 +3761,10 @@
     "title": "Integrazioni",
     "section": {
       "description": "Collega servizi di terze parti per ricevere notifiche di monitoraggio dell'uptime quando il tuo sito web va offline o si ripristina."
+    },
+    "monitoringNotConfigured": {
+      "title": "Le notifiche non sono attive su questa istanza",
+      "description": "Le integrazioni inviano solo avvisi del monitoraggio uptime, e il monitoraggio uptime è disabilitato (ENABLE_UPTIME_MONITORING). Le integrazioni possono comunque essere configurate, ma non verrà inviato nulla finché non sarà abilitato."
     },
     "integrations": {
       "pushover": {

--- a/dashboard/messages/nb.json
+++ b/dashboard/messages/nb.json
@@ -3363,6 +3363,29 @@
       "title": "Ingen Core Web Vitals-data ennå",
       "description": "Sørg for at sporing er aktivert.",
       "action": "Lær mer"
+    },
+    "featureNotEnabled": {
+      "action": "Selvhosting-guide",
+      "monitoring": {
+        "title": "Oppetidsovervåking er ikke aktivert på denne instansen",
+        "description": "Monitorer kan settes opp, men de sjekkes ikke, og ingen varsler sendes før det er aktivert."
+      },
+      "statusPages": {
+        "title": "Statussider er ikke aktivert på denne instansen",
+        "description": "Statussider kan settes opp, men de publiseres ikke før funksjonen er aktivert."
+      },
+      "statusPagesRequireMonitoring": {
+        "title": "Statussider krever oppetidsovervåking, som ikke er aktivert på denne instansen",
+        "description": "Statussider kan settes opp, men de publiseres ikke før oppetidsovervåking er aktivert."
+      },
+      "sessionReplay": {
+        "title": "Øktopptak er ikke aktivert på denne instansen",
+        "description": "Ingen økter tas opp før det er aktivert."
+      },
+      "geography": {
+        "title": "Geolokasjon er ikke aktivert på denne instansen",
+        "description": "Besøkendes plassering samles ikke inn før det er aktivert."
+      }
     }
   },
   "githubStar": {

--- a/dashboard/messages/nb.json
+++ b/dashboard/messages/nb.json
@@ -3832,7 +3832,8 @@
     },
     "status": {
       "connected": "Tilkoblet",
-      "disabled": "Deaktivert"
+      "disabled": "Deaktivert",
+      "unavailable": "Ikke tilgjengelig på denne instansen"
     },
     "actions": {
       "configure": "Konfigurer",
@@ -3922,6 +3923,9 @@
       "invalidSlackWebhook": "Ugyldig Slack webhook URL",
       "invalidTeamsWebhook": "Ugyldig Teams webhook URL",
       "invalidWebhookUrl": "Ugyldig webhook URL"
+    },
+    "unavailable": {
+      "description": "{name} krever et app-token konfigurert på denne instansen før den kan kobles til."
     }
   },
   "errors": {

--- a/dashboard/messages/nb.json
+++ b/dashboard/messages/nb.json
@@ -3764,7 +3764,7 @@
     },
     "monitoringNotConfigured": {
       "title": "Varsler er ikke aktive på denne instansen",
-      "description": "Integrasjoner sender kun varsler fra oppetidsovervåking, og oppetidsovervåking er deaktivert (ENABLE_UPTIME_MONITORING). Integrasjoner kan fortsatt settes opp, men ingenting blir sendt før det er aktivert."
+      "description": "Integrasjoner sender kun varsler fra oppetidsovervåking, og oppetidsovervåking er deaktivert på denne instansen. Integrasjoner kan fortsatt settes opp, men ingenting blir sendt før det er aktivert."
     },
     "integrations": {
       "pushover": {

--- a/dashboard/messages/nb.json
+++ b/dashboard/messages/nb.json
@@ -2065,6 +2065,12 @@
       "onSslExpiry": "Varsel ved SSL-utløp",
       "onSslExpiryDescription": "Send varsel når SSL-sertifikatet er i ferd med å utløpe",
       "sslExpiryDisabledTooltip": "Aktiver SSL-overvåking i Avanserte innstillinger først",
+      "emailsNotConfigured": {
+        "badge": "E-post ikke konfigurert",
+        "title": "Varsel-e-poster kan ikke leveres",
+        "description": "E-postlevering er ikke konfigurert på denne instansen, så varsel-e-poster fra oppetidsovervåking blir ikke sendt. Innstillingene beholdes og trer i kraft når e-post er konfigurert.",
+        "tooltip": "Konfigurer e-postlevering på denne instansen for å aktivere varsler"
+      },
       "failureThreshold": "Feilterskel",
       "failureThresholdDescription": "Antall påfølgende feil før varsel sendes",
       "failureCount": "{count, plural, one {{count} feil} other {{count} feil}}",
@@ -3755,6 +3761,10 @@
     "title": "Integrasjoner",
     "section": {
       "description": "Koble til tredjepartstjenester for å motta oppetidsovervåkingsvarsler når nettsiden din går ned eller kommer tilbake."
+    },
+    "monitoringNotConfigured": {
+      "title": "Varsler er ikke aktive på denne instansen",
+      "description": "Integrasjoner sender kun varsler fra oppetidsovervåking, og oppetidsovervåking er deaktivert (ENABLE_UPTIME_MONITORING). Integrasjoner kan fortsatt settes opp, men ingenting blir sendt før det er aktivert."
     },
     "integrations": {
       "pushover": {

--- a/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/geography/page.tsx
+++ b/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/geography/page.tsx
@@ -1,9 +1,12 @@
 import GeographySection from './GeographySection';
 import DashboardFilters from '@/components/dashboard/DashboardFilters';
+import { FeatureNotEnabledBanner } from '@/components/dashboard/FeatureNotEnabledBanner';
+import { isFeatureEnabled } from '@/lib/feature-flags';
 
 export default function GeographyPage() {
   return (
     <div className='fixed inset-0 top-14 w-full'>
+      {!isFeatureEnabled('enableGeolocation') && <FeatureNotEnabledBanner feature='geography' />}
       <GeographySection />
 
       <div className='fixed top-16 right-4 z-30'>

--- a/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/monitoring/CreateMonitorButton.tsx
+++ b/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/monitoring/CreateMonitorButton.tsx
@@ -6,6 +6,8 @@ import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
 import { UpgradeButton } from '@/components/billing/UpgradeButton';
 import { CreateMonitorDialog } from './CreateMonitorDialog';
+import { DisabledTooltip } from '@/components/tooltip/DisabledTooltip';
+import { useClientFeatureFlags } from '@/hooks/use-client-feature-flags';
 
 type CreateMonitorButtonProps = {
   dashboardId: string;
@@ -29,10 +31,21 @@ export function CreateMonitorButton({
   const [open, setOpen] = useState(false);
   const router = useRouter();
   const t = useTranslations('monitoringPage.form');
+  const tBanner = useTranslations('banners.featureNotEnabled.monitoring');
+  const monitoringEnabled = useClientFeatureFlags().isFeatureFlagEnabled('enableUptimeMonitoring');
 
   if (atLimit) {
     return <UpgradeButton>{t('upgradeToCreate')}</UpgradeButton>;
   }
+
+  const createButton = (featureDisabled: boolean) => (
+    <Button variant='default' className='cursor-pointer whitespace-nowrap' disabled={disabled || featureDisabled}>
+      {t('create')}
+      <span className='ml-1.5 text-xs opacity-70'>
+        ({monitorCount}/{maxMonitors})
+      </span>
+    </Button>
+  );
 
   return (
     <CreateMonitorDialog
@@ -43,12 +56,15 @@ export function CreateMonitorButton({
       existingUrls={existingUrls}
       onCreated={() => router.refresh()}
       trigger={
-        <Button variant='default' className='cursor-pointer whitespace-nowrap' disabled={disabled}>
-          {t('create')}
-          <span className='ml-1.5 text-xs opacity-70'>
-            ({monitorCount}/{maxMonitors})
+        monitoringEnabled ? (
+          createButton(false)
+        ) : (
+          <span>
+            <DisabledTooltip disabled message={tBanner('title')}>
+              {createButton}
+            </DisabledTooltip>
           </span>
-        </Button>
+        )
       }
     />
   );

--- a/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/monitoring/page.tsx
+++ b/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/monitoring/page.tsx
@@ -2,7 +2,7 @@ import { fetchMonitorChecksAction } from '@/app/actions/analytics/monitoring.act
 import { getCurrentDashboardAction } from '@/app/actions/dashboard/dashboard.action';
 import { getUserTimezone } from '@/lib/cookies';
 import { isFeatureEnabled } from '@/lib/feature-flags';
-import { notFound } from 'next/navigation';
+import { FeatureNotEnabledBanner } from '@/components/dashboard/FeatureNotEnabledBanner';
 import { MonitoringClient } from './MonitoringClient';
 
 type MonitoringPageParams = {
@@ -10,10 +10,6 @@ type MonitoringPageParams = {
 };
 
 export default async function MonitoringPage({ params }: MonitoringPageParams) {
-  if (!isFeatureEnabled('enableUptimeMonitoring')) {
-    notFound();
-  }
-
   const { dashboardId } = await params;
   const timezone = await getUserTimezone();
   const [monitors, dashboard] = await Promise.all([
@@ -23,11 +19,8 @@ export default async function MonitoringPage({ params }: MonitoringPageParams) {
 
   return (
     <div className='container space-y-4 p-2 pt-4 sm:p-6'>
-      <MonitoringClient
-        dashboardId={dashboardId}
-        monitors={monitors}
-        domain={dashboard.domain}
-      />
+      {!isFeatureEnabled('enableUptimeMonitoring') && <FeatureNotEnabledBanner feature='monitoring' />}
+      <MonitoringClient dashboardId={dashboardId} monitors={monitors} domain={dashboard.domain} />
     </div>
   );
 }

--- a/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/monitoring/shared/components/AlertsSection.tsx
+++ b/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/monitoring/shared/components/AlertsSection.tsx
@@ -5,6 +5,8 @@ import { useTranslations } from 'next-intl';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { LabeledSlider } from '@/components/inputs/LabeledSlider';
 import { SettingToggle } from '@/components/inputs/SettingToggle';
+import { WarningBanner } from '@/components/WarningBanner';
+import { useClientFeatureFlags } from '@/hooks/use-client-feature-flags';
 import { SectionHeader } from './SectionHeader';
 import { SSL_EXPIRY_MARKS, SSL_EXPIRY_DISPLAY_MARKS, RECOMMENDED_SSL_EXPIRY_DAYS } from '../utils/sliderConstants';
 import type { MonitorFormInterface } from '../types';
@@ -30,6 +32,12 @@ export function AlertsSection({
 }: AlertsSectionProps) {
   const t = useTranslations('monitoringEditDialog.alerts');
   const { state, setField } = form;
+  const alertEmailsEnabled = useClientFeatureFlags().isFeatureFlagEnabled('enableEmails');
+  // Alerts only deliver over email; keep the stored preference but never present it as active when emails are off
+  const alertsActive = alertEmailsEnabled && state.alertsEnabled;
+  // Config-blocked: keep the options discoverable (disabled). User-disabled: collapse them.
+  const showAlertOptions = !alertEmailsEnabled || state.alertsEnabled;
+  const optionsDisabled = isPending || !alertEmailsEnabled;
 
   return (
     <Collapsible
@@ -41,7 +49,12 @@ export function AlertsSection({
       <CollapsibleTrigger className='hover:bg-muted/50 -mx-2 flex w-[calc(100%+1rem)] cursor-pointer items-center justify-between rounded-lg px-2 py-2 transition-colors'>
         <SectionHeader icon={Bell} title={t('title')} />
         <div className='flex items-center gap-2'>
-          {state.alertsEnabled && (
+          {!alertEmailsEnabled && (
+            <span className='rounded-full bg-orange-500/10 px-2 py-0.5 text-xs font-medium text-orange-600 dark:text-orange-400'>
+              {t('emailsNotConfigured.badge')}
+            </span>
+          )}
+          {alertsActive && (
             <span className='rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-600 dark:text-emerald-400'>
               {t('enabled')}
             </span>
@@ -51,7 +64,14 @@ export function AlertsSection({
       </CollapsibleTrigger>
 
       <CollapsibleContent className='data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down overflow-x-visible overflow-y-clip'>
-        <div className='space-y-5 pt-4'>
+        <div className='space-y-5 pt-4 pb-3'>
+          {!alertEmailsEnabled && (
+            <WarningBanner
+              title={t('emailsNotConfigured.title')}
+              description={t('emailsNotConfigured.description')}
+            />
+          )}
+
           <SettingToggle
             id='alerts-enabled'
             label={
@@ -59,19 +79,20 @@ export function AlertsSection({
                 {t('enableAlerts')} <span className='text-muted-foreground font-normal'>({userEmail})</span>
               </>
             }
-            checked={state.alertsEnabled}
+            checked={alertsActive}
             onCheckedChange={setField('alertsEnabled')}
-            disabled={isPending}
+            disabled={isPending || !alertEmailsEnabled}
+            disabledTooltip={!alertEmailsEnabled ? t('emailsNotConfigured.tooltip') : undefined}
           />
 
-          {state.alertsEnabled && (
+          {showAlertOptions && (
             <div className='space-y-5 pl-1'>
               <SettingToggle
                 id='alert-on-down'
                 label={t('onDown')}
                 checked={state.alertOnDown}
                 onCheckedChange={setField('alertOnDown')}
-                disabled={isPending}
+                disabled={optionsDisabled}
               />
 
               <SettingToggle
@@ -79,7 +100,7 @@ export function AlertsSection({
                 label={t('onRecovery')}
                 checked={state.alertOnRecovery}
                 onCheckedChange={setField('alertOnRecovery')}
-                disabled={isPending}
+                disabled={optionsDisabled}
               />
 
               <SettingToggle
@@ -87,8 +108,10 @@ export function AlertsSection({
                 label={t('onSslExpiry')}
                 checked={sslMonitoringEnabled && state.alertOnSslExpiry}
                 onCheckedChange={setField('alertOnSslExpiry')}
-                disabled={isPending || !sslMonitoringEnabled}
-                disabledTooltip={!sslMonitoringEnabled ? t('sslExpiryDisabledTooltip') : undefined}
+                disabled={optionsDisabled || !sslMonitoringEnabled}
+                disabledTooltip={
+                  alertEmailsEnabled && !sslMonitoringEnabled ? t('sslExpiryDisabledTooltip') : undefined
+                }
               />
 
               {sslMonitoringEnabled && state.alertOnSslExpiry && (
@@ -107,7 +130,7 @@ export function AlertsSection({
                       suffix: ` ${t('unit', { count: state.sslExpiryAlertDays })}`,
                     }}
                     recommendedValue={SSL_EXPIRY_MARKS.indexOf(RECOMMENDED_SSL_EXPIRY_DAYS)}
-                    disabled={isPending}
+                    disabled={optionsDisabled}
                   />
                 </div>
               )}

--- a/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/monitoring/shared/components/TimingSection.tsx
+++ b/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/monitoring/shared/components/TimingSection.tsx
@@ -63,7 +63,7 @@ export function TimingSection({ form, isPending, open, onOpenChange, defaultOpen
       </CollapsibleTrigger>
 
       <CollapsibleContent className='data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down overflow-x-visible overflow-y-clip'>
-        <div className='space-y-6 pt-4'>
+        <div className='space-y-6 pt-4 pb-3'>
           <LabeledSlider
             label={tTiming('interval.label')}
             description={tTiming('interval.description', {

--- a/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/replay/page.tsx
+++ b/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/replay/page.tsx
@@ -3,7 +3,7 @@ import DashboardFilters from '@/components/dashboard/DashboardFilters';
 import { DashboardHeader } from '@/components/dashboard/DashboardHeader';
 import { getTranslations } from 'next-intl/server';
 import { isFeatureEnabled } from '@/lib/feature-flags';
-import { notFound } from 'next/navigation';
+import { FeatureNotEnabledBanner } from '@/components/dashboard/FeatureNotEnabledBanner';
 
 type PageProps = {
   params: Promise<{ dashboardId: string }>;
@@ -11,16 +11,13 @@ type PageProps = {
 };
 
 export default async function Page({ params }: PageProps) {
-  if (!isFeatureEnabled('enableSessionReplay')) {
-    notFound();
-  }
-
   const { dashboardId } = await params;
 
   const t = await getTranslations('dashboard.sidebar');
 
   return (
     <div className='w-full space-y-4 p-4'>
+      {!isFeatureEnabled('enableSessionReplay') && <FeatureNotEnabledBanner feature='sessionReplay' />}
       <DashboardHeader title={t('sessionReplay')}>
         <DashboardFilters showComparison={false} />
       </DashboardHeader>

--- a/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/status-pages/StatusPagesClient.tsx
+++ b/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/status-pages/StatusPagesClient.tsx
@@ -37,6 +37,8 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { PermissionGate } from '@/components/tooltip/PermissionGate';
+import { DisabledTooltip } from '@/components/tooltip/DisabledTooltip';
+import { useClientFeatureFlags } from '@/hooks/use-client-feature-flags';
 import { StatusPageBrandAvatar } from '@/components/statusPage/StatusPageBrandAvatar';
 import { DashboardHeader } from '@/components/dashboard/DashboardHeader';
 import { UpgradeButton } from '@/components/billing/UpgradeButton';
@@ -44,10 +46,7 @@ import { useCapabilities } from '@/contexts/CapabilitiesProvider';
 import { useDashboardNavigation } from '@/contexts/DashboardNavigationContext';
 import { useCopy } from '@/hooks/use-copy';
 import { cn } from '@/lib/utils';
-import {
-  useDeleteStatusPageMutation,
-  useSetStatusPagePublishedMutation,
-} from './shared/useStatusPageMutations';
+import { useDeleteStatusPageMutation, useSetStatusPagePublishedMutation } from './shared/useStatusPageMutations';
 import type { StatusPageListItem } from '@/entities/analytics/statusPage/statusPage.entities';
 import { statusPagePublicUrl, statusPagePublicUrlLabel } from '@/entities/analytics/statusPage/statusPage.helpers';
 import type { MonitorOperationalState } from '@/entities/analytics/monitoring.entities';
@@ -98,6 +97,8 @@ export function StatusPagesClient({
   domain,
 }: StatusPagesClientProps) {
   const t = useTranslations('statusPagesPage');
+  const tBanner = useTranslations('banners.featureNotEnabled.statusPages');
+  const featureEnabled = useClientFeatureFlags().isFeatureFlagEnabled('enablePublicStatusPages');
   const tStatus = useTranslations('monitoring.status');
   const router = useRouter();
   const { caps } = useCapabilities();
@@ -138,10 +139,18 @@ export function StatusPagesClient({
     ) : (
       <PermissionGate>
         {(disabled) => (
-          <Button disabled={disabled} onClick={() => setShowCreateStudio(true)} className='cursor-pointer'>
-            <Plus className='mr-1 h-4 w-4' />
-            {label}
-          </Button>
+          <DisabledTooltip disabled={!featureEnabled} message={tBanner('title')}>
+            {(featureDisabled) => (
+              <Button
+                disabled={disabled || featureDisabled}
+                onClick={() => setShowCreateStudio(true)}
+                className='cursor-pointer'
+              >
+                <Plus className='mr-1 h-4 w-4' />
+                {label}
+              </Button>
+            )}
+          </DisabledTooltip>
         )}
       </PermissionGate>
     );
@@ -199,9 +208,7 @@ export function StatusPagesClient({
           </div>
           {incidentPages.length === 1 && (
             <Button asChild variant='outline' size='sm' className='shrink-0'>
-              <Link href={resolveHref(`status-pages/${incidentPages[0].id}`)}>
-                {t('banner.viewIncidents')}
-              </Link>
+              <Link href={resolveHref(`status-pages/${incidentPages[0].id}`)}>{t('banner.viewIncidents')}</Link>
             </Button>
           )}
         </div>

--- a/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/status-pages/page.tsx
+++ b/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/status-pages/page.tsx
@@ -1,4 +1,3 @@
-import { notFound } from 'next/navigation';
 import { fetchStatusPagesAction } from '@/app/actions/analytics/statusPage.actions';
 import { fetchMonitorChecksAction } from '@/app/actions/analytics/monitoring.actions';
 import { getCurrentDashboardAction } from '@/app/actions/dashboard/dashboard.action';
@@ -7,16 +6,13 @@ import { env } from '@/lib/env';
 import { isFeatureEnabled } from '@/lib/feature-flags';
 import type { MonitorOperationalState } from '@/entities/analytics/monitoring.entities';
 import { StatusPagesClient } from './StatusPagesClient';
+import { FeatureNotEnabledBanner } from '@/components/dashboard/FeatureNotEnabledBanner';
 
 type StatusPagesPageParams = {
   params: Promise<{ dashboardId: string }>;
 };
 
 export default async function StatusPagesPage({ params }: StatusPagesPageParams) {
-  if (!isFeatureEnabled('enablePublicStatusPages')) {
-    notFound();
-  }
-
   const { dashboardId } = await params;
   const [statusPages, dashboard] = await Promise.all([
     fetchStatusPagesAction(dashboardId),
@@ -34,6 +30,11 @@ export default async function StatusPagesPage({ params }: StatusPagesPageParams)
 
   return (
     <div className='container space-y-4 p-2 pt-4 sm:p-6'>
+      {!isFeatureEnabled('enablePublicStatusPages') && (
+        <FeatureNotEnabledBanner
+          feature={isFeatureEnabled('enableUptimeMonitoring') ? 'statusPages' : 'statusPagesRequireMonitoring'}
+        />
+      )}
       <StatusPagesClient
         dashboardId={dashboardId}
         statusPages={statusPages}

--- a/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(settings)/settings/integrations/IntegrationCard.tsx
+++ b/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(settings)/settings/integrations/IntegrationCard.tsx
@@ -20,6 +20,7 @@ type IntegrationCardProps = {
   name: string;
   description: string;
   integration?: Integration;
+  unavailable?: boolean;
   isPending: boolean;
   onConfigure: () => void;
   onDisconnect: () => void;
@@ -31,6 +32,7 @@ export function IntegrationCard({
   name,
   description,
   integration,
+  unavailable = false,
   isPending,
   onConfigure,
   onDisconnect,
@@ -38,6 +40,24 @@ export function IntegrationCard({
 }: IntegrationCardProps) {
   const t = useTranslations('integrationsSettings');
   const isConnected = !!integration;
+
+  if (unavailable) {
+    return (
+      <div className='bg-card flex items-center gap-4 rounded-lg border border-dashed px-4 py-4'>
+        <Image src={iconSrc} alt={name} width={32} height={32} className='flex-shrink-0 opacity-50' />
+
+        <div className='min-w-0 flex-1'>
+          <div className='flex items-center gap-2'>
+            <span className='text-muted-foreground text-sm font-semibold'>{name}</span>
+            <Badge variant='secondary' className='border-border rounded-full px-2 py-0 text-[10px]'>
+              {t('status.unavailable')}
+            </Badge>
+          </div>
+          <p className='text-muted-foreground mt-0.5 text-xs'>{t('unavailable.description', { name })}</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className='bg-card hover:bg-accent/30 flex items-center gap-4 rounded-lg border px-4 py-4 transition-colors'>

--- a/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(settings)/settings/integrations/IntegrationsSettings.tsx
+++ b/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(settings)/settings/integrations/IntegrationsSettings.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition, useMemo, use } from 'react';
 import { toast } from 'sonner';
 import SettingsPageHeader from '@/components/settings/SettingsPageHeader';
+import { WarningBanner } from '@/components/WarningBanner';
 import { useDashboardId } from '@/hooks/use-dashboard-id';
 import {
   saveIntegrationAction,
@@ -28,11 +29,13 @@ import { NotificationHistoryDialog } from '@/components/dialogs/NotificationHist
 interface IntegrationsSettingsProps {
   availableTypesPromise: Promise<IntegrationType[]>;
   integrationsPromise: Promise<Integration[]>;
+  monitoringEnabled: boolean;
 }
 
 export default function IntegrationsSettings({
   availableTypesPromise,
   integrationsPromise,
+  monitoringEnabled,
 }: IntegrationsSettingsProps) {
   const t = useTranslations('integrationsSettings');
   const dashboardId = useDashboardId();
@@ -124,6 +127,14 @@ export default function IntegrationsSettings({
       </div>
 
       <p className='text-muted-foreground -mt-4 mb-6 text-sm'>{t('section.description')}</p>
+
+      {!monitoringEnabled && (
+        <WarningBanner
+          className='mb-6'
+          title={t('monitoringNotConfigured.title')}
+          description={t('monitoringNotConfigured.description')}
+        />
+      )}
 
       <div className='space-y-3'>
         {availableIntegrations.map((def) => (

--- a/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(settings)/settings/integrations/IntegrationsSettings.tsx
+++ b/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(settings)/settings/integrations/IntegrationsSettings.tsx
@@ -59,11 +59,6 @@ export default function IntegrationsSettings({
     [t],
   );
 
-  const availableIntegrations = useMemo(
-    () => allIntegrations.filter((def) => initialTypes.includes(def.type)),
-    [allIntegrations, initialTypes],
-  );
-
   const handleSave = (type: IntegrationType, config: IntegrationConfigInput) => {
     startTransition(async () => {
       try {
@@ -137,13 +132,14 @@ export default function IntegrationsSettings({
       )}
 
       <div className='space-y-3'>
-        {availableIntegrations.map((def) => (
+        {allIntegrations.map((def) => (
           <IntegrationCard
             key={def.type}
             iconSrc={def.iconSrc}
             name={def.name}
             description={def.description}
             integration={integrations[def.type]}
+            unavailable={!initialTypes.includes(def.type)}
             isPending={isPending}
             onConfigure={() => setConfigDialogType(def.type)}
             onDisconnect={() => setDisconnectType(def.type)}

--- a/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(settings)/settings/integrations/page.tsx
+++ b/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(settings)/settings/integrations/page.tsx
@@ -2,6 +2,7 @@ import {
   getAvailableIntegrationTypesAction,
   getIntegrationsAction,
 } from '@/app/actions/dashboard/integrations.action';
+import { isFeatureEnabled } from '@/lib/feature-flags';
 import IntegrationsSettings from './IntegrationsSettings';
 
 type IntegrationsPageProps = {
@@ -12,11 +13,14 @@ export default async function IntegrationsPage({ params }: IntegrationsPageProps
   const { dashboardId } = await params;
   const availableTypesPromise = getAvailableIntegrationTypesAction(dashboardId);
   const integrationsPromise = getIntegrationsAction(dashboardId);
+  // Integrations are only ever triggered by uptime monitoring, so without it nothing will be delivered
+  const monitoringEnabled = isFeatureEnabled('enableUptimeMonitoring');
 
   return (
     <IntegrationsSettings
       availableTypesPromise={availableTypesPromise}
       integrationsPromise={integrationsPromise}
+      monitoringEnabled={monitoringEnabled}
     />
   );
 }

--- a/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(settings)/settings/reports/ReportsSettings.tsx
+++ b/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(settings)/settings/reports/ReportsSettings.tsx
@@ -5,11 +5,12 @@ import { Switch } from '@/components/ui/switch';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { AlertCircle, Mail, Plus, X } from 'lucide-react';
+import { Mail, Plus, X } from 'lucide-react';
 import { z } from 'zod';
 import { toast } from 'sonner';
 import SettingsSection from '@/components/settings/SettingsSection';
 import SettingsPageHeader from '@/components/settings/SettingsPageHeader';
+import { WarningBanner } from '@/components/WarningBanner';
 import { useSettings } from '@/contexts/SettingsProvider';
 import { useDashboardId } from '@/hooks/use-dashboard-id';
 import { updateDashboardSettingsAction } from '@/app/actions/dashboard/dashboardSettings.action';
@@ -229,13 +230,11 @@ export default function ReportsSettings({ emailsEnabled }: { emailsEnabled: bool
       <SettingsPageHeader title={t('title')} />
 
       {!emailsEnabled && (
-        <div className='mb-6 flex items-center gap-3 rounded-lg border border-orange-200 bg-orange-50 p-3 dark:border-orange-800 dark:bg-orange-950'>
-          <AlertCircle className='h-5 w-5 flex-shrink-0 text-orange-600 dark:text-orange-400' />
-          <div className='flex-1'>
-            <p className='text-sm font-medium text-orange-800 dark:text-orange-200'>{t('emailsNotConfigured.title')}</p>
-            <p className='text-xs text-orange-700 dark:text-orange-300'>{t('emailsNotConfigured.description')}</p>
-          </div>
-        </div>
+        <WarningBanner
+          className='mb-6'
+          title={t('emailsNotConfigured.title')}
+          description={t('emailsNotConfigured.description')}
+        />
       )}
 
       <div className='space-y-6'>

--- a/dashboard/src/app/actions/analytics/monitoring.actions.ts
+++ b/dashboard/src/app/actions/analytics/monitoring.actions.ts
@@ -23,6 +23,7 @@ import { revalidatePath } from 'next/cache';
 import { findDashboardById } from '@/repositories/postgres/dashboard.repository';
 import { isUrlOnDomain } from '@/utils/domainValidation';
 import { UserException } from '@/lib/exceptions';
+import { isFeatureEnabled } from '@/lib/feature-flags';
 import { getDashboardCapabilities } from '@/lib/billing/capabilityAccess';
 import { monitoringValidator } from '@/lib/billing/validators';
 import z from 'zod';
@@ -37,6 +38,10 @@ export const fetchMonitorCheckAction = withDashboardAuthContext(
 
 export const createMonitorCheckAction = withDashboardMutationAuthContext(
   async (ctx: AuthContext, input: z.input<typeof MonitorCheckCreateSchema>) => {
+    if (!isFeatureEnabled('enableUptimeMonitoring')) {
+      throw new UserException('Uptime monitoring is not enabled');
+    }
+    
     const t = await getTranslations('validation');
     const payload = MonitorCheckCreateSchema.parse(input);
 

--- a/dashboard/src/app/actions/dashboard/integrations.action.ts
+++ b/dashboard/src/app/actions/dashboard/integrations.action.ts
@@ -36,6 +36,10 @@ export const saveIntegrationAction = withDashboardMutationAuthContext(
     config: IntegrationConfigInput,
     name?: string | null,
   ): Promise<SaveIntegrationResult> => {
+    if (!integrationAvailability[type]()) {
+      return { success: false, error: 'unavailable' };
+    }
+
     const validationError = await IntegrationService.validateIntegrationConfig(type, config);
     if (validationError) {
       return { success: false, error: validationError };

--- a/dashboard/src/components/WarningBanner.tsx
+++ b/dashboard/src/components/WarningBanner.tsx
@@ -1,0 +1,27 @@
+import { AlertCircle } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { ReactNode } from 'react';
+
+type WarningBannerProps = {
+  title: ReactNode;
+  description?: ReactNode;
+  className?: string;
+};
+
+export function WarningBanner({ title, description, className }: WarningBannerProps) {
+  return (
+    <div
+      role='status'
+      className={cn(
+        'flex items-center gap-3 rounded-lg border border-orange-200 bg-orange-50 p-3 dark:border-orange-800 dark:bg-orange-950',
+        className,
+      )}
+    >
+      <AlertCircle className='h-5 w-5 flex-shrink-0 text-orange-600 dark:text-orange-400' />
+      <div className='flex-1'>
+        <p className='text-sm font-medium text-orange-800 dark:text-orange-200'>{title}</p>
+        {description && <p className='text-xs text-orange-700 dark:text-orange-300'>{description}</p>}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/dashboard/FeatureNotEnabledBanner.tsx
+++ b/dashboard/src/components/dashboard/FeatureNotEnabledBanner.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useTranslations } from 'next-intl';
+import { Button } from '@/components/ui/button';
+import { useBannerContext } from '@/contexts/BannerProvider';
+
+export type NotEnabledFeature =
+  'monitoring' | 'statusPages' | 'statusPagesRequireMonitoring' | 'sessionReplay' | 'geography';
+
+type FeatureNotEnabledBannerProps = {
+  feature: NotEnabledFeature;
+};
+
+/**
+ * Page banner for features a self-host operator can switch on through instance configuration.
+ */
+export function FeatureNotEnabledBanner({ feature }: FeatureNotEnabledBannerProps) {
+  const t = useTranslations('banners.featureNotEnabled');
+  const { addBanner } = useBannerContext();
+
+  useEffect(() => {
+    addBanner({
+      id: `feature-not-enabled-${feature}`,
+      level: 'warning',
+      title: t(`${feature}.title`),
+      description: t(`${feature}.description`),
+      action: (
+        <Button
+          variant='default'
+          className='text-primary-foreground cursor-pointer border-1 border-white bg-amber-600/50 shadow-md hover:bg-amber-600/20'
+          onClick={() => {
+            window.open('https://betterlytics.io/docs/installation/self-hosting', '_blank');
+          }}
+        >
+          {t('action')}
+        </Button>
+      ),
+      dismissible: true,
+    });
+  }, [feature, t, addBanner]);
+
+  return null;
+}

--- a/dashboard/src/components/inputs/LabeledSlider.tsx
+++ b/dashboard/src/components/inputs/LabeledSlider.tsx
@@ -73,7 +73,7 @@ export function LabeledSlider({
 
   return (
     <div className='space-y-4'>
-      <div className='flex items-end justify-between'>
+      <div className={cn('flex items-end justify-between', disabled && 'opacity-50')}>
         <div className='space-y-0.5'>
           <Label className='text-sm font-medium'>{label}</Label>
           {description && <p className='text-muted-foreground text-xs'>{description}</p>}
@@ -87,12 +87,7 @@ export function LabeledSlider({
           )}
         >
           {valueParts ? (
-            <NumberFlow
-              className='tabular-nums'
-              locales={locale}
-              willChange
-              {...valueParts}
-            />
+            <NumberFlow className='tabular-nums' locales={locale} willChange {...valueParts} />
           ) : (
             formatValue(value)
           )}
@@ -110,7 +105,7 @@ export function LabeledSlider({
           disabled={disabled}
           className='cursor-pointer dark:[&_[role=slider]]:bg-white'
         />
-        <div className='relative h-4 w-full'>
+        <div className={cn('relative h-4 w-full', disabled && 'opacity-50')}>
           {marks.map(({ idx, label: markLabel }) => {
             const percent = ((idx - min) / totalSteps) * 100;
             const isLocked = minAllowed !== undefined && idx < minAllowed;

--- a/dashboard/src/components/inputs/SettingToggle.tsx
+++ b/dashboard/src/components/inputs/SettingToggle.tsx
@@ -3,6 +3,7 @@
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
 import type { ReactNode } from 'react';
 
 type SettingToggleProps = {
@@ -32,7 +33,7 @@ export function SettingToggle({
     <>
       <div className='space-y-1'>
         <div className='flex items-center justify-between gap-4'>
-          <Label htmlFor={id} className='text-sm font-medium'>
+          <Label htmlFor={id} className={cn('text-sm font-medium', disabled && 'opacity-50')}>
             {label}
           </Label>
           {disabled && disabledTooltip ? (
@@ -48,7 +49,9 @@ export function SettingToggle({
             toggle
           )}
         </div>
-        {description && <p className='text-muted-foreground text-xs'>{description}</p>}
+        {description && (
+          <p className={cn('text-muted-foreground text-xs', disabled && 'opacity-50')}>{description}</p>
+        )}
       </div>
       {children}
     </>

--- a/dashboard/src/components/sidebar/BASidebar.tsx
+++ b/dashboard/src/components/sidebar/BASidebar.tsx
@@ -41,7 +41,6 @@ import { DashboardDropdown } from './DashboardDropdown';
 import { getTranslations } from 'next-intl/server';
 import { ActiveUsersLabel } from './ActiveUsersLabel';
 import { Badge } from '../ui/badge';
-import { isFeatureEnabled } from '@/lib/feature-flags';
 import { Dashboard } from '@/entities/dashboard/dashboard.entities';
 
 const ICON_SIZE = 16;
@@ -105,7 +104,7 @@ export default async function BASidebar({ dashboardId, isDemo }: BASidebarProps)
       key: 'sessionReplay',
       href: '/replay',
       icon: <Video size={ICON_SIZE} />,
-      hidden: !isFeatureEnabled('enableSessionReplay') || isDemo,
+      hidden: isDemo,
       hideOnMobile: true,
     },
   ];
@@ -118,14 +117,12 @@ export default async function BASidebar({ dashboardId, isDemo }: BASidebarProps)
       key: 'monitoring',
       href: '/monitoring',
       icon: <Activity size={ICON_SIZE} />,
-      hidden: !isFeatureEnabled('enableUptimeMonitoring'),
     },
     {
       name: t('statusPages'),
       key: 'statusPages',
       href: '/status-pages',
       icon: <Radio size={ICON_SIZE} />,
-      hidden: !isFeatureEnabled('enablePublicStatusPages'),
     },
   ];
 
@@ -190,7 +187,6 @@ export default async function BASidebar({ dashboardId, isDemo }: BASidebarProps)
                         <span className='dark:text-muted-foreground/90'>{item.icon}</span>
                         <span>{item.name}</span>
                       </div>
-
                     </FilterPreservingLink>
                   </SidebarMenuButton>
                 </SidebarMenuItem>

--- a/dashboard/src/components/ui/slider.tsx
+++ b/dashboard/src/components/ui/slider.tsx
@@ -12,7 +12,7 @@ const Slider = React.forwardRef<
   <SliderPrimitive.Root
     ref={ref}
     className={cn(
-      "relative flex w-full touch-none select-none items-center",
+      "relative flex w-full touch-none select-none items-center data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     {...props}

--- a/dashboard/src/contexts/BannerProvider.tsx
+++ b/dashboard/src/contexts/BannerProvider.tsx
@@ -136,7 +136,7 @@ export function BannerProvider({ children }: BannerProviderProps) {
   return (
     <BannerContext.Provider value={{ addBanner, removeBanner, dismissBanner }}>
       <div className='w-full overflow-x-hidden'>
-        <div className={cn('w-full space-y-0 overflow-hidden p-0', nowVisible.length && 'border-b')}>
+        <div className={cn('relative z-20 w-full space-y-0 overflow-hidden p-0', nowVisible.length && 'border-b')}>
           {nowVisible.map((banner) => (
             <Banner key={banner.id} banner={banner} banners={nowVisible} />
           ))}

--- a/dashboard/src/lib/env.ts
+++ b/dashboard/src/lib/env.ts
@@ -92,6 +92,17 @@ const envSchema = sharedEmailEnvSchema.merge(appEnvSchema).superRefine((env, ctx
       path: ['STATUS_PAGE_ASK_SECRET'],
     });
   }
+
+  // Emails, data retention purges and scheduled reports are all worker jobs, so disabling
+  // background jobs outside development makes those features fail silently.
+  if (!env.IS_DEVELOPMENT && !env.BACKGROUND_JOBS_ENABLED) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message:
+        'BACKGROUND_JOBS_ENABLED=false is only supported in development. Emails, data retention and scheduled reports all run as background jobs, so set BACKGROUND_JOBS_ENABLED=true.',
+      path: ['BACKGROUND_JOBS_ENABLED'],
+    });
+  }
 });
 
 if (!process.env.AUTH_SECRET && process.env.NEXTAUTH_SECRET) {

--- a/dashboard/src/lib/env.ts
+++ b/dashboard/src/lib/env.ts
@@ -92,17 +92,6 @@ const envSchema = sharedEmailEnvSchema.merge(appEnvSchema).superRefine((env, ctx
       path: ['STATUS_PAGE_ASK_SECRET'],
     });
   }
-
-  // Emails, data retention purges and scheduled reports are all worker jobs, so disabling
-  // background jobs outside development makes those features fail silently.
-  if (!env.IS_DEVELOPMENT && !env.BACKGROUND_JOBS_ENABLED) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message:
-        'BACKGROUND_JOBS_ENABLED=false is only supported in development. Emails, data retention and scheduled reports all run as background jobs, so set BACKGROUND_JOBS_ENABLED=true.',
-      path: ['BACKGROUND_JOBS_ENABLED'],
-    });
-  }
 });
 
 if (!process.env.AUTH_SECRET && process.env.NEXTAUTH_SECRET) {

--- a/dashboard/src/lib/feature-flags-factory.ts
+++ b/dashboard/src/lib/feature-flags-factory.ts
@@ -1,6 +1,6 @@
 import type { env } from '@/lib/env';
 
-type FeatureFlagEnvironmentKeys = 'PUBLIC_IS_CLOUD';
+type FeatureFlagEnvironmentKeys = 'PUBLIC_IS_CLOUD' | 'ENABLE_EMAILS';
 export type FeatureFlagEnvironment = {
   [K in FeatureFlagEnvironmentKeys]: (typeof env)[K];
 };
@@ -9,6 +9,7 @@ export function createFeatureFlags(environment: FeatureFlagEnvironment) {
   return {
     enableBilling: environment.PUBLIC_IS_CLOUD,
     isCloud: environment.PUBLIC_IS_CLOUD,
-    enableBugReports: environment.PUBLIC_IS_CLOUD
+    enableBugReports: environment.PUBLIC_IS_CLOUD,
+    enableEmails: environment.ENABLE_EMAILS,
   } as const;
 }

--- a/dashboard/src/lib/feature-flags-factory.ts
+++ b/dashboard/src/lib/feature-flags-factory.ts
@@ -1,6 +1,7 @@
 import type { env } from '@/lib/env';
 
-type FeatureFlagEnvironmentKeys = 'PUBLIC_IS_CLOUD' | 'ENABLE_EMAILS';
+type FeatureFlagEnvironmentKeys =
+  'PUBLIC_IS_CLOUD' | 'ENABLE_EMAILS' | 'ENABLE_UPTIME_MONITORING' | 'ENABLE_PUBLIC_STATUS_PAGES';
 export type FeatureFlagEnvironment = {
   [K in FeatureFlagEnvironmentKeys]: (typeof env)[K];
 };
@@ -11,5 +12,7 @@ export function createFeatureFlags(environment: FeatureFlagEnvironment) {
     isCloud: environment.PUBLIC_IS_CLOUD,
     enableBugReports: environment.PUBLIC_IS_CLOUD,
     enableEmails: environment.ENABLE_EMAILS,
+    enableUptimeMonitoring: environment.ENABLE_UPTIME_MONITORING,
+    enablePublicStatusPages: environment.ENABLE_UPTIME_MONITORING && environment.ENABLE_PUBLIC_STATUS_PAGES,
   } as const;
 }

--- a/dashboard/src/lib/feature-flags.ts
+++ b/dashboard/src/lib/feature-flags.ts
@@ -10,6 +10,7 @@ export const featureFlags = {
   enableAccountVerification: env.ENABLE_ACCOUNT_VERIFICATION,
   enableBilling: env.ENABLE_BILLING,
   enableSessionReplay: env.SESSION_REPLAYS_ENABLED,
+  enableGeolocation: env.ENABLE_GEOLOCATION,
   enableBugReports: env.IS_CLOUD,
   enableUptimeMonitoring: env.ENABLE_UPTIME_MONITORING,
   // Status pages publish uptime data, so they additionally require monitoring to be enabled

--- a/dashboard/src/services/system/environment.service.ts
+++ b/dashboard/src/services/system/environment.service.ts
@@ -8,7 +8,11 @@ type PublicPrefixedKey = keyof typeof env & `PUBLIC_${string}`;
  * Non-`PUBLIC_` feature flags that are safe to expose to the client.
  * They reveal feature availability only, never secrets.
  */
-const EXPOSED_FEATURE_FLAG_KEYS = ['ENABLE_EMAILS'] as const satisfies readonly (keyof typeof env)[];
+const EXPOSED_FEATURE_FLAG_KEYS = [
+  'ENABLE_EMAILS',
+  'ENABLE_UPTIME_MONITORING',
+  'ENABLE_PUBLIC_STATUS_PAGES',
+] as const satisfies readonly (keyof typeof env)[];
 
 export const PUBLIC_ENVIRONMENT_VARIABLES_KEYS: readonly (
   PublicPrefixedKey | (typeof EXPOSED_FEATURE_FLAG_KEYS)[number]

--- a/dashboard/src/services/system/environment.service.ts
+++ b/dashboard/src/services/system/environment.service.ts
@@ -2,9 +2,20 @@ import 'server-only';
 
 import { env } from '@/lib/env';
 
-export const PUBLIC_ENVIRONMENT_VARIABLES_KEYS = Object.keys(env).filter((key) =>
-  key.startsWith('PUBLIC_'),
-) as readonly (keyof typeof env & `PUBLIC_${string}`)[];
+type PublicPrefixedKey = keyof typeof env & `PUBLIC_${string}`;
+
+/**
+ * Non-`PUBLIC_` feature flags that are safe to expose to the client.
+ * They reveal feature availability only, never secrets.
+ */
+const EXPOSED_FEATURE_FLAG_KEYS = ['ENABLE_EMAILS'] as const satisfies readonly (keyof typeof env)[];
+
+export const PUBLIC_ENVIRONMENT_VARIABLES_KEYS: readonly (
+  PublicPrefixedKey | (typeof EXPOSED_FEATURE_FLAG_KEYS)[number]
+)[] = [
+  ...(Object.keys(env).filter((key) => key.startsWith('PUBLIC_')) as PublicPrefixedKey[]),
+  ...EXPOSED_FEATURE_FLAG_KEYS,
+];
 
 export type PublicEnvironmentVariableKeys = (typeof PUBLIC_ENVIRONMENT_VARIABLES_KEYS)[number];
 


### PR DESCRIPTION
Notification integrations, monitor alerts, uptime monitoring, status pages, session replay and geography all become available to selfhosters, and each depends on instance configuration. This makes the UI state that up front: settings pages show a warning banner when what they configure is not switched on, and config-gated feature pages stay browsable with a page banner plus disabled create actions rather than being hidden.

Closes betterlytics/betterlytics-internal#40
Closes betterlytics/betterlytics-internal#92
Closes betterlytics/betterlytics-internal#147

Deviation from #40: Pushover is already limited to instances with `PUSHOVER_APP_TOKEN`, and Slack, Discord, Teams and webhooks all work on self-host once monitoring is on, so no integration is gated off entirely. The real dependency is monitoring, not cloud. Instead of hiding the Pushover card, it now renders in a muted "not available on this instance" state.

Reviewer notes:
- `ENABLE_EMAILS`, `ENABLE_UPTIME_MONITORING` and `ENABLE_PUBLIC_STATUS_PAGES` are now readable client-side through an explicit allowlist in `environment.service.ts`. The rendered payload carries only those three plus the existing `PUBLIC_*` keys.
- `createMonitorCheckAction` refuses when monitoring is off, matching the guard the status page mutations already had. Update and delete stay open so existing monitors remain manageable.
- `ui/slider.tsx`, `LabeledSlider` and `SettingToggle` now actually look disabled. Radix sets `data-disabled`, so the old `disabled:` styling never matched the span thumb. This also changes the existing SSL-expiry and pending states.
- `BannerProvider`'s strip got `relative z-20` so banners render above fixed page content (the geography map). I have confirmed this doesn't seem to cause issues and only appears on empty geography maps anyways.
- `.env.example` and `.env.production.example` now default `BACKGROUND_JOBS_ENABLED` to true, since emails, retention purges and scheduled reports all run as worker jobs.


<img width="918" height="844" alt="image" src="https://github.com/user-attachments/assets/9c92cd9e-e30b-42a8-996e-5b1da48d8ae3" />
<img width="933" height="890" alt="image" src="https://github.com/user-attachments/assets/3620bcaa-40a9-41a2-a744-03c483dac1e0" />
<img width="779" height="994" alt="image" src="https://github.com/user-attachments/assets/502d612d-b722-4c15-988d-3dc3423e6ebb" />
<img width="2554" height="1318" alt="image" src="https://github.com/user-attachments/assets/014d4e01-bcfc-4f33-9360-d373488ee225" /> (Similar banner shown on other pages where configuration can be missing)

