### PR TITLE
Name the failing variables when env validation fails instead of a masked TypeError

### DIFF
--- a/dashboard/src/lib/env.ts
+++ b/dashboard/src/lib/env.ts
@@ -1,5 +1,6 @@
 import { SUPPORTED_LANGUAGES, type SupportedLanguages } from '@/constants/i18n';
 import { z } from 'zod';
+import { parseEnv } from '@/lib/env/parse-env';
 import { sharedEmailEnvSchema, zStringBoolean, zStringBooleanDefaultTrue } from '@/lib/env/shared.env';
 
 const appEnvSchema = z.object({
@@ -102,7 +103,7 @@ if (!process.env.AUTH_URL && process.env.NEXTAUTH_URL) {
   throw new Error('NEXTAUTH_URL is no longer read. Rename it to AUTH_URL (the value can stay the same).');
 }
 
-export const env = envSchema.parse(process.env);
+export const env = parseEnv('app', envSchema);
 
 export const s3Env = {
   enabled: env.S3_ENABLED,

--- a/dashboard/src/lib/env/parse-env.test.ts
+++ b/dashboard/src/lib/env/parse-env.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { parseEnv } from '@/lib/env/parse-env';
+
+const schema = z.object({
+  AUTH_SECRET: z.string().min(1),
+  PUBLIC_BASE_URL: z.string().url(),
+  IS_CLOUD: z
+    .enum(['true', 'false'])
+    .optional()
+    .default('false')
+    .transform((val) => val === 'true'),
+});
+
+describe('parseEnv', () => {
+  it('returns parsed values with defaults applied', () => {
+    const parsed = parseEnv('test', schema, { AUTH_SECRET: 'secret', PUBLIC_BASE_URL: 'https://example.io' });
+    expect(parsed).toEqual({ AUTH_SECRET: 'secret', PUBLIC_BASE_URL: 'https://example.io', IS_CLOUD: false });
+  });
+
+  it('names every failing variable in the error message', () => {
+    expect(() => parseEnv('test', schema, { PUBLIC_BASE_URL: 'not-a-url' })).toThrowError(
+      /AUTH_SECRET: Required.*PUBLIC_BASE_URL: Invalid url/s,
+    );
+  });
+
+  it('throws a plain Error with a writable message, so Next error wrapping cannot mask it', () => {
+    let caught: unknown;
+    try {
+      parseEnv('test', schema, {});
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught).not.toBeInstanceOf(z.ZodError);
+    expect(() => {
+      (caught as Error).message = `wrapped: ${(caught as Error).message}`;
+    }).not.toThrow();
+  });
+});

--- a/dashboard/src/lib/env/parse-env.test.ts
+++ b/dashboard/src/lib/env/parse-env.test.ts
@@ -20,7 +20,7 @@ describe('parseEnv', () => {
 
   it('names every failing variable in the error message', () => {
     expect(() => parseEnv('test', schema, { PUBLIC_BASE_URL: 'not-a-url' })).toThrowError(
-      /AUTH_SECRET: Required.*PUBLIC_BASE_URL: Invalid url/s,
+      /AUTH_SECRET: Required[\s\S]*PUBLIC_BASE_URL: Invalid url/,
     );
   });
 

--- a/dashboard/src/lib/env/parse-env.ts
+++ b/dashboard/src/lib/env/parse-env.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+// Plain Error on purpose: Next assigns to err.message while ZodError's is getter-only, masking the issues
+export function parseEnv<T extends z.ZodType>(label: string, schema: T, source: unknown = process.env): z.output<T> {
+  const result = schema.safeParse(source);
+  if (result.success) {
+    return result.data;
+  }
+  const issues = result.error.issues
+    .map((issue) => `${issue.path.join('.') || '(env)'}: ${issue.message}`)
+    .join('; ');
+  throw new Error(`Invalid environment variables (${label}): ${issues}. Compare your .env against .env.example.`);
+}

--- a/dashboard/src/lib/env/parse-env.ts
+++ b/dashboard/src/lib/env/parse-env.ts
@@ -9,5 +9,5 @@ export function parseEnv<T extends z.ZodType>(label: string, schema: T, source: 
   const issues = result.error.issues
     .map((issue) => `${issue.path.join('.') || '(env)'}: ${issue.message}`)
     .join('; ');
-  throw new Error(`Invalid environment variables (${label}): ${issues}. Compare your .env against .env.example.`);
+  throw new Error(`Invalid environment variables (${label}): ${issues}. Check the environment passed to the dashboard.`);
 }

--- a/dashboard/src/lib/env/shared.env.ts
+++ b/dashboard/src/lib/env/shared.env.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { parseEnv } from './parse-env';
 
 export const zStringBoolean = z
   .enum(['true', 'false'])
@@ -17,7 +18,7 @@ export const sharedEmailEnvSchema = z.object({
   PUBLIC_BASE_URL: z.string().optional().default('https://betterlytics.io'),
 });
 
-const parsedSharedEmailEnv = sharedEmailEnvSchema.parse(process.env);
+const parsedSharedEmailEnv = parseEnv('shared', sharedEmailEnvSchema);
 
 export const sharedEmailEnv = {
   isCloud: parsedSharedEmailEnv.IS_CLOUD,

--- a/dashboard/src/lib/env/worker.env.ts
+++ b/dashboard/src/lib/env/worker.env.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { parseEnv } from './parse-env';
 import { sharedEmailEnvSchema, zStringBoolean } from './shared.env';
 
 const workerOnlyEnvSchema = z.object({
@@ -32,4 +33,4 @@ const workerEnvSchema = sharedEmailEnvSchema.merge(workerOnlyEnvSchema).superRef
   }
 });
 
-export const workerEnv = workerEnvSchema.parse(process.env);
+export const workerEnv = parseEnv('worker', workerEnvSchema);


### PR DESCRIPTION
Env validation failures now name every failing variable instead of crashing with `TypeError: Cannot set property message of [object Object] which has only a getter`.

## Description of why

- zod v3's `ZodError.message` is getter-only, and Next's instrumentation error wrapping assigns to `err.message`, so any env schema failure at boot erased the real issues behind a generic TypeError - any missing required variable was undiagnosable.
- Closes betterlytics/betterlytics-internal#210

## Changes

- Added a `parseEnv(label, schema)` helper: `safeParse`, then a plain writable-message `Error` listing every issue as `NAME: reason`, tagged with the failing schema (`app`/`shared`/`worker`) and pointing at `.env.example`
- Routed the three env modules through it; validation timing is unchanged (eager at build/boot)
- Unit tests, including a regression test that the thrown error is not a `ZodError` and its `message` is writable

## Additional Notes

Failure output after this change, with `AUTH_SECRET` and `INTEGRATION_ENCRYPTION_KEY` commented out:

```
Error: An error occurred while loading instrumentation hook: Invalid environment variables (app): AUTH_SECRET: Required; INTEGRATION_ENCRYPTION_KEY: Required. Compare your .env against .env.example.
    at parseEnv (src\lib\env\parse-env.ts:12:9)
    at __TURBOPACK__module__evaluation__ (src\lib\env.ts:106:28)
    at <unknown> (C:\Users\cwr\personal\betterlytics\dashboard\.next\server\chunks\_f05743ca._.js:30:16)
    at async registerOpenTelemetry (src\instrumentation.ts:43:21)
    at async Module.register (src\instrumentation.ts:2:3)
  10 |     .map((issue) => `${issue.path.join('.') || '(env)'}: ${issue.message}`)
  11 |     .join('; ');
> 12 |   throw new Error(`Invalid environment variables (${label}): ${issues}. Compare your .env against .env.example.`);
     |         ^
  13 | }
  14 |
```