### PR TITLE
fix(funnels): persist funnel step order explicitly (#963)

### DIFF
--- a/dashboard/prisma/migrations/20260823120000_add_funnel_step_position/migration.sql
+++ b/dashboard/prisma/migrations/20260823120000_add_funnel_step_position/migration.sql
@@ -1,0 +1,14 @@
+-- AlterTable
+ALTER TABLE "FunnelStep" ADD COLUMN     "position" INTEGER NOT NULL DEFAULT 0;
+
+-- MigrateData: the step order was never stored, so recover the best signal still available.
+-- Prisma mints one cuid per step in the order the steps are written, and cuids sort
+-- lexicographically by creation time, so ordering by the primary key restores the authored
+-- order for the funnels the application has written.
+UPDATE "FunnelStep" AS "step"
+SET "position" = "ordered"."position"
+FROM (
+    SELECT "id", (ROW_NUMBER() OVER (PARTITION BY "funnelId" ORDER BY "id") - 1)::INTEGER AS "position"
+    FROM "FunnelStep"
+) AS "ordered"
+WHERE "step"."id" = "ordered"."id";

--- a/dashboard/prisma/migrations/20260823120000_add_funnel_step_position/migration.sql
+++ b/dashboard/prisma/migrations/20260823120000_add_funnel_step_position/migration.sql
@@ -2,13 +2,20 @@
 ALTER TABLE "FunnelStep" ADD COLUMN     "position" INTEGER NOT NULL DEFAULT 0;
 
 -- MigrateData: the step order was never stored, so recover the best signal still available.
--- Prisma mints one cuid per step in the order the steps are written, and cuids sort
--- lexicographically by creation time, so ordering by the primary key restores the authored
--- order for the funnels the application has written.
+-- Prisma mints one cuid per step in write order and cuid v1 sorts lexicographically by
+-- creation time, so the primary key recovers the authored order for every step the
+-- application has written. Some steps backfilled by 20251130102124 got gen_random_uuid()
+-- instead, which carries no order at all; nothing has rewritten those rows since, so their
+-- physical position is still the order that migration inserted them in.
 UPDATE "FunnelStep" AS "step"
 SET "position" = "ordered"."position"
 FROM (
-    SELECT "id", (ROW_NUMBER() OVER (PARTITION BY "funnelId" ORDER BY "id") - 1)::INTEGER AS "position"
+    SELECT
+        "id",
+        (ROW_NUMBER() OVER (
+            PARTITION BY "funnelId"
+            ORDER BY CASE WHEN "id" LIKE '%-%' THEN NULL ELSE "id" END NULLS LAST, "ctid"
+        ) - 1)::INTEGER AS "position"
     FROM "FunnelStep"
 ) AS "ordered"
 WHERE "step"."id" = "ordered"."id";

--- a/dashboard/prisma/schema.prisma
+++ b/dashboard/prisma/schema.prisma
@@ -300,7 +300,10 @@ model Funnel {
 model FunnelStep {
   id String @id @default(cuid())
 
-  name String
+  name     String
+  // Funnels are order-dependent, so the step order is stored explicitly rather than
+  // inferred from row order, which Postgres does not guarantee.
+  position Int    @default(0)
 
   filters FunnelStepFilter[]
 

--- a/dashboard/src/repositories/postgres/funnels.repository.test.ts
+++ b/dashboard/src/repositories/postgres/funnels.repository.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  createFunnel,
+  getFunnelById,
+  getFunnelsByDashboardId,
+  updateFunnel,
+} from '@/repositories/postgres/funnels.repository';
+
+const prismaMock = vi.hoisted(() => ({
+  funnel: {
+    findMany: vi.fn(),
+    findFirst: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/postgres', () => ({
+  default: prismaMock,
+}));
+
+const DASHBOARD_ID = 'cldashboard0000000000000';
+const FUNNEL_ID = 'clfunnel00000000000000000';
+
+function step(name: string) {
+  return { name, filters: [{ column: 'url' as const, operator: '=' as const, values: [`/${name}`] }] };
+}
+
+function positionsOf(steps: { name: string; position: number }[]) {
+  return steps.map(({ name, position }) => [name, position]);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('createFunnel', () => {
+  it('stores each step with its index in the submitted order', async () => {
+    prismaMock.funnel.create.mockResolvedValue({ id: FUNNEL_ID });
+
+    await createFunnel({
+      name: 'Checkout',
+      dashboardId: DASHBOARD_ID,
+      isStrict: true,
+      funnelSteps: [step('landing'), step('cart'), step('payment')],
+    });
+
+    const { create } = prismaMock.funnel.create.mock.calls[0][0].data.funnelSteps;
+    expect(positionsOf(create)).toEqual([
+      ['landing', 0],
+      ['cart', 1],
+      ['payment', 2],
+    ]);
+  });
+});
+
+describe('updateFunnel', () => {
+  it('renumbers the positions when an edit reorders the steps', async () => {
+    prismaMock.funnel.update.mockResolvedValue({ id: FUNNEL_ID });
+
+    await updateFunnel(DASHBOARD_ID, {
+      id: FUNNEL_ID,
+      name: 'Checkout',
+      dashboardId: DASHBOARD_ID,
+      isStrict: true,
+      funnelSteps: [step('cart'), step('landing'), step('payment')],
+    });
+
+    const { create } = prismaMock.funnel.update.mock.calls[0][0].data.funnelSteps;
+    expect(positionsOf(create)).toEqual([
+      ['cart', 0],
+      ['landing', 1],
+      ['payment', 2],
+    ]);
+  });
+});
+
+describe('reading funnels', () => {
+  const orderedSteps = expect.objectContaining({ orderBy: { position: 'asc' } });
+
+  it('asks for the steps of a single funnel in stored order', async () => {
+    prismaMock.funnel.findFirst.mockResolvedValue({
+      id: FUNNEL_ID,
+      name: 'Checkout',
+      dashboardId: DASHBOARD_ID,
+      isStrict: true,
+      funnelSteps: [],
+    });
+
+    await getFunnelById(DASHBOARD_ID, FUNNEL_ID);
+
+    expect(prismaMock.funnel.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ include: { funnelSteps: orderedSteps } }),
+    );
+  });
+
+  it('asks for the steps of every dashboard funnel in stored order', async () => {
+    prismaMock.funnel.findMany.mockResolvedValue([]);
+
+    await getFunnelsByDashboardId(DASHBOARD_ID);
+
+    expect(prismaMock.funnel.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ include: { funnelSteps: orderedSteps } }),
+    );
+  });
+});

