### PR TITLE
Added the running version to the sidebar footer for self-hosted deploys

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,5 +39,7 @@ jobs:
           push: true
           tags: ${{ steps.selfhost_meta.outputs.tags }}
           labels: ${{ steps.selfhost_meta.outputs.labels }}
+          build-args: |
+            APP_VERSION=${{ github.event.release.tag_name }}
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/betterlytics-selfhost:buildcache
           cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/betterlytics-selfhost:buildcache,mode=max

--- a/Dockerfile.selfhost
+++ b/Dockerfile.selfhost
@@ -124,3 +124,7 @@ COPY dashboard/prisma/ /app/initializer/prisma/
 
 # Copy minified analytics script for nginx
 COPY --from=static-builder /app/analytics.min.js /usr/share/nginx/html/analytics.js
+
+# Bake the release version for the dashboard
+ARG APP_VERSION=dev
+ENV APP_VERSION=$APP_VERSION

--- a/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(settings)/settings/SettingsSidebar.tsx
+++ b/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(settings)/settings/SettingsSidebar.tsx
@@ -17,6 +17,8 @@ import { getTranslations } from 'next-intl/server';
 import { FilterPreservingLink } from '@/components/ui/FilterPreservingLink';
 import { DashboardDropdown } from '@/components/sidebar/DashboardDropdown';
 import { getAllUserDashboardsAction, getCurrentDashboardAction } from '@/app/actions/index.actions';
+import { isFeatureEnabled } from '@/lib/feature-flags';
+import { env } from '@/lib/env';
 
 type SettingsSidebarProps = {
   dashboardId: string;
@@ -131,7 +133,13 @@ export default async function SettingsSidebar({ dashboardId }: SettingsSidebarPr
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>
-      <SidebarFooter></SidebarFooter>
+      <SidebarFooter className='bg-sidebar'>
+        {!isFeatureEnabled('isCloud') && (
+          <span className='text-muted-foreground/70 px-2 font-mono text-xs group-data-[collapsible=icon]:hidden'>
+            {env.APP_VERSION}
+          </span>
+        )}
+      </SidebarFooter>
     </Sidebar>
   );
 }

--- a/dashboard/src/lib/env.ts
+++ b/dashboard/src/lib/env.ts
@@ -16,6 +16,7 @@ const appEnvSchema = z.object({
   ENABLE_REGISTRATION: zStringBoolean,
   PUBLIC_IS_CLOUD: zStringBoolean,
   PUBLIC_ENABLE_FAVICON_FETCHING: zStringBooleanDefaultTrue,
+  APP_VERSION: z.string().optional().default('dev'),
   ENABLE_BILLING: zStringBoolean,
   PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string().optional().default(''),
   STRIPE_SECRET_KEY: z.string().optional().default(''),

--- a/dashboard/src/lib/feature-flags.ts
+++ b/dashboard/src/lib/feature-flags.ts
@@ -12,6 +12,7 @@ export const featureFlags = {
   enableBilling: env.ENABLE_BILLING,
   enableSessionReplay: env.SESSION_REPLAYS_ENABLED,
   enableBugReports: env.IS_CLOUD,
+  isCloud: env.IS_CLOUD,
   enableUptimeMonitoring: env.ENABLE_UPTIME_MONITORING,
   // Status pages publish uptime data, so they additionally require monitoring to be enabled
   enablePublicStatusPages: env.ENABLE_UPTIME_MONITORING && env.ENABLE_PUBLIC_STATUS_PAGES,


### PR DESCRIPTION
Re-created from #1055, which was squash-merged to the retired next branch; the same content cherry-picked onto main.

The publish workflow now bakes the release tag into the selfhost image (build arg `APP_VERSION`, exposed to the app as a server-side env var), and the dashboard renders it as muted mono text in the settings sidebar footer (moved there from the main app sidebar during the original review: the previously empty settings footer avoids spacing shifts, and anyone who cares about the version is heading to settings anyway). Release images show their exact tag, local and manual builds show `dev`, cloud hides it entirely (continuous deploys have no meaningful tag).

Closes betterlytics/betterlytics-internal#172

Deviations from ticket:
- The ticket asked for a public (browser-readable) env var. Implemented server-only (`APP_VERSION`, no `PUBLIC_` prefix) instead, for security: `PUBLIC_` keys are auto-served to anonymous callers by the public environment endpoint, and an exact version readable without auth lets anyone fingerprint an instance for known vulnerabilities. Selfhost instances lag releases, which is exactly when that matters. None of the surveyed competitors (umami, plausible, posthog, matomo) disclose their version pre-auth, matomo deliberately hides it. The version renders only on authenticated pages, gated off cloud (share pages never render the settings sidebar).
- The cloud gate is a server-side flag (`isCloud` in feature-flags.ts) rather than the client factory named in the ticket, since the sidebar is a server component. Behavior is identical, cloud sets both flags.

Reviewer notes:
- The publish.yml build-arg path only runs on a real release. If it were ever miswired the image just shows `dev`, nothing breaks; worth one glance at the footer during the next release soak.
- No selfhost compose changes needed, the value ships as image ENV.

Verified: SSR footer shows `dev` with cloud flags off and nothing with them on; logged-out fetches of the public environment endpoint and of a share page contain no version in any form; a test image built with `--build-arg APP_VERSION=v9.9.9-test` reported that value at runtime (before the mechanical ENV rename; the tagged path gets its one-glance confirmation at the next release soak).

## Demo
<img width="3692" height="1710" alt="image" src="https://github.com/user-attachments/assets/6e4a419d-f59b-4295-be12-ea669e6d77d2" />
