### PR TITLE
Promoted the bot-filter rules that four weeks of shadow data proved bot-only

### DIFF
--- a/backend/src/bot_detection/bot_patterns_local.txt
+++ b/backend/src/bot_detection/bot_patterns_local.txt
@@ -19,10 +19,6 @@ googleproducer
 mediapartners-google
 # Site24x7 monitoring (the bare "24x7" pattern is shadow-only)
 site24x7
-# Crawlers promoted from four weeks of production bot_events shadow data (2026-08-09
-# to 2026-09-06): every session showed zero trusted input events, zero outbound
-# clicks and the self-identifying UA. Upstream only catches them via the demoted
-# generic words (spider, radar, google, \.com\b).
 baiduspider
 bytespider
 sogou web spider

--- a/backend/src/bot_detection/bot_patterns_local.txt
+++ b/backend/src/bot_detection/bot_patterns_local.txt
@@ -19,3 +19,27 @@ googleproducer
 mediapartners-google
 # Site24x7 monitoring (the bare "24x7" pattern is shadow-only)
 site24x7
+# Crawlers promoted from four weeks of production bot_events shadow data (2026-08-09
+# to 2026-09-06): every session showed zero trusted input events, zero outbound
+# clicks and the self-identifying UA. Upstream only catches them via the demoted
+# generic words (spider, radar, google, \.com\b).
+baiduspider
+bytespider
+sogou web spider
+worldgraphspider
+yisouspider
+360spider
+yeti/
+iubenda-radar
+dataprovider\.com
+rootevidence
+lightpanda
+bitdiscovery
+playstore-google
+google-businesslinkverification
+google-websight
+google web preview
+google-app-companion
+google-structured-data-testing-tool
+google-ads-conversions
+^google$

--- a/backend/src/bot_detection/mod.rs
+++ b/backend/src/bot_detection/mod.rs
@@ -100,6 +100,7 @@ pub const REASON_HOSTING_NETWORK: &str = "hosting-network";
 pub const REASON_PREFETCH: &str = "prefetch";
 pub const REASON_VELOCITY: &str = "velocity";
 pub const REASON_MISSING_CLIENT_HINTS: &str = "missing-client-hints";
+pub const REASON_STALE_CHROMIUM_NO_HINTS: &str = "stale-chromium-no-hints";
 pub const REASON_CLIENT_HINTS_MISMATCH: &str = "client-hints-mismatch";
 pub const REASON_STALE_BROWSER: &str = "stale-browser";
 
@@ -107,6 +108,7 @@ pub const REASON_STALE_BROWSER: &str = "stale-browser";
 const ENFORCING_REASONS: &[&str] = &[
     REASON_UA_BLOCKLIST,
     REASON_CLIENT_AUTOMATION,
+    REASON_STALE_CHROMIUM_NO_HINTS,
 ];
 
 pub struct Detection {
@@ -144,6 +146,11 @@ const UA_MAX_LENGTH: usize = 500;
 
 /// Chromium sends low-entropy client hints on every request since major 89
 const CLIENT_HINTS_MIN_CHROMIUM_MAJOR: u32 = 89;
+/// A desktop Chromium UA below this major that sends no client hints is rejected:
+/// four weeks of production shadow data (~8k sessions, 96 sites) showed no trusted
+/// input event in that band, while real hint-less users only appeared on 130+.
+/// Real desktop Chrome that old is <1% of hint-sending sessions.
+const CLIENT_HINTS_ENFORCE_BELOW_MAJOR: u32 = 130;
 /// Desktop Chromium auto-updates; majors older than this are suspect. Starts very
 /// generous (~3 years behind); tighten from shadow data.
 const STALE_DESKTOP_CHROMIUM_MAJOR: u32 = 110;
@@ -218,7 +225,11 @@ fn collect_reasons(input: &DetectionInput) -> Vec<&'static str> {
     if let Some(major) = chromium_major(user_agent) {
         if major >= CLIENT_HINTS_MIN_CHROMIUM_MAJOR {
             if input.sec_ch_ua.is_empty() {
-                reasons.push(REASON_MISSING_CLIENT_HINTS);
+                if major < CLIENT_HINTS_ENFORCE_BELOW_MAJOR && is_desktop_ua(user_agent) {
+                    reasons.push(REASON_STALE_CHROMIUM_NO_HINTS);
+                } else {
+                    reasons.push(REASON_MISSING_CLIENT_HINTS);
+                }
             } else if !input.sec_ch_ua.contains(&format!("v=\"{}\"", major)) {
                 reasons.push(REASON_CLIENT_HINTS_MISMATCH);
             }
@@ -633,8 +644,40 @@ mod tests {
     }
 
     #[test]
-    fn chromium_without_client_hints_is_shadow_flagged() {
+    fn current_chromium_without_client_hints_is_shadow_flagged() {
+        // Desktop Chrome 131: real hint-less users exist on 130+, so shadow only
         let detection = detect(&DetectionInput { sec_ch_ua: "", ..human_input() });
+        assert_eq!(detection.shadow, vec![REASON_MISSING_CLIENT_HINTS]);
+        assert!(!detection.should_reject());
+    }
+
+    #[test]
+    fn stale_desktop_chromium_without_client_hints_rejects() {
+        let ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36";
+        let detection = detect(&DetectionInput {
+            user_agent: ua,
+            header_user_agent: ua,
+            screen_resolution: "1280x1200",
+            sec_ch_ua: "",
+            ..Default::default()
+        });
+        assert_eq!(detection.enforcing, vec![REASON_STALE_CHROMIUM_NO_HINTS]);
+        assert!(detection.should_reject());
+        assert_eq!(detection.tagged_reasons(), vec!["stale-chromium-no-hints"]);
+
+        // The same major with consistent hints is a plain (if unusual) browser
+        assert!(detect_ua(ua).is_empty());
+
+        // Mobile Chromium without hints stays shadow: webviews and vendor browsers
+        // (Samsung Internet, HeyTap, WeChat) legitimately omit them
+        let mobile = "Mozilla/5.0 (Linux; Android 13; SM-A145R) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/21.0 Chrome/110.0.5481.154 Mobile Safari/537.36";
+        let detection = detect(&DetectionInput {
+            user_agent: mobile,
+            header_user_agent: mobile,
+            screen_resolution: "412x915",
+            sec_ch_ua: "",
+            ..Default::default()
+        });
         assert_eq!(detection.shadow, vec![REASON_MISSING_CLIENT_HINTS]);
         assert!(!detection.should_reject());
     }

--- a/backend/src/bot_detection/mod.rs
+++ b/backend/src/bot_detection/mod.rs
@@ -149,7 +149,8 @@ const CLIENT_HINTS_MIN_CHROMIUM_MAJOR: u32 = 89;
 /// A desktop Chromium UA below this major that sends no client hints is rejected:
 /// four weeks of production shadow data (~8k sessions, 96 sites) showed no trusted
 /// input event in that band, while real hint-less users only appeared on 130+.
-/// Real desktop Chrome that old is <1% of hint-sending sessions.
+/// Real desktop Chrome that old still exists (~4% of desktop sessions) but sends
+/// the header, so it is unaffected; the rule only fires when the header is missing too.
 const CLIENT_HINTS_ENFORCE_BELOW_MAJOR: u32 = 130;
 /// Desktop Chromium auto-updates; majors older than this are suspect. Starts very
 /// generous (~3 years behind); tighten from shadow data.

--- a/backend/src/bot_detection/mod.rs
+++ b/backend/src/bot_detection/mod.rs
@@ -389,6 +389,16 @@ mod tests {
         "FeedFetcher-Google; (+http://www.google.com/feedfetcher.html)",
         "Site24x7",
         "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36 Chrome-Lighthouse",
+        // Local promotions backed by bot_events shadow data (see bot_patterns_local.txt)
+        "Mozilla/5.0 (compatible; Baiduspider-render/2.0; +http://www.baidu.com/search/spider.html)",
+        "Mozilla/5.0 (Linux; Android 5.0) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Safari/537.36 (compatible; Bytespider; spider-feedback@bytedance.com)",
+        "Sogou web spider/4.0(+http://www.sogou.com/docs/help/webmasters.htm#07)",
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko; compatible; Yeti/1.1; +https://naver.me/spd) Chrome/149.0.0.0 Safari/537.36",
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36 iubenda-radar/3.30.0",
+        "Mozilla/5.0 (compatible; Dataprovider.com)",
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.7922.173 Safari/537.36 PlayStore-Google",
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko; Google-BusinessLinkVerification) Chrome/151.0.7922.173 Safari/537.36",
+        "Google",
     ];
 
     // Real browser UAs, including in-app webviews, Electron shells, and niche
@@ -435,11 +445,8 @@ mod tests {
         "Go-http-client/2.0",
         "okhttp/4.12.0",
         "Scrapy/2.11.0 (+https://scrapy.org)",
-        // Named crawlers whose only upstream coverage is a demoted generic token
-        // (spider, node\b); shadow until bot_events evidence promotes a signature
-        "Mozilla/5.0 (compatible; Bytespider; spider-feedback@bytedance.com)",
-        "Mozilla/5.0 (Linux; Android 5.0) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Safari/537.36 (compatible; Bytespider; spider-feedback@bytedance.com)",
-        "Mozilla/5.0 (compatible; Baiduspider/2.0; +http://www.baidu.com/search/spider.html)",
+        // Named crawler whose only upstream coverage is a demoted generic token
+        // (node\b); shadow until bot_events evidence promotes a signature
         "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
     ];
 


### PR DESCRIPTION
Promotes the shadow rules from #1043 that four weeks of production `bot_events` data (2026-08-09 to 2026-09-06) showed to be bot-only, so they now reject instead of counting as human. Follow-up to betterlytics/betterlytics-internal#15.

**What is promoted, and the evidence**

Every shadow-flagged event still lands in `events`, so each rule was judged by joining its sessions back and checking for behaviour that needs a person: INP (only recorded after a trusted input event), outbound-link clicks and non-automatic custom events. Unflagged sessions show INP in 6% and clicks in 8%; unflagged desktop Chrome sessions from Vietnam and Brazil show INP in 2 to 10% and engagement in 60 to 75%.

- **Named crawler signatures** (Baiduspider, Bytespider, Sogou, YisouSpider, 360Spider, WorldGraphSpider, Naver Yeti, iubenda-radar, Dataprovider.com, RootEvidence, Lightpanda, bitdiscovery, PlayStore-Google and the Google verification/preview agents) added to the local enforced list. Upstream only caught them through the demoted generic words. 24k events on 92 sites, 5.2k sessions, zero INP, zero clicks. Google-AdWords-Express is deliberately left out: one of its 36 sessions had a real click, consistent with an ads reviewer.
- **Stale desktop Chromium without client hints** (`stale-chromium-no-hints`): a desktop UA claiming Chrome 89 to 129 that sends no `sec-ch-ua`. This is the residential-proxy scraper fleet customers see as Vietnamese, Latin American and Singaporean traffic. 9.5k events on 96 sites, ~8k sessions, zero INP, zero LCP, one click from an impossible "Chrome/125 Edge/12.246" UA, two screen sizes in total, and 100% empty referrers on the Vietnamese slice. Chrome 130+ and all mobile UAs stay shadow: real hint-less users appeared there (Jio and Airtel Chrome 151, Samsung Internet, WeChat, HeyTap). Real desktop Chrome on 89 to 129 still exists (about 4% of desktop sessions) but sends the header, so it is unaffected.