--- a/dashboard/src/repositories/postgres/funnels.repository.ts
+++ b/dashboard/src/repositories/postgres/funnels.repository.ts
@@ -9,6 +9,9 @@ import prisma from '@/lib/postgres';
 
 const FUNNEL_STEPS_INCLUDE = {
   funnelSteps: {
+    orderBy: {
+      position: 'asc',
+    },
     include: {
       filters: true,
     },
@@ -45,8 +48,9 @@ export async function createFunnel(funnelData: CreateFunnel) {
     data: {
       ...funnelDataWithoutSteps,
       funnelSteps: {
-        create: funnelSteps.map((step) => ({
+        create: funnelSteps.map((step, position) => ({
           name: step.name,
+          position,
           filters: {
             create: step.filters,
           },
@@ -73,8 +77,9 @@ export async function updateFunnel(dashboardId: string, funnel: UpdateFunnel): P
       isStrict: funnel.isStrict,
       funnelSteps: {
         deleteMany: {},
-        create: funnel.funnelSteps.map((step) => ({
+        create: funnel.funnelSteps.map((step, position) => ({
           name: step.name,
+          position,
           filters: {
             create: step.filters,
           },


### PR DESCRIPTION
## Summary

- Funnel steps were stored without any order column and read back without an `orderBy`, so the sequence a user authored survived only as long as Postgres happened to return the rows in insertion order.
- `updateFunnel` deletes every step and recreates it, which is precisely when that stops holding — the new rows reuse space freed by the deleted ones, in whatever order the free-space map hands it back. That matches the report that this is most likely to surface after a funnel is edited.
- The array order is load-bearing downstream: `getFunnelDetails` feeds the per-step conditions positionally into ClickHouse `windowFunnel(...)`, which is order-dependent, and `toFunnel` zips `funnelSteps[i]` against `visitors[i]`. So a reshuffle silently changed both the displayed steps and the computed conversion numbers. The edit dialog's drag-to-reorder was effectively discarded on save.
- Fixed by storing the order explicitly, following the existing `StatusPageMonitor.position` precedent rather than inventing a new pattern.

## Changes

- `dashboard/prisma/schema.prisma`: add `position Int @default(0)` to `FunnelStep`.
- `dashboard/prisma/migrations/20260823120000_add_funnel_step_position/migration.sql`: add the column and backfill existing rows with `ROW_NUMBER() OVER (PARTITION BY "funnelId" ORDER BY "id") - 1`. Prisma mints one cuid per step in write order and cuids sort lexicographically by creation time, so ordering by the primary key recovers the authored order for existing data. This is best-effort recovery for rows written before the column existed — happy to drop the backfill and let everything default to 0 if you'd rather not rely on that.
- `dashboard/src/repositories/postgres/funnels.repository.ts`: write `position` from the array index in `createFunnel` and `updateFunnel`, and add `orderBy: { position: 'asc' }` to the shared `FUNNEL_STEPS_INCLUDE` so both read paths return steps in stored order.
- `dashboard/src/repositories/postgres/funnels.repository.test.ts`: new tests covering position assignment on create, renumbering after a reorder on update, and both read paths ordering by position. All four fail without the repository change.

`FunnelStepFilter` ordering is deliberately unchanged — filters within a step are `AND`-ed, so their order is not semantically significant.

Fixes #963