### PR TITLE
Removed the unused updateUserPassword repository function

### DIFF
--- a/dashboard/src/repositories/postgres/user.repository.test.ts
+++ b/dashboard/src/repositories/postgres/user.repository.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import * as bcrypt from 'bcrypt';
 import {
   findUserById,
   findUserByEmail,
   findCredentialAccount,
   createUser,
-  updateUserPassword,
   anonymizeUser,
 } from '@/repositories/postgres/user.repository';
 import { makeUser } from '@/test/auth-fixtures';
@@ -132,29 +130,6 @@ describe('createUser', () => {
       'Failed to create user.',
     );
     expect(prismaMock.user.create).not.toHaveBeenCalled();
-  });
-});
-
-describe('updateUserPassword', () => {
-  it('stores a bcrypt hash of the new password on the credential account', async () => {
-    prismaMock.account.update.mockResolvedValue({});
-
-    await updateUserPassword('user-1', 'New-password-1');
-
-    const updateCall = prismaMock.account.update.mock.calls[0][0];
-    expect(updateCall.where).toEqual({
-      providerId_accountId: { providerId: 'credential', accountId: 'user-1' },
-      userId: 'user-1',
-    });
-    expect(await bcrypt.compare('New-password-1', updateCall.data.password)).toBe(true);
-  });
-
-  it('throws when the user has no credential account row', async () => {
-    prismaMock.account.update.mockRejectedValue(new Error('Record to update not found.'));
-
-    await expect(updateUserPassword('user-1', 'New-password-1')).rejects.toThrow(
-      'Failed to update password',
-    );
   });
 });
 

--- a/dashboard/src/repositories/postgres/user.repository.ts
+++ b/dashboard/src/repositories/postgres/user.repository.ts
@@ -2,7 +2,6 @@ import 'server-only';
 
 import prisma from '@/lib/postgres';
 import { GithubStarPromptState, Prisma } from '@prisma/client';
-import { hashPassword } from '@/lib/password';
 import {
   User,
   UserSchema,
@@ -121,23 +120,6 @@ export async function updateUser(userId: string, data: UpdateUserData): Promise<
   } catch (error) {
     console.error(`Error updating user ${userId}:`, error);
     throw new Error(`Failed to update user ${userId}.`);
-  }
-}
-
-export async function updateUserPassword(userId: string, newPassword: string): Promise<void> {
-  try {
-    const passwordHash = await hashPassword(newPassword);
-
-    await prisma.account.update({
-      where: {
-        providerId_accountId: { providerId: CREDENTIAL_PROVIDER_ID, accountId: userId },
-        userId,
-      },
-      data: { password: passwordHash },
-    });
-  } catch (error) {
-    console.error(`Error updating password for user ${userId}:`, error);
-    throw new Error(`Failed to update password for user ${userId}.`);
   }
 }
 


### PR DESCRIPTION
`updateUserPassword` lost its last production caller when change-password and forgot/reset-password moved onto better-auth's own endpoints (#1074, #1076) — better-auth writes the credential account row itself. Only the function's own unit tests still referenced it.

Removes the function, its two tests, and the now-unused `hashPassword` / `bcrypt` imports. No behaviour change.