### PR TITLE
Raised session replay flush interval to 60 s and chunk cap to 350 KB

### DIFF
--- a/static/replay.js
+++ b/static/replay.js
@@ -8396,8 +8396,8 @@ or you can use record.mirror to access the mirror instance during recording.`;
     };
 
     var config = {
-      maxChunkMs: 5000,
-      maxUncompressedBytes: 256 * 1024,
+      maxChunkMs: 60000,
+      maxUncompressedBytes: 350 * 1024,
       maxConsecutiveFlushErrors: 3,
     };
 


### PR DESCRIPTION
Replay segments were flushed every 5 s, so a typical recording uploaded one tiny segment per 5 s (~240 per 20 min session). Flushes now trigger at 350 KB uncompressed or every 60 s, whichever comes first, cutting segment count roughly 4x at the prod median and 12x for quiet sessions.

350 KB gzips to ~40 KB (measured 8.3x to 10.8x on betterlytics.io), keeping every size-triggered chunk under the 60 KB keepalive limit so unload uploads are no worse than before. Related, not fixed: betterlytics/betterlytics-internal#202.
