### PR TITLE
Persisted the recovery notification timestamp on resolved incidents

### DIFF
--- a/backend/src/monitor/service.rs
+++ b/backend/src/monitor/service.rs
@@ -277,9 +277,11 @@ impl IncidentOrchestrator {
             }
         };
 
-        self.persist_incident_snapshot(ctx).await;
-
+        // Alert first: the resolved incident gets no later snapshot, so persisting after the
+        // alert is the only chance for notified_resolve_at to reach the incident row.
         self.send_recovery_alert(ctx, incident_id, downtime_duration).await;
+
+        self.persist_incident_snapshot(ctx).await;
     }
 
     async fn send_recovery_alert(


### PR DESCRIPTION
`handle_success` persisted the incident snapshot before sending the recovery alert, and a resolved incident is never persisted again, so `notified_resolve_at` in `analytics.monitor_incidents` was always NULL even when the recovery email went out (`notified_down_at` self-heals on the next probe; the resolve path has no next probe). Sending the alert first lets the snapshot capture the tracker's recovery mark.

No linked issue; found while end-to-end testing monitor alerts. Behavior predates the worker email migration (introduced in #631).
