### PR TITLE
Moved custom status domain routing from the proxy into the app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -131,7 +131,9 @@ BACKGROUND_JOBS_ENABLED=false
 PUSHOVER_APP_TOKEN=
 INTEGRATION_ENCRYPTION_KEY=your-32-character-encryption-key
 
-# Public status pages. The status-host proxy (TLS, rewrites, rate limiting) lives in the
-# production setup repo; these two are consumed by the app itself.
+# Public status pages. Host routing for custom status domains lives in the app itself and needs
+# no proxy config. STATUS_PAGE_ASK_SECRET is required whenever public status pages are enabled
+# outside development (the selfhost setup derives it) and is used only by a proxy doing on-demand
+# TLS through /api/status-page/ask.
 STATUS_PAGE_DOMAIN=status.localhost
 # STATUS_PAGE_ASK_SECRET=

--- a/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/status-pages/shared/CustomDomainSetup.tsx
+++ b/dashboard/src/app/(app)/(protected)/dashboard/[dashboardId]/(dashboard)/status-pages/shared/CustomDomainSetup.tsx
@@ -4,10 +4,8 @@ import { useTranslations } from 'next-intl';
 import { Info } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { CopyButton } from '@/components/CopyButton';
-
-export function statusPageCnameTarget(slug: string, publicHost: string): string {
-  return `${slug}.status.${publicHost}`;
-}
+import { statusPageCnameTarget } from '@/entities/analytics/statusPage/statusPage.helpers';
+import { useClientFeatureFlags } from '@/hooks/use-client-feature-flags';
 
 type CustomDomainSetupProps = {
   customDomain: string;
@@ -18,11 +16,12 @@ type CustomDomainSetupProps = {
 
 export function CustomDomainSetup({ customDomain, slug, publicHost, isValid }: CustomDomainSetupProps) {
   const t = useTranslations('statusPagesPage.editor');
+  const { isFeatureFlagEnabled } = useClientFeatureFlags();
 
   const domain = customDomain.trim();
   if (!domain || !isValid || !slug.trim()) return null;
 
-  const target = statusPageCnameTarget(slug, publicHost);
+  const target = statusPageCnameTarget(slug, publicHost, isFeatureFlagEnabled('isCloud'));
   // Many providers (Namecheap, Cloudflare, GoDaddy…) auto-append the domain, so the Name field wants
   // just the subdomain label.
   const hostLabel = domain.split('.')[0];

--- a/dashboard/src/app/api/status-page/ask/askGuard.ts
+++ b/dashboard/src/app/api/status-page/ask/askGuard.ts
@@ -1,7 +1,9 @@
 import 'server-only';
 
 import { createSlidingWindowLimiter } from '@/lib/rate-limit';
-import { getTlsAuthorization, normalizeHostname } from '@/services/analytics/statusPageDomain.service';
+import { ExpiringSet } from '@/lib/expiring-set';
+import { normalizeHostname } from '@/lib/status-host-routing';
+import { getTlsAuthorization } from '@/services/analytics/statusPageDomain.service';
 
 // Hardening for the Caddy on-demand-TLS `ask` endpoint. Caddy calls it during the TLS
 // handshake for every new SNI, so anyone enumerating hostnames turns into a flood of DB
@@ -23,17 +25,7 @@ const GLOBAL_MAX_LOOKUPS = 600;
 const checkGlobalLookupLimit = createSlidingWindowLimiter(GLOBAL_WINDOW_MS, GLOBAL_MAX_LOOKUPS);
 const GLOBAL_KEY = 'global';
 
-// normalized hostname -> epoch ms after which the cached "unauthorized" result expires.
-// Expiry is lazy (checked on access) and the size cap evicts oldest-inserted — no sweep needed.
-const negativeCache = new Map<string, number>();
-
-function rememberUnauthorized(domain: string, now: number): void {
-  if (negativeCache.size >= NEGATIVE_CACHE_MAX_ENTRIES) {
-    const oldest = negativeCache.keys().next().value;
-    if (oldest !== undefined) negativeCache.delete(oldest);
-  }
-  negativeCache.set(domain, now + NEGATIVE_CACHE_TTL_MS);
-}
+const negativeCache = new ExpiringSet(NEGATIVE_CACHE_TTL_MS, NEGATIVE_CACHE_MAX_ENTRIES);
 
 /**
  * Resolve the HTTP status Caddy's `ask` endpoint should return for a hostname:
@@ -45,19 +37,13 @@ export async function resolveAskStatus(rawDomain: string): Promise<number> {
   const domain = normalizeHostname(rawDomain);
   if (!domain) return 400;
 
-  const now = Date.now();
-
-  const cachedUntil = negativeCache.get(domain);
-  if (cachedUntil !== undefined) {
-    if (cachedUntil > now) return 404;
-    negativeCache.delete(domain);
-  }
+  if (negativeCache.has(domain)) return 404;
 
   if (!checkGlobalLookupLimit(GLOBAL_KEY).allowed) return 429;
 
   const authorization = await getTlsAuthorization(domain);
   // Only the DB-backed miss is worth caching; `forbidden` (own namespace) is already DB-free.
-  if (authorization === 'unauthorized') rememberUnauthorized(domain, now);
+  if (authorization === 'unauthorized') negativeCache.add(domain);
 
   return authorization === 'authorized' ? 200 : authorization === 'forbidden' ? 403 : 404;
 }

--- a/dashboard/src/app/status/domain/[domain]/page.tsx
+++ b/dashboard/src/app/status/domain/[domain]/page.tsx
@@ -2,13 +2,14 @@ import { cache } from 'react';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { isFeatureEnabled } from '@/lib/feature-flags';
-import { normalizeHostname } from '@/services/analytics/statusPageDomain.service';
+import { normalizeHostname } from '@/lib/status-host-routing';
 import { getPublicStatusPageDataByDomain } from '@/services/analytics/publicStatusPage.service';
 import { buildStatusPageMetadata, StatusPageShell } from '@/app/status/shared/statusPageShell';
 
 /**
- * Custom-domain (tier-2) status host entry point. Caddy rewrites the custom
- * domain's `/` to `/status/domain/{host}`
+ * Custom-domain (tier-2) status host entry point. The middleware rewrites `/` on a host that has
+ * a custom-domain row to `/status/domain/{host}` (see lib/status-host-routing.ts); this page still
+ * answers 404 while that page is unpublished.
  */
 export const revalidate = 60;
 

--- a/dashboard/src/entities/analytics/statusPage/statusPage.helpers.ts
+++ b/dashboard/src/entities/analytics/statusPage/statusPage.helpers.ts
@@ -1,4 +1,5 @@
 import { safeHostname } from '@/utils/domainValidation';
+import { hostnameOf } from '@/lib/status-host-routing';
 import {
   STATUS_PAGE_LIMITS,
   StatusPageCustomDomainSchema,
@@ -21,6 +22,11 @@ export function statusPagePublicUrl(page: StatusPageUrlParts, publicBaseUrl: str
 
 export function statusPagePublicUrlLabel(page: StatusPageUrlParts): string {
   return page.customDomain ?? `/status/${page.slug}`;
+}
+
+export function statusPageCnameTarget(slug: string, publicHost: string, isCloud: boolean): string {
+  const host = hostnameOf(publicHost);
+  return isCloud ? `${slug}.status.${host}` : host;
 }
 
 export function defaultPublicMonitorName(monitor: { name?: string | null; url: string }): string {

--- a/dashboard/src/lib/expiring-set.test.ts
+++ b/dashboard/src/lib/expiring-set.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ExpiringSet } from './expiring-set';
+
+describe('ExpiringSet', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('forgets a key once its ttl has passed', () => {
+    const set = new ExpiringSet(1_000, 10);
+    set.add('a');
+    vi.advanceTimersByTime(999);
+    expect(set.has('a')).toBe(true);
+    vi.advanceTimersByTime(2);
+    expect(set.has('a')).toBe(false);
+  });
+
+  it('evicts the oldest key past the cap and keeps re-added keys', () => {
+    const set = new ExpiringSet(1_000, 2);
+    set.add('a');
+    set.add('b');
+    set.add('a');
+    set.add('c');
+    expect(set.has('a')).toBe(true);
+    expect(set.has('b')).toBe(false);
+    expect(set.has('c')).toBe(true);
+  });
+
+  it('deletes a key on request', () => {
+    const set = new ExpiringSet(1_000, 10);
+    set.add('a');
+    set.delete('a');
+    expect(set.has('a')).toBe(false);
+  });
+});

--- a/dashboard/src/lib/expiring-set.ts
+++ b/dashboard/src/lib/expiring-set.ts
@@ -1,0 +1,34 @@
+/**
+ * Set of keys that forget themselves after `ttlMs`. Expiry is lazy (checked on access) and the
+ * size cap evicts oldest-inserted, so no sweep is needed. Re-adding a key moves it to the tail.
+ */
+export class ExpiringSet {
+  private readonly until = new Map<string, number>();
+
+  constructor(
+    private readonly ttlMs: number,
+    private readonly maxEntries: number,
+  ) {}
+
+  has(key: string): boolean {
+    const expiry = this.until.get(key);
+    if (expiry === undefined) return false;
+    if (expiry > Date.now()) return true;
+    this.until.delete(key);
+    return false;
+  }
+
+  add(key: string): void {
+    this.until.delete(key);
+    while (this.until.size >= this.maxEntries) {
+      const oldest = this.until.keys().next().value;
+      if (oldest === undefined) break;
+      this.until.delete(oldest);
+    }
+    this.until.set(key, Date.now() + this.ttlMs);
+  }
+
+  delete(key: string): void {
+    this.until.delete(key);
+  }
+}

--- a/dashboard/src/lib/status-host-routing.test.ts
+++ b/dashboard/src/lib/status-host-routing.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import {
+  decideStatusHostRoute,
+  hostnameOf,
+  isOwnHost,
+  normalizeHostname,
+  ownHostsFrom,
+} from './status-host-routing';
+import { statusPageCnameTarget } from '@/entities/analytics/statusPage/statusPage.helpers';
+
+describe('normalizeHostname', () => {
+  it('lowercases and strips port then trailing dot', () => {
+    expect(normalizeHostname('Status.Acme.com.:443')).toBe('status.acme.com');
+    expect(normalizeHostname('status.acme.com.')).toBe('status.acme.com');
+    expect(normalizeHostname('  Status.Acme.com:8443 ')).toBe('status.acme.com');
+  });
+});
+
+describe('hostnameOf', () => {
+  it('returns the bare hostname for urls and host:port forms', () => {
+    expect(hostnameOf('https://acme.com:8443/')).toBe('acme.com');
+    expect(hostnameOf('acme.com:8443/')).toBe('acme.com');
+    expect(hostnameOf('localhost:3000')).toBe('localhost');
+    expect(hostnameOf('acme.com')).toBe('acme.com');
+    expect(hostnameOf('http://localhost:3000')).toBe('localhost');
+  });
+});
+
+describe('isOwnHost', () => {
+  const cloud = ownHostsFrom('https://betterlytics.io', 'status.betterlytics.io', true);
+  const cloudOwn = [
+    'betterlytics.io',
+    'www.betterlytics.io',
+    'foo.betterlytics.io',
+    'status.betterlytics.io',
+    'x.status.betterlytics.io',
+    'localhost',
+    'app',
+    'foo.localhost',
+  ];
+  const cloudClaimable = ['status.acme.com'];
+
+  const selfhost = ownHostsFrom('https://acme.com', '', false);
+  const selfhostOwn = ['acme.com', 'www.acme.com', '192.168.1.10', '[::1]', 'localhost', 'app'];
+  const selfhostClaimable = ['status.acme.com', 'foo.acme.com'];
+
+  it('reserves cloud hosts and their subdomains', () => {
+    for (const host of cloudOwn) expect(isOwnHost(host, cloud), host).toBe(true);
+    for (const host of cloudClaimable) expect(isOwnHost(host, cloud), host).toBe(false);
+  });
+
+  it('reserves only the app host, its www and non-domains off cloud', () => {
+    for (const host of selfhostOwn) expect(isOwnHost(host, selfhost), host).toBe(true);
+    for (const host of selfhostClaimable) expect(isOwnHost(host, selfhost), host).toBe(false);
+  });
+
+  it('never marks a host both own and claimable', () => {
+    for (const host of cloudOwn) expect(cloudClaimable).not.toContain(host);
+    for (const host of selfhostOwn) expect(selfhostClaimable).not.toContain(host);
+  });
+
+  it('parses ownHostsFrom inputs leniently', () => {
+    expect(ownHostsFrom('https://acme.com', '', false)).toEqual({ appHost: 'acme.com', statusPageDomain: '', wildcard: false });
+    expect(ownHostsFrom('localhost:3000', '', false).appHost).toBe('localhost');
+    expect(ownHostsFrom('acme.com', '', false).appHost).toBe('acme.com');
+  });
+});
+
+describe('decideStatusHostRoute', () => {
+  const domain = 'status.acme.com';
+
+  it('rewrites the root to the domain page', () => {
+    expect(decideStatusHostRoute(domain, '/')).toEqual({ kind: 'rewrite', pathname: '/status/domain/status.acme.com' });
+  });
+
+  it('passes status images and the legacy rewrite path', () => {
+    expect(decideStatusHostRoute(domain, '/status/x/image/logo')).toEqual({ kind: 'pass' });
+    expect(decideStatusHostRoute(domain, '/status/domain/status.acme.com')).toEqual({ kind: 'pass' });
+    expect(decideStatusHostRoute(domain, '/status/domain/Status.Acme.com')).toEqual({ kind: 'pass' });
+  });
+
+  it('404s everything else', () => {
+    for (const pathname of [
+      '/dashboard',
+      '/api/trpc/system.publicEnvironmentVariables',
+      '/api/trpc/a,b',
+      '/status/other',
+      '/status/domain/other.com',
+      '/favicon.ico',
+    ]) {
+      expect(decideStatusHostRoute(domain, pathname), pathname).toEqual({ kind: 'notFound' });
+    }
+  });
+});
+
+describe('statusPageCnameTarget', () => {
+  it('returns a bare hostname without port or path', () => {
+    expect(statusPageCnameTarget('acme', 'acme.com:8443/', false)).toBe('acme.com');
+    expect(statusPageCnameTarget('acme', 'acme.com:8443/', true)).toBe('acme.status.acme.com');
+  });
+});

--- a/dashboard/src/lib/status-host-routing.test.ts
+++ b/dashboard/src/lib/status-host-routing.test.ts
@@ -68,15 +68,17 @@ describe('isOwnHost', () => {
 
 describe('decideStatusHostRoute', () => {
   const domain = 'status.acme.com';
+  const status = (pathname: string) => decideStatusHostRoute('status', domain, pathname, true);
+  const paths = ['/', '/dashboard', '/status/domain/status.acme.com', '/_next/image'];
 
   it('rewrites the root to the domain page', () => {
-    expect(decideStatusHostRoute(domain, '/')).toEqual({ kind: 'rewrite', pathname: '/status/domain/status.acme.com' });
+    expect(status('/')).toEqual({ kind: 'rewrite', pathname: '/status/domain/status.acme.com' });
   });
 
   it('passes status images and the legacy rewrite path', () => {
-    expect(decideStatusHostRoute(domain, '/status/x/image/logo')).toEqual({ kind: 'pass' });
-    expect(decideStatusHostRoute(domain, '/status/domain/status.acme.com')).toEqual({ kind: 'pass' });
-    expect(decideStatusHostRoute(domain, '/status/domain/Status.Acme.com')).toEqual({ kind: 'pass' });
+    expect(status('/status/x/image/logo')).toEqual({ kind: 'pass' });
+    expect(status('/status/domain/status.acme.com')).toEqual({ kind: 'pass' });
+    expect(status('/status/domain/Status.Acme.com')).toEqual({ kind: 'pass' });
   });
 
   it('404s everything else', () => {
@@ -87,8 +89,23 @@ describe('decideStatusHostRoute', () => {
       '/status/other',
       '/status/domain/other.com',
       '/favicon.ico',
+      '/_next/image',
     ]) {
-      expect(decideStatusHostRoute(domain, pathname), pathname).toEqual({ kind: 'notFound' });
+      expect(status(pathname), pathname).toEqual({ kind: 'notFound' });
+    }
+  });
+
+  it('reports unavailable regardless of path or deployment', () => {
+    for (const pathname of paths) {
+      expect(decideStatusHostRoute('unavailable', domain, pathname, true), pathname).toEqual({ kind: 'unavailable' });
+      expect(decideStatusHostRoute('unavailable', domain, pathname, false), pathname).toEqual({ kind: 'unavailable' });
+    }
+  });
+
+  it('404s an unknown host on cloud and passes it through off cloud', () => {
+    for (const pathname of paths) {
+      expect(decideStatusHostRoute('unknown', domain, pathname, true), pathname).toEqual({ kind: 'notFound' });
+      expect(decideStatusHostRoute('unknown', domain, pathname, false), pathname).toEqual({ kind: 'pass' });
     }
   });
 });

--- a/dashboard/src/lib/status-host-routing.ts
+++ b/dashboard/src/lib/status-host-routing.ts
@@ -1,0 +1,54 @@
+export function normalizeHostname(raw: string): string {
+  return raw.trim().toLowerCase().replace(/:\d+$/, '').replace(/\.$/, '');
+}
+
+export function hostnameOf(urlOrHost: string): string {
+  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(urlOrHost) ? urlOrHost : `http://${urlOrHost}`;
+  try {
+    return new URL(withScheme).hostname;
+  } catch {
+    return urlOrHost;
+  }
+}
+
+export type OwnHosts = {
+  appHost: string;
+  statusPageDomain: string;
+  wildcard: boolean;
+};
+
+export function ownHostsFrom(publicBaseUrl: string, statusPageDomain: string, wildcard: boolean): OwnHosts {
+  return {
+    appHost: normalizeHostname(hostnameOf(publicBaseUrl)),
+    statusPageDomain: normalizeHostname(statusPageDomain),
+    wildcard,
+  };
+}
+
+const IPV4_LITERAL = /^\d{1,3}(\.\d{1,3}){3}$/;
+
+/**
+ * The single reserved-host policy: middleware skips the custom-domain lookup for these hosts and
+ * the status page actions refuse to claim them.
+ */
+export function isOwnHost(domain: string, own: OwnHosts): boolean {
+  if (!domain.includes('.')) return true;
+  if (domain.endsWith('.localhost')) return true;
+  if (IPV4_LITERAL.test(domain) || domain.startsWith('[')) return true;
+  if (domain === own.appHost || domain === `www.${own.appHost}`) return true;
+  if (own.wildcard && domain.endsWith(`.${own.appHost}`)) return true;
+  if (!own.statusPageDomain) return false;
+  return domain === own.statusPageDomain || (own.wildcard && domain.endsWith(`.${own.statusPageDomain}`));
+}
+
+const STATUS_IMAGE_PATH = /^\/status\/[^/]+\/image\/[^/]+$/;
+
+export type StatusHostRoute = { kind: 'pass' } | { kind: 'rewrite'; pathname: string } | { kind: 'notFound' };
+
+export function decideStatusHostRoute(domain: string, pathname: string): StatusHostRoute {
+  if (pathname === '/') return { kind: 'rewrite', pathname: `/status/domain/${domain}` };
+  if (STATUS_IMAGE_PATH.test(pathname)) return { kind: 'pass' };
+  // Legacy: the production proxy still rewrites `/` to this path itself. Remove once it no longer does.
+  if (pathname.toLowerCase().replace(/\.+$/, '') === `/status/domain/${domain}`) return { kind: 'pass' };
+  return { kind: 'notFound' };
+}

--- a/dashboard/src/lib/status-host-routing.ts
+++ b/dashboard/src/lib/status-host-routing.ts
@@ -43,9 +43,24 @@ export function isOwnHost(domain: string, own: OwnHosts): boolean {
 
 const STATUS_IMAGE_PATH = /^\/status\/[^/]+\/image\/[^/]+$/;
 
-export type StatusHostRoute = { kind: 'pass' } | { kind: 'rewrite'; pathname: string } | { kind: 'notFound' };
+export type StatusHostClassification = 'status' | 'unknown' | 'unavailable';
 
-export function decideStatusHostRoute(domain: string, pathname: string): StatusHostRoute {
+export type StatusHostRoute =
+  | { kind: 'pass' }
+  | { kind: 'rewrite'; pathname: string }
+  | { kind: 'notFound' }
+  | { kind: 'unavailable' };
+
+export function decideStatusHostRoute(
+  classification: StatusHostClassification,
+  domain: string,
+  pathname: string,
+  isCloud: boolean,
+): StatusHostRoute {
+  if (classification === 'unavailable') return { kind: 'unavailable' };
+  // On cloud every non-own host that reaches us holds a cert on our IP, so no row means a removed
+  // domain or the feature off; neither may see the app. Off cloud the app has hostnames we cannot know.
+  if (classification === 'unknown') return isCloud ? { kind: 'notFound' } : { kind: 'pass' };
   if (pathname === '/') return { kind: 'rewrite', pathname: `/status/domain/${domain}` };
   if (STATUS_IMAGE_PATH.test(pathname)) return { kind: 'pass' };
   // Legacy: the production proxy still rewrites `/` to this path itself. Remove once it no longer does.

--- a/dashboard/src/middleware.ts
+++ b/dashboard/src/middleware.ts
@@ -1,16 +1,44 @@
 import createMiddleware from 'next-intl/middleware';
 import { routing } from '@/i18n/routing';
 import { NextResponse, type NextRequest } from 'next/server';
+import { env } from '@/lib/env';
+import { sharedEmailEnv } from '@/lib/env/shared.env';
+import { decideStatusHostRoute, isOwnHost, normalizeHostname, ownHostsFrom } from '@/lib/status-host-routing';
+import { classifyStatusHost } from '@/services/analytics/statusHost.service';
 
 const intlMiddleware = createMiddleware(routing);
+const OWN_HOSTS = ownHostsFrom(
+  env.PUBLIC_BASE_URL,
+  sharedEmailEnv.isCloud ? env.STATUS_PAGE_DOMAIN : '',
+  sharedEmailEnv.isCloud,
+);
+// Was the matcher's negative lookahead; now applied after the host check so status hosts can 404 these.
+const SKIP_INTL = /^\/(api|dashboard|dashboards|billing|admin)(\/|$)/;
 
-export function middleware(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
+  const host = normalizeHostname(request.headers.get('host') ?? '');
 
-  // Status paths carry a hostname from Caddy's rewrite, as sent by the client. Canonicalize
-  // (lowercase, strip trailing dots) before routing so case variants of the same host share one
-  // ISR cache entry. Safe to lowercase the whole path: slugs and custom domains are stored
-  // lowercase, and the other path segments already are.
+  if (host && !isOwnHost(host, OWN_HOSTS)) {
+    const classification = await classifyStatusHost(host);
+    if (classification === 'unavailable') {
+      return new NextResponse(null, { status: 503, headers: { 'Retry-After': '10' } });
+    }
+    if (classification === 'status') {
+      const route = decideStatusHostRoute(host, pathname);
+      if (route.kind === 'notFound') return new NextResponse(null, { status: 404 });
+      if (route.kind === 'rewrite') {
+        const url = request.nextUrl.clone();
+        url.pathname = route.pathname;
+        return NextResponse.rewrite(url);
+      }
+    }
+  }
+
+  // Status paths carry a hostname as sent by the client. Canonicalize (lowercase, strip trailing
+  // dots) before routing so case variants of the same host share one ISR cache entry. Safe to
+  // lowercase the whole path: slugs and custom domains are stored lowercase, and the other path
+  // segments already are.
   if (pathname.startsWith('/status/')) {
     const normalized = pathname.toLowerCase().replace(/\.+$/, '');
     if (normalized !== pathname) {
@@ -21,6 +49,8 @@ export function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
+  if (SKIP_INTL.test(pathname) || pathname.includes('.')) return NextResponse.next();
+
   if (request.method === 'POST' && request.url.includes('[locale]')) {
     console.error('[next-intl loop detected]', request.url);
     return new Response('Bad request', { status: 400 });
@@ -30,5 +60,7 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/((?!api|_next|.*\\..*|dashboard|dashboards|billing|admin|status).*)', '/status/:path*'],
+  runtime: 'nodejs',
+  // Only Next's own assets skip the host check; every other path, dotted or not, is classified first.
+  matcher: ['/((?!_next/).*)'],
 };

--- a/dashboard/src/middleware.ts
+++ b/dashboard/src/middleware.ts
@@ -20,20 +20,19 @@ export async function middleware(request: NextRequest) {
   const host = normalizeHostname(request.headers.get('host') ?? '');
 
   if (host && !isOwnHost(host, OWN_HOSTS)) {
-    const classification = await classifyStatusHost(host);
-    if (classification === 'unavailable') {
+    const route = decideStatusHostRoute(await classifyStatusHost(host), host, pathname, sharedEmailEnv.isCloud);
+    if (route.kind === 'unavailable') {
       return new NextResponse(null, { status: 503, headers: { 'Retry-After': '10' } });
     }
-    if (classification === 'status') {
-      const route = decideStatusHostRoute(host, pathname);
-      if (route.kind === 'notFound') return new NextResponse(null, { status: 404 });
-      if (route.kind === 'rewrite') {
-        const url = request.nextUrl.clone();
-        url.pathname = route.pathname;
-        return NextResponse.rewrite(url);
-      }
+    if (route.kind === 'notFound') return new NextResponse(null, { status: 404 });
+    if (route.kind === 'rewrite') {
+      const url = request.nextUrl.clone();
+      url.pathname = route.pathname;
+      return NextResponse.rewrite(url);
     }
   }
+
+  if (pathname.startsWith('/_next/')) return NextResponse.next();
 
   // Status paths carry a hostname as sent by the client. Canonicalize (lowercase, strip trailing
   // dots) before routing so case variants of the same host share one ISR cache entry. Safe to
@@ -61,6 +60,6 @@ export async function middleware(request: NextRequest) {
 
 export const config = {
   runtime: 'nodejs',
-  // Only Next's own assets skip the host check; every other path, dotted or not, is classified first.
-  matcher: ['/((?!_next/).*)'],
+  // Only Next's static assets skip the host check; every other path, dotted or not, is classified first.
+  matcher: ['/((?!_next/static/).*)'],
 };

--- a/dashboard/src/services/analytics/statusHost.service.test.ts
+++ b/dashboard/src/services/analytics/statusHost.service.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { STATUS_HOST_LIMITS as L } from './statusHost.service';
+
+const findStatusPageByCustomDomain = vi.fn();
+
+vi.mock('@/repositories/postgres/statusPage.repository', () => ({
+  findStatusPageByCustomDomain: (domain: string) => findStatusPageByCustomDomain(domain),
+}));
+
+vi.mock('@/lib/feature-flags', () => ({
+  isFeatureEnabled: () => true,
+}));
+
+type Service = typeof import('./statusHost.service');
+type Classify = Service['classifyStatusHost'];
+
+const ROW = { id: 'sp1', dashboardId: 'd1', slug: 'acme', isPublished: true };
+const UNPUBLISHED_ROW = { ...ROW, isPublished: false };
+
+async function loadService(): Promise<Service> {
+  vi.resetModules();
+  return import('./statusHost.service');
+}
+
+function pendingForever(): Promise<never> {
+  return new Promise(() => {});
+}
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+function goStale(): void {
+  vi.advanceTimersByTime(L.freshMs + 1);
+}
+
+function nextWindow(): void {
+  vi.advanceTimersByTime(L.globalWindowMs + 1);
+}
+
+async function classifyColdHosts(classify: Classify, prefix: string, count: number): Promise<void> {
+  for (let i = 0; i < count; i++) {
+    if (i > 0 && i % L.globalMaxLookups === 0) nextWindow();
+    await classify(`${prefix}-${i}.example.com`);
+  }
+}
+
+describe('classifyStatusHost', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'Date'] });
+    findStatusPageByCustomDomain.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('classifies a row as status and no row as unknown, one query each', async () => {
+    const { classifyStatusHost } = await loadService();
+    findStatusPageByCustomDomain.mockResolvedValueOnce(ROW).mockResolvedValueOnce(null);
+
+    expect(await classifyStatusHost('status.acme.com')).toBe('status');
+    expect(await classifyStatusHost('other.com')).toBe('unknown');
+    expect(await classifyStatusHost('status.acme.com')).toBe('status');
+    expect(await classifyStatusHost('other.com')).toBe('unknown');
+    expect(findStatusPageByCustomDomain).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats an unpublished row as a status host', async () => {
+    const { classifyStatusHost } = await loadService();
+    findStatusPageByCustomDomain.mockResolvedValueOnce(UNPUBLISHED_ROW);
+
+    expect(await classifyStatusHost('status.acme.com')).toBe('status');
+  });
+
+  it('coalesces concurrent lookups for one cold host', async () => {
+    const { classifyStatusHost } = await loadService();
+    findStatusPageByCustomDomain.mockResolvedValueOnce(ROW);
+
+    const results = await Promise.all([classifyStatusHost('status.acme.com'), classifyStatusHost('status.acme.com')]);
+
+    expect(results).toEqual(['status', 'status']);
+    expect(findStatusPageByCustomDomain).toHaveBeenCalledTimes(1);
+  });
+
+  it('is unavailable on error without a prior answer and stale status with one', async () => {
+    const { classifyStatusHost } = await loadService();
+    findStatusPageByCustomDomain.mockRejectedValueOnce(new Error('db down'));
+    expect(await classifyStatusHost('cold.com')).toBe('unavailable');
+
+    findStatusPageByCustomDomain.mockResolvedValueOnce(ROW);
+    expect(await classifyStatusHost('status.acme.com')).toBe('status');
+
+    goStale();
+    findStatusPageByCustomDomain.mockRejectedValueOnce(new Error('db down'));
+    expect(await classifyStatusHost('status.acme.com')).toBe('status');
+    await flushPromises();
+    findStatusPageByCustomDomain.mockRejectedValueOnce(new Error('db down'));
+    expect(await classifyStatusHost('status.acme.com')).toBe('status');
+  });
+
+  it('re-queries a status host once fresh expires and an unknown host once its ttl expires', async () => {
+    const { classifyStatusHost } = await loadService();
+    findStatusPageByCustomDomain.mockResolvedValue(ROW);
+    await classifyStatusHost('status.acme.com');
+    vi.advanceTimersByTime(L.freshMs - 1);
+    await classifyStatusHost('status.acme.com');
+    expect(findStatusPageByCustomDomain).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(2);
+    await classifyStatusHost('status.acme.com');
+    await flushPromises();
+    expect(findStatusPageByCustomDomain).toHaveBeenCalledTimes(2);
+
+    findStatusPageByCustomDomain.mockResolvedValue(null);
+    await classifyStatusHost('other.com');
+    vi.advanceTimersByTime(L.unknownTtlMs - 1);
+    await classifyStatusHost('other.com');
+    expect(findStatusPageByCustomDomain).toHaveBeenCalledTimes(3);
+    vi.advanceTimersByTime(2);
+    await classifyStatusHost('other.com');
+    expect(findStatusPageByCustomDomain).toHaveBeenCalledTimes(4);
+  });
+
+  it('answers a stale known host immediately while a slow refresh is pending', async () => {
+    const { classifyStatusHost } = await loadService();
+    findStatusPageByCustomDomain.mockResolvedValueOnce(ROW);
+    await classifyStatusHost('status.acme.com');
+
+    goStale();
+    findStatusPageByCustomDomain.mockImplementation(pendingForever);
+    expect(await classifyStatusHost('status.acme.com')).toBe('status');
+    expect(await classifyStatusHost('status.acme.com')).toBe('status');
+    expect(findStatusPageByCustomDomain).toHaveBeenCalledTimes(2);
+  });
+
+  it('gives a cold host up after the deadline and keeps the single query running', async () => {
+    const { classifyStatusHost } = await loadService();
+    let resolveLookup: (row: typeof ROW) => void = () => {};
+    findStatusPageByCustomDomain.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveLookup = resolve;
+        }),
+    );
+
+    const first = classifyStatusHost('status.acme.com');
+    await vi.advanceTimersByTimeAsync(L.lookupDeadlineMs);
+    expect(await first).toBe('unavailable');
+
+    const retry = classifyStatusHost('status.acme.com');
+    await vi.advanceTimersByTimeAsync(L.lookupDeadlineMs);
+    expect(await retry).toBe('unavailable');
+    expect(findStatusPageByCustomDomain).toHaveBeenCalledTimes(1);
+
+    resolveLookup(ROW);
+    await flushPromises();
+    expect(await classifyStatusHost('status.acme.com')).toBe('status');
+    expect(findStatusPageByCustomDomain).toHaveBeenCalledTimes(1);
+  });
+
+  it('forgets a domain once the refresh finds no row', async () => {
+    const { classifyStatusHost } = await loadService();
+    findStatusPageByCustomDomain.mockResolvedValueOnce(ROW);
+    await classifyStatusHost('status.acme.com');
+
+    goStale();
+    findStatusPageByCustomDomain.mockResolvedValueOnce(null);
+    await classifyStatusHost('status.acme.com');
+    await flushPromises();
+    expect(await classifyStatusHost('status.acme.com')).toBe('unknown');
+
+    vi.advanceTimersByTime(L.unknownTtlMs + 1);
+    findStatusPageByCustomDomain.mockRejectedValueOnce(new Error('db down'));
+    expect(await classifyStatusHost('status.acme.com')).toBe('unavailable');
+  });
+
+  it('drops a known host not refreshed within the retention period', async () => {
+    const { classifyStatusHost } = await loadService();
+    findStatusPageByCustomDomain.mockResolvedValueOnce(ROW);
+    await classifyStatusHost('status.acme.com');
+
+    vi.advanceTimersByTime(L.retainMs + 1);
+    findStatusPageByCustomDomain.mockRejectedValueOnce(new Error('db down'));
+    expect(await classifyStatusHost('status.acme.com')).toBe('unavailable');
+  });
+
+  it('evicts the oldest known host past the cap unless it was refreshed', async () => {
+    const { classifyStatusHost } = await loadService();
+    findStatusPageByCustomDomain.mockResolvedValue(ROW);
+
+    await classifyColdHosts(classifyStatusHost, 'host', L.statusMaxEntries);
+    goStale();
+    await classifyStatusHost('host-0.example.com');
+    await flushPromises();
+    await classifyStatusHost(`host-${L.statusMaxEntries}.example.com`);
+
+    findStatusPageByCustomDomain.mockRejectedValue(new Error('db down'));
+    goStale();
+    expect(await classifyStatusHost('host-0.example.com')).toBe('status');
+    expect(await classifyStatusHost('host-1.example.com')).toBe('unavailable');
+  });
+
+  it('refuses cold hosts past the global lookup ceiling but keeps known ones', async () => {
+    const { classifyStatusHost } = await loadService();
+    findStatusPageByCustomDomain.mockResolvedValue(ROW);
+    await classifyStatusHost('status.acme.com');
+
+    findStatusPageByCustomDomain.mockResolvedValue(null);
+    await classifyColdHosts(classifyStatusHost, 'spray', L.globalMaxLookups - 1);
+    expect(await classifyStatusHost('spray-over.example.com')).toBe('unavailable');
+    expect(findStatusPageByCustomDomain).toHaveBeenCalledTimes(L.globalMaxLookups);
+
+    goStale();
+    expect(await classifyStatusHost('status.acme.com')).toBe('status');
+  });
+});

--- a/dashboard/src/services/analytics/statusHost.service.ts
+++ b/dashboard/src/services/analytics/statusHost.service.ts
@@ -1,0 +1,88 @@
+import 'server-only';
+
+import { createSlidingWindowLimiter } from '@/lib/rate-limit';
+import { ExpiringSet } from '@/lib/expiring-set';
+import { isFeatureEnabled } from '@/lib/feature-flags';
+import { findStatusPageByCustomDomain } from '@/repositories/postgres/statusPage.repository';
+
+export type StatusHostClassification = 'status' | 'unknown' | 'unavailable';
+
+// Per-process caches in the same spirit as app/api/status-page/ask/askGuard.ts: reset on restart,
+// deliberately cheap. They keep host classification off Postgres for all but cold hosts.
+export const STATUS_HOST_LIMITS = {
+  freshMs: 60_000,
+  retainMs: 24 * 60 * 60 * 1000,
+  statusMaxEntries: 10_000,
+  unknownTtlMs: 30_000,
+  unknownMaxEntries: 10_000,
+  lookupDeadlineMs: 2_000,
+  globalWindowMs: 60_000,
+  globalMaxLookups: 600,
+} as const;
+
+const checkGlobalLookupLimit = createSlidingWindowLimiter(
+  STATUS_HOST_LIMITS.globalWindowMs,
+  STATUS_HOST_LIMITS.globalMaxLookups,
+);
+const GLOBAL_KEY = 'global';
+
+// A known status host is retained for a day and considered fresh for a minute; a refresh re-adds
+// it at the tail, so live domains survive the cap and abandoned ones age out.
+const retainedHosts = new ExpiringSet(STATUS_HOST_LIMITS.retainMs, STATUS_HOST_LIMITS.statusMaxEntries);
+const freshHosts = new ExpiringSet(STATUS_HOST_LIMITS.freshMs, STATUS_HOST_LIMITS.statusMaxEntries);
+const unknownHosts = new ExpiringSet(STATUS_HOST_LIMITS.unknownTtlMs, STATUS_HOST_LIMITS.unknownMaxEntries);
+// One DB query per host at a time; a caller that stops waiting leaves it running, so retries never add work.
+const inflight = new Map<string, Promise<StatusHostClassification>>();
+
+/**
+ * Classifies a hostname for middleware routing. `status` means a status page row claims this
+ * custom domain (published or not; the page decides what to render). A known host is answered from
+ * cache and refreshed in the background, so a slow database never delays it. A cold host waits for
+ * its lookup at most STATUS_HOST_LIMITS.lookupDeadlineMs and is `unavailable` beyond that.
+ */
+export async function classifyStatusHost(domain: string): Promise<StatusHostClassification> {
+  if (!isFeatureEnabled('enablePublicStatusPages')) return 'unknown';
+
+  if (retainedHosts.has(domain)) {
+    if (!freshHosts.has(domain)) void refresh(domain);
+    return 'status';
+  }
+  if (unknownHosts.has(domain)) return 'unknown';
+
+  return Promise.race([
+    refresh(domain),
+    resolveAfter(STATUS_HOST_LIMITS.lookupDeadlineMs, 'unavailable' as const),
+  ]);
+}
+
+function refresh(domain: string): Promise<StatusHostClassification> {
+  const pending = inflight.get(domain);
+  if (pending) return pending;
+
+  // Stale status beats refusing; refusing beats serving the app on a status domain.
+  const fallback: StatusHostClassification = retainedHosts.has(domain) ? 'status' : 'unavailable';
+  if (!checkGlobalLookupLimit(GLOBAL_KEY).allowed) return Promise.resolve(fallback);
+
+  const lookup = findStatusPageByCustomDomain(domain)
+    .then((page): StatusHostClassification => {
+      if (page) {
+        retainedHosts.add(domain);
+        freshHosts.add(domain);
+        return 'status';
+      }
+      retainedHosts.delete(domain);
+      freshHosts.delete(domain);
+      unknownHosts.add(domain);
+      return 'unknown';
+    })
+    .catch(() => fallback)
+    .finally(() => inflight.delete(domain));
+  inflight.set(domain, lookup);
+  return lookup;
+}
+
+function resolveAfter<T>(ms: number, value: T): Promise<T> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(value), ms).unref();
+  });
+}

--- a/dashboard/src/services/analytics/statusHost.service.ts
+++ b/dashboard/src/services/analytics/statusHost.service.ts
@@ -4,8 +4,9 @@ import { createSlidingWindowLimiter } from '@/lib/rate-limit';
 import { ExpiringSet } from '@/lib/expiring-set';
 import { isFeatureEnabled } from '@/lib/feature-flags';
 import { findStatusPageByCustomDomain } from '@/repositories/postgres/statusPage.repository';
+import type { StatusHostClassification } from '@/lib/status-host-routing';
 
-export type StatusHostClassification = 'status' | 'unknown' | 'unavailable';
+export type { StatusHostClassification };
 
 // Per-process caches in the same spirit as app/api/status-page/ask/askGuard.ts: reset on restart,
 // deliberately cheap. They keep host classification off Postgres for all but cold hosts.

--- a/dashboard/src/services/analytics/statusPageDomain.service.ts
+++ b/dashboard/src/services/analytics/statusPageDomain.service.ts
@@ -5,28 +5,19 @@ import { sharedEmailEnv } from '@/lib/env/shared.env';
 import { findStatusPageByCustomDomain } from '@/repositories/postgres/statusPage.repository';
 import { canUseStatusPageCustomDomain } from '@/lib/billing/capabilityAccess';
 import { isFeatureEnabled } from '@/lib/feature-flags';
+import { isOwnHost, normalizeHostname, ownHostsFrom } from '@/lib/status-host-routing';
 
 export type TlsAuthorization = 'authorized' | 'forbidden' | 'unauthorized';
 
-export function normalizeHostname(raw: string): string {
-  return raw.trim().toLowerCase().replace(/\.$/, '').replace(/:\d+$/, '');
-}
+const OWN_HOSTS = ownHostsFrom(
+  sharedEmailEnv.publicBaseUrl,
+  sharedEmailEnv.isCloud ? env.STATUS_PAGE_DOMAIN : '',
+  sharedEmailEnv.isCloud,
+);
 
-function publicBaseUrlHost(): string {
-  try {
-    return new URL(sharedEmailEnv.publicBaseUrl).hostname;
-  } catch {
-    return sharedEmailEnv.publicBaseUrl; // tolerate a bare hostname without scheme
-  }
-}
-
-// Hosts this install serves itself: the app origin and the tier-1 status namespace. Derived from
-// config rather than hardcoded so self-host deployments are protected too.
-const OWN_NAMESPACES = [publicBaseUrlHost(), env.STATUS_PAGE_DOMAIN].map(normalizeHostname).filter(Boolean);
-
-/** Rejects our own hosts + status namespace so they can never be claimed as a custom domain. */
+/** Rejects our own hosts so they can never be claimed as a custom domain; same policy the middleware routes by. */
 export function isOwnNamespace(domain: string): boolean {
-  return OWN_NAMESPACES.some((ns) => domain === ns || domain.endsWith(`.${ns}`));
+  return isOwnHost(domain, OWN_HOSTS);
 }
 
 /**


### PR DESCRIPTION
The dashboard now routes custom status domains itself: a Node-runtime middleware classifies every request's Host against the status page table (cached, coalesced, bounded) and rewrites `/` to the domain page, 404s everything else on that host, and 503s with Retry-After when the lookup cannot be answered. Any reverse proxy can now sit in front of the app with no path allowlist, slug regex, or rewrite, which unblocks the selfhost setup (#153) and the own-proxy docs (#168).

Closes betterlytics/betterlytics-internal#167

Reviewer notes
- Read in order: `lib/status-host-routing.ts` (pure policy: reserved hosts, route decision), `services/analytics/statusHost.service.ts` (cache and DB lookup), `middleware.ts` (wiring, now `runtime: 'nodejs'` with a `/((?!_next/).*)` matcher; the old path exclusions moved inside so status hosts can 404 them).
- One reserved-host policy now serves both claiming and routing: `isOwnNamespace` delegates to `isOwnHost`. Off cloud only the app host and its `www` are reserved, so a selfhoster on `analytics.acme.com` can claim `status.acme.com`.
- `ExpiringSet` replaces the hand-rolled negative cache in the `ask` guard and backs the new caches; no behaviour change there.
- The `/status/domain/<host>` path still passes on a status host so the current prod Caddy rewrite keeps working. Deploy the app first, then simplify the proxy.
- No new env vars. `STATUS_PAGE_DOMAIN` is ignored off cloud; the CNAME target shown in the editor is the bare app host off cloud.

Verified with tsc and the three new vitest files. Not verified against a live proxy or Postgres outage; the manual checks are a `pnpm build`, a curl with a custom Host header, unpublishing a page (404), and stopping Postgres (503 only for cold hosts).
