### PR TITLE
Queued pre-load setGlobalProperties calls and applied them before the initial pageview

### DIFF
--- a/dashboard/src/instrumentation-client.ts
+++ b/dashboard/src/instrumentation-client.ts
@@ -2,4 +2,7 @@ window.betterlytics = window.betterlytics || {
   event: (...args: unknown[]) => {
     (window.betterlytics!.q = window.betterlytics!.q || []).push(args as unknown as IArguments);
   },
+  setGlobalProperties: (...args: unknown[]) => {
+    (window.betterlytics!.gq = window.betterlytics!.gq || []).push(args as unknown as IArguments);
+  },
 };

--- a/docs/src/content/integration/custom-events.mdx
+++ b/docs/src/content/integration/custom-events.mdx
@@ -38,6 +38,9 @@ If you're loading the analytics script asynchronously, and not using our npm pac
     window.betterlytics || {
       event: function () {
         (window.betterlytics.q = window.betterlytics.q || []).push(arguments);
+      },
+      setGlobalProperties: function () {
+        (window.betterlytics.gq = window.betterlytics.gq || []).push(arguments);
       }
     };
 </script>
@@ -48,7 +51,7 @@ If you're loading the analytics script asynchronously, and not using our npm pac
 ></script>
 ```
 
-This ensures `betterlytics.event()` calls work immediately, even before the main script finishes loading.
+This ensures `betterlytics.event()` and `betterlytics.setGlobalProperties()` calls work immediately, even before the main script finishes loading. Queued global properties are applied before events.
 
 ### Simple Event Tracking
 

--- a/docs/src/content/integration/global-properties.mdx
+++ b/docs/src/content/integration/global-properties.mdx
@@ -46,6 +46,10 @@ betterlytics.clearGlobalProperties();
 betterlytics.getGlobalProperties(); // {}
 ```
 
+## Setting Properties Before the Script Loads
+
+If you load `analytics.js` with `async`, add the [pre-load snippet](/integration/custom-events#handling-async-script-loading-recommended) before the script tag. `setGlobalProperties()` calls made before the script has loaded are then queued and applied in order, before the initial pageview, so the first event already carries them. Properties set this way merge on top of `data-global-properties`.
+
 ## Accepted Values
 
 Values must be **strings**, **numbers**, or **booleans**.

--- a/docs/src/content/troubleshooting.mdx
+++ b/docs/src/content/troubleshooting.mdx
@@ -154,13 +154,16 @@ For frameworks that ship with their own analytics-friendly conventions (Next.js 
 
 If page views work but [custom events](/integration/custom-events) don't, the usual cause is that `betterlytics.event(...)` ran **before** the async script finished loading.
 
-If you load `analytics.js` with `async`, add this snippet **before** the analytics script tag so calls made during page load are queued and flushed once the script is ready:
+If you load `analytics.js` with `async`, add this snippet **before** the analytics script tag so `event()` and `setGlobalProperties()` calls made during page load are queued and flushed once the script is ready:
 
 ```html
 <script>
   window.betterlytics = window.betterlytics || {
     event: function () {
       (window.betterlytics.q = window.betterlytics.q || []).push(arguments);
+    },
+    setGlobalProperties: function () {
+      (window.betterlytics.gq = window.betterlytics.gq || []).push(arguments);
     }
   };
 </script>

--- a/static/analytics.js
+++ b/static/analytics.js
@@ -147,6 +147,8 @@
   }
 
   var queuedEvents = (window.betterlytics && window.betterlytics.q) || [];
+  var queuedGlobalProperties =
+    (window.betterlytics && window.betterlytics.gq) || [];
 
   var replayConsentCallbacks = [];
 
@@ -196,6 +198,13 @@
 
   if (initialGlobalProperties !== null) {
     window.betterlytics.setGlobalProperties(initialGlobalProperties);
+  }
+
+  for (var i = 0; i < queuedGlobalProperties.length; i++) {
+    window.betterlytics.setGlobalProperties.apply(
+      this,
+      queuedGlobalProperties[i],
+    );
   }
 
   for (var i = 0; i < queuedEvents.length; i++) {


### PR DESCRIPTION
The pre-load stub now queues `setGlobalProperties()` calls (`window.betterlytics.gq`) alongside `event()` calls, and analytics.js drains that queue at startup after `data-global-properties` and before queued events and the initial pageview. Fixes the dogfooding gap where `theme` was missing from every event on betterlytics.io page loads.

Closes betterlytics/betterlytics-internal#102

Reviewer notes: the two queues are independent, so any mix of old/new stub and old/cached analytics.js degrades to today's behavior (old stub with new script just has no `gq`; new stub with old script keeps queuing harmlessly). The npm tracker stub is not touched.
