### PR TITLE
Hide links to cloud-gated routes in public nav and footers off-cloud

### DIFF
--- a/dashboard/src/app/(app)/[locale]/(public)/layout.tsx
+++ b/dashboard/src/app/(app)/[locale]/(public)/layout.tsx
@@ -2,11 +2,12 @@ import { Footer } from '@/components/footer/Footer';
 import PublicTopBar from '@/components/topbar/PublicTopBar';
 import { SUPPORTED_LANGUAGES } from '@/constants/i18n';
 import ThemeToggleFab from '@/components/ThemeToggleFab';
+import { isFeatureEnabled } from '@/lib/feature-flags';
 
 export default async function LocaleLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className='flex min-h-screen flex-col justify-between'>
-      <PublicTopBar />
+      <PublicTopBar isCloud={isFeatureEnabled('isCloud')} />
       <div className='flex flex-1 flex-col'>{children}</div>
       <Footer />
       <ThemeToggleFab />

--- a/dashboard/src/app/(app)/[locale]/(public)/layout.tsx
+++ b/dashboard/src/app/(app)/[locale]/(public)/layout.tsx
@@ -1,15 +1,18 @@
 import { Footer } from '@/components/footer/Footer';
+import { MinimalFooter } from '@/components/footer/MinimalFooter';
 import PublicTopBar from '@/components/topbar/PublicTopBar';
 import { SUPPORTED_LANGUAGES } from '@/constants/i18n';
 import ThemeToggleFab from '@/components/ThemeToggleFab';
 import { isFeatureEnabled } from '@/lib/feature-flags';
 
 export default async function LocaleLayout({ children }: { children: React.ReactNode }) {
+  const isCloud = isFeatureEnabled('isCloud');
+
   return (
     <div className='flex min-h-screen flex-col justify-between'>
-      <PublicTopBar isCloud={isFeatureEnabled('isCloud')} />
+      <PublicTopBar isCloud={isCloud} />
       <div className='flex flex-1 flex-col'>{children}</div>
-      <Footer />
+      {isCloud ? <Footer /> : <MinimalFooter />}
       <ThemeToggleFab />
     </div>
   );

--- a/dashboard/src/components/CloudOnly.tsx
+++ b/dashboard/src/components/CloudOnly.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from 'react';
+import { isFeatureEnabled } from '@/lib/feature-flags';
+
+export function CloudOnly({ children }: { children: ReactNode }) {
+  return isFeatureEnabled('isCloud') ? children : null;
+}

--- a/dashboard/src/components/footer/Footer.tsx
+++ b/dashboard/src/components/footer/Footer.tsx
@@ -4,13 +4,16 @@ import { GitHubIcon, DiscordIcon, BlueskyIcon } from '@/components/icons/SocialI
 import ExternalLink from '@/components/ExternalLink';
 import { getTranslations } from 'next-intl/server';
 import { FooterLanguageSelector } from './FooterLanguageSelector';
+import { CloudOnly } from '@/components/CloudOnly';
+import { isFeatureEnabled } from '@/lib/feature-flags';
 
 export async function Footer() {
   const t = await getTranslations('public.footer');
+  const columns = isFeatureEnabled('isCloud') ? 'md:grid-cols-5' : 'md:grid-cols-3';
   return (
     <footer className='border-border/40 border-t py-12'>
       <div className='container mx-auto px-4 sm:px-6 lg:px-8'>
-        <div className='grid gap-8 md:grid-cols-5'>
+        <div className={`grid gap-8 ${columns}`}>
           <div>
             <div className='mb-4'>
               <Link href='/' className='flex items-center space-x-2'>
@@ -20,41 +23,43 @@ export async function Footer() {
             <p className='text-muted-foreground mb-6 text-sm'>{t('blurb')}</p>
             <FooterLanguageSelector />
           </div>
-          <div>
-            <h3 className='mb-4 font-semibold'>{t('company')}</h3>
-            <ul className='text-muted-foreground space-y-2 text-sm'>
-              <li>
-                <Link href='/about' className='hover:text-foreground transition-colors'>
-                  {t('about')}
-                </Link>
-              </li>
-              <li>
-                <Link href='/contact' className='hover:text-foreground transition-colors'>
-                  {t('contact')}
-                </Link>
-              </li>
-              <li>
-                <Link href='/privacy' className='hover:text-foreground transition-colors'>
-                  {t('privacyPolicy')}
-                </Link>
-              </li>
-              <li>
-                <Link href='/terms' className='hover:text-foreground transition-colors'>
-                  {t('termsOfService')}
-                </Link>
-              </li>
-              <li>
-                <Link href='/dpa' className='hover:text-foreground transition-colors'>
-                  {t('dpa')}
-                </Link>
-              </li>
-              <li>
-                <Link href='/subprocessors' className='hover:text-foreground transition-colors'>
-                  {t('subprocessors')}
-                </Link>
-              </li>
-            </ul>
-          </div>
+          <CloudOnly>
+            <div>
+              <h3 className='mb-4 font-semibold'>{t('company')}</h3>
+              <ul className='text-muted-foreground space-y-2 text-sm'>
+                <li>
+                  <Link href='/about' className='hover:text-foreground transition-colors'>
+                    {t('about')}
+                  </Link>
+                </li>
+                <li>
+                  <Link href='/contact' className='hover:text-foreground transition-colors'>
+                    {t('contact')}
+                  </Link>
+                </li>
+                <li>
+                  <Link href='/privacy' className='hover:text-foreground transition-colors'>
+                    {t('privacyPolicy')}
+                  </Link>
+                </li>
+                <li>
+                  <Link href='/terms' className='hover:text-foreground transition-colors'>
+                    {t('termsOfService')}
+                  </Link>
+                </li>
+                <li>
+                  <Link href='/dpa' className='hover:text-foreground transition-colors'>
+                    {t('dpa')}
+                  </Link>
+                </li>
+                <li>
+                  <Link href='/subprocessors' className='hover:text-foreground transition-colors'>
+                    {t('subprocessors')}
+                  </Link>
+                </li>
+              </ul>
+            </div>
+          </CloudOnly>
           <div>
             <h3 className='mb-4 font-semibold'>{t('resources')}</h3>
             <ul className='text-muted-foreground space-y-2 text-sm'>
@@ -67,67 +72,71 @@ export async function Footer() {
                   {t('documentation')}
                 </ExternalLink>
               </li>
-              <li>
-                <Link href='/changelog' className='hover:text-foreground transition-colors'>
-                  {t('changelog')}
-                </Link>
-              </li>
-              <li>
-                <Link href='/features' className='hover:text-foreground transition-colors'>
-                  {t('features')}
-                </Link>
-              </li>
-              <li>
-                <Link href='/pricing' className='hover:text-foreground transition-colors'>
-                  {t('pricing')}
-                </Link>
-              </li>
-              <li>
-                <ExternalLink
-                  href='https://status.betterlytics.io'
-                  title={t('status')}
-                  className='hover:text-foreground transition-colors'
-                >
-                  {t('status')}
-                </ExternalLink>
-              </li>
+              <CloudOnly>
+                <li>
+                  <Link href='/changelog' className='hover:text-foreground transition-colors'>
+                    {t('changelog')}
+                  </Link>
+                </li>
+                <li>
+                  <Link href='/features' className='hover:text-foreground transition-colors'>
+                    {t('features')}
+                  </Link>
+                </li>
+                <li>
+                  <Link href='/pricing' className='hover:text-foreground transition-colors'>
+                    {t('pricing')}
+                  </Link>
+                </li>
+                <li>
+                  <ExternalLink
+                    href='https://status.betterlytics.io'
+                    title={t('status')}
+                    className='hover:text-foreground transition-colors'
+                  >
+                    {t('status')}
+                  </ExternalLink>
+                </li>
+              </CloudOnly>
             </ul>
           </div>
-          <div>
-            <h3 className='mb-4 font-semibold'>{t('compare')}</h3>
-            <ul className='text-muted-foreground space-y-2 text-sm'>
-              <li>
-                <Link href='/vs/google-analytics' className='hover:text-foreground transition-colors'>
-                  vs Google Analytics
-                </Link>
-              </li>
-              <li>
-                <Link href='/vs/matomo' className='hover:text-foreground transition-colors'>
-                  vs Matomo
-                </Link>
-              </li>
-              <li>
-                <Link href='/vs/plausible' className='hover:text-foreground transition-colors'>
-                  vs Plausible
-                </Link>
-              </li>
-              <li>
-                <Link href='/vs/posthog' className='hover:text-foreground transition-colors'>
-                  vs PostHog
-                </Link>
-              </li>
-              <li>
-                <Link href='/vs/fathom-analytics' className='hover:text-foreground transition-colors'>
-                  vs Fathom Analytics
-                </Link>
-              </li>
-              <li>
-                <Link href='/vs/umami' className='hover:text-foreground transition-colors'>
-                  vs Umami
-                </Link>
-              </li>
-            </ul>
-          </div>
+          <CloudOnly>
+            <div>
+              <h3 className='mb-4 font-semibold'>{t('compare')}</h3>
+              <ul className='text-muted-foreground space-y-2 text-sm'>
+                <li>
+                  <Link href='/vs/google-analytics' className='hover:text-foreground transition-colors'>
+                    vs Google Analytics
+                  </Link>
+                </li>
+                <li>
+                  <Link href='/vs/matomo' className='hover:text-foreground transition-colors'>
+                    vs Matomo
+                  </Link>
+                </li>
+                <li>
+                  <Link href='/vs/plausible' className='hover:text-foreground transition-colors'>
+                    vs Plausible
+                  </Link>
+                </li>
+                <li>
+                  <Link href='/vs/posthog' className='hover:text-foreground transition-colors'>
+                    vs PostHog
+                  </Link>
+                </li>
+                <li>
+                  <Link href='/vs/fathom-analytics' className='hover:text-foreground transition-colors'>
+                    vs Fathom Analytics
+                  </Link>
+                </li>
+                <li>
+                  <Link href='/vs/umami' className='hover:text-foreground transition-colors'>
+                    vs Umami
+                  </Link>
+                </li>
+              </ul>
+            </div>
+          </CloudOnly>
           <div>
             <h3 className='mb-4 font-semibold'>{t('connect')}</h3>
             <ul className='text-muted-foreground space-y-2 text-sm'>

--- a/dashboard/src/components/footer/Footer.tsx
+++ b/dashboard/src/components/footer/Footer.tsx
@@ -4,16 +4,13 @@ import { GitHubIcon, DiscordIcon, BlueskyIcon } from '@/components/icons/SocialI
 import ExternalLink from '@/components/ExternalLink';
 import { getTranslations } from 'next-intl/server';
 import { FooterLanguageSelector } from './FooterLanguageSelector';
-import { CloudOnly } from '@/components/CloudOnly';
-import { isFeatureEnabled } from '@/lib/feature-flags';
 
 export async function Footer() {
   const t = await getTranslations('public.footer');
-  const columns = isFeatureEnabled('isCloud') ? 'md:grid-cols-5' : 'md:grid-cols-3';
   return (
     <footer className='border-border/40 border-t py-12'>
       <div className='container mx-auto px-4 sm:px-6 lg:px-8'>
-        <div className={`grid gap-8 ${columns}`}>
+        <div className='grid gap-8 md:grid-cols-5'>
           <div>
             <div className='mb-4'>
               <Link href='/' className='flex items-center space-x-2'>
@@ -23,43 +20,41 @@ export async function Footer() {
             <p className='text-muted-foreground mb-6 text-sm'>{t('blurb')}</p>
             <FooterLanguageSelector />
           </div>
-          <CloudOnly>
-            <div>
-              <h3 className='mb-4 font-semibold'>{t('company')}</h3>
-              <ul className='text-muted-foreground space-y-2 text-sm'>
-                <li>
-                  <Link href='/about' className='hover:text-foreground transition-colors'>
-                    {t('about')}
-                  </Link>
-                </li>
-                <li>
-                  <Link href='/contact' className='hover:text-foreground transition-colors'>
-                    {t('contact')}
-                  </Link>
-                </li>
-                <li>
-                  <Link href='/privacy' className='hover:text-foreground transition-colors'>
-                    {t('privacyPolicy')}
-                  </Link>
-                </li>
-                <li>
-                  <Link href='/terms' className='hover:text-foreground transition-colors'>
-                    {t('termsOfService')}
-                  </Link>
-                </li>
-                <li>
-                  <Link href='/dpa' className='hover:text-foreground transition-colors'>
-                    {t('dpa')}
-                  </Link>
-                </li>
-                <li>
-                  <Link href='/subprocessors' className='hover:text-foreground transition-colors'>
-                    {t('subprocessors')}
-                  </Link>
-                </li>
-              </ul>
-            </div>
-          </CloudOnly>
+          <div>
+            <h3 className='mb-4 font-semibold'>{t('company')}</h3>
+            <ul className='text-muted-foreground space-y-2 text-sm'>
+              <li>
+                <Link href='/about' className='hover:text-foreground transition-colors'>
+                  {t('about')}
+                </Link>
+              </li>
+              <li>
+                <Link href='/contact' className='hover:text-foreground transition-colors'>
+                  {t('contact')}
+                </Link>
+              </li>
+              <li>
+                <Link href='/privacy' className='hover:text-foreground transition-colors'>
+                  {t('privacyPolicy')}
+                </Link>
+              </li>
+              <li>
+                <Link href='/terms' className='hover:text-foreground transition-colors'>
+                  {t('termsOfService')}
+                </Link>
+              </li>
+              <li>
+                <Link href='/dpa' className='hover:text-foreground transition-colors'>
+                  {t('dpa')}
+                </Link>
+              </li>
+              <li>
+                <Link href='/subprocessors' className='hover:text-foreground transition-colors'>
+                  {t('subprocessors')}
+                </Link>
+              </li>
+            </ul>
+          </div>
           <div>
             <h3 className='mb-4 font-semibold'>{t('resources')}</h3>
             <ul className='text-muted-foreground space-y-2 text-sm'>
@@ -72,71 +67,67 @@ export async function Footer() {
                   {t('documentation')}
                 </ExternalLink>
               </li>
-              <CloudOnly>
-                <li>
-                  <Link href='/changelog' className='hover:text-foreground transition-colors'>
-                    {t('changelog')}
-                  </Link>
-                </li>
-                <li>
-                  <Link href='/features' className='hover:text-foreground transition-colors'>
-                    {t('features')}
-                  </Link>
-                </li>
-                <li>
-                  <Link href='/pricing' className='hover:text-foreground transition-colors'>
-                    {t('pricing')}
-                  </Link>
-                </li>
-                <li>
-                  <ExternalLink
-                    href='https://status.betterlytics.io'
-                    title={t('status')}
-                    className='hover:text-foreground transition-colors'
-                  >
-                    {t('status')}
-                  </ExternalLink>
-                </li>
-              </CloudOnly>
+              <li>
+                <Link href='/changelog' className='hover:text-foreground transition-colors'>
+                  {t('changelog')}
+                </Link>
+              </li>
+              <li>
+                <Link href='/features' className='hover:text-foreground transition-colors'>
+                  {t('features')}
+                </Link>
+              </li>
+              <li>
+                <Link href='/pricing' className='hover:text-foreground transition-colors'>
+                  {t('pricing')}
+                </Link>
+              </li>
+              <li>
+                <ExternalLink
+                  href='https://status.betterlytics.io'
+                  title={t('status')}
+                  className='hover:text-foreground transition-colors'
+                >
+                  {t('status')}
+                </ExternalLink>
+              </li>
             </ul>
           </div>
-          <CloudOnly>
-            <div>
-              <h3 className='mb-4 font-semibold'>{t('compare')}</h3>
-              <ul className='text-muted-foreground space-y-2 text-sm'>
-                <li>
-                  <Link href='/vs/google-analytics' className='hover:text-foreground transition-colors'>
-                    vs Google Analytics
-                  </Link>
-                </li>
-                <li>
-                  <Link href='/vs/matomo' className='hover:text-foreground transition-colors'>
-                    vs Matomo
-                  </Link>
-                </li>
-                <li>
-                  <Link href='/vs/plausible' className='hover:text-foreground transition-colors'>
-                    vs Plausible
-                  </Link>
-                </li>
-                <li>
-                  <Link href='/vs/posthog' className='hover:text-foreground transition-colors'>
-                    vs PostHog
-                  </Link>
-                </li>
-                <li>
-                  <Link href='/vs/fathom-analytics' className='hover:text-foreground transition-colors'>
-                    vs Fathom Analytics
-                  </Link>
-                </li>
-                <li>
-                  <Link href='/vs/umami' className='hover:text-foreground transition-colors'>
-                    vs Umami
-                  </Link>
-                </li>
-              </ul>
-            </div>
-          </CloudOnly>
+          <div>
+            <h3 className='mb-4 font-semibold'>{t('compare')}</h3>
+            <ul className='text-muted-foreground space-y-2 text-sm'>
+              <li>
+                <Link href='/vs/google-analytics' className='hover:text-foreground transition-colors'>
+                  vs Google Analytics
+                </Link>
+              </li>
+              <li>
+                <Link href='/vs/matomo' className='hover:text-foreground transition-colors'>
+                  vs Matomo
+                </Link>
+              </li>
+              <li>
+                <Link href='/vs/plausible' className='hover:text-foreground transition-colors'>
+                  vs Plausible
+                </Link>
+              </li>
+              <li>
+                <Link href='/vs/posthog' className='hover:text-foreground transition-colors'>
+                  vs PostHog
+                </Link>
+              </li>
+              <li>
+                <Link href='/vs/fathom-analytics' className='hover:text-foreground transition-colors'>
+                  vs Fathom Analytics
+                </Link>
+              </li>
+              <li>
+                <Link href='/vs/umami' className='hover:text-foreground transition-colors'>
+                  vs Umami
+                </Link>
+              </li>
+            </ul>
+          </div>
           <div>
             <h3 className='mb-4 font-semibold'>{t('connect')}</h3>
             <ul className='text-muted-foreground space-y-2 text-sm'>

--- a/dashboard/src/components/footer/MinimalFooter.tsx
+++ b/dashboard/src/components/footer/MinimalFooter.tsx
@@ -2,9 +2,14 @@ import { Link } from '@/i18n/navigation';
 import { getTranslations } from 'next-intl/server';
 import { FooterLanguageSelector } from './FooterLanguageSelector';
 import { CloudOnly } from '@/components/CloudOnly';
+import ExternalLink from '@/components/ExternalLink';
+import { isFeatureEnabled } from '@/lib/feature-flags';
+
+const LINK_CLASS = 'text-muted-foreground hover:text-foreground transition-colors';
 
 export async function MinimalFooter() {
   const t = await getTranslations('public.footer');
+  const isCloud = isFeatureEnabled('isCloud');
 
   return (
     <footer className='border-border/40 mt-auto w-full border-t py-6'>
@@ -13,16 +18,43 @@ export async function MinimalFooter() {
           <div className='flex flex-wrap items-center justify-center gap-4 text-sm'>
             <FooterLanguageSelector />
             <CloudOnly>
-              <Link href='/privacy' className='text-muted-foreground hover:text-foreground transition-colors'>
+              <Link href='/privacy' className={LINK_CLASS}>
                 {t('privacyPolicy')}
               </Link>
-              <Link href='/terms' className='text-muted-foreground hover:text-foreground transition-colors'>
+              <Link href='/terms' className={LINK_CLASS}>
                 {t('termsOfService')}
               </Link>
-              <Link href='/contact' className='text-muted-foreground hover:text-foreground transition-colors'>
+              <Link href='/contact' className={LINK_CLASS}>
                 {t('contact')}
               </Link>
             </CloudOnly>
+            {!isCloud && (
+              <>
+                <ExternalLink
+                  href='https://betterlytics.io/docs'
+                  title={t('documentation')}
+                  className={LINK_CLASS}
+                >
+                  {t('documentation')}
+                </ExternalLink>
+                <ExternalLink
+                  href='https://github.com/betterlytics/betterlytics'
+                  className={LINK_CLASS}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                >
+                  {t('github')}
+                </ExternalLink>
+                <ExternalLink
+                  href='https://discord.com/invite/vwqSvPn6sP'
+                  className={LINK_CLASS}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                >
+                  {t('discord')}
+                </ExternalLink>
+              </>
+            )}
           </div>
           <p className='text-muted-foreground text-center text-sm'>
             {t('copyright', { year: new Date().getFullYear() })}

--- a/dashboard/src/components/footer/MinimalFooter.tsx
+++ b/dashboard/src/components/footer/MinimalFooter.tsx
@@ -1,6 +1,7 @@
 import { Link } from '@/i18n/navigation';
 import { getTranslations } from 'next-intl/server';
 import { FooterLanguageSelector } from './FooterLanguageSelector';
+import { CloudOnly } from '@/components/CloudOnly';
 
 export async function MinimalFooter() {
   const t = await getTranslations('public.footer');
@@ -11,15 +12,17 @@ export async function MinimalFooter() {
         <div className='flex flex-col items-center space-y-4'>
           <div className='flex flex-wrap items-center justify-center gap-4 text-sm'>
             <FooterLanguageSelector />
-            <Link href='/privacy' className='text-muted-foreground hover:text-foreground transition-colors'>
-              {t('privacyPolicy')}
-            </Link>
-            <Link href='/terms' className='text-muted-foreground hover:text-foreground transition-colors'>
-              {t('termsOfService')}
-            </Link>
-            <Link href='/contact' className='text-muted-foreground hover:text-foreground transition-colors'>
-              {t('contact')}
-            </Link>
+            <CloudOnly>
+              <Link href='/privacy' className='text-muted-foreground hover:text-foreground transition-colors'>
+                {t('privacyPolicy')}
+              </Link>
+              <Link href='/terms' className='text-muted-foreground hover:text-foreground transition-colors'>
+                {t('termsOfService')}
+              </Link>
+              <Link href='/contact' className='text-muted-foreground hover:text-foreground transition-colors'>
+                {t('contact')}
+              </Link>
+            </CloudOnly>
           </div>
           <p className='text-muted-foreground text-center text-sm'>
             {t('copyright', { year: new Date().getFullYear() })}

--- a/dashboard/src/components/topbar/PublicTopBar.tsx
+++ b/dashboard/src/components/topbar/PublicTopBar.tsx
@@ -11,7 +11,7 @@ import { GitHubIcon } from '@/components/icons/SocialIcons';
 import { useTranslations } from 'next-intl';
 import NextLink from 'next/link';
 
-export default function PublicTopBar() {
+export default function PublicTopBar({ isCloud }: { isCloud: boolean }) {
   const t = useTranslations('public.nav');
   const { data: session, isPending } = useHydratedSession();
   const pathname = usePathname();
@@ -46,18 +46,22 @@ export default function PublicTopBar() {
               >
                 {t('documentation')}
               </ExternalLink>
-              <Link
-                href='/features'
-                className='text-muted-foreground hover:text-foreground text-sm font-medium transition-colors'
-              >
-                {t('features')}
-              </Link>
-              <Link
-                href='/pricing'
-                className='text-muted-foreground hover:text-foreground text-sm font-medium transition-colors'
-              >
-                {t('pricing')}
-              </Link>
+              {isCloud && (
+                <>
+                  <Link
+                    href='/features'
+                    className='text-muted-foreground hover:text-foreground text-sm font-medium transition-colors'
+                  >
+                    {t('features')}
+                  </Link>
+                  <Link
+                    href='/pricing'
+                    className='text-muted-foreground hover:text-foreground text-sm font-medium transition-colors'
+                  >
+                    {t('pricing')}
+                  </Link>
+                </>
+              )}
             </nav>
 
             <div className='ml-6 flex items-center gap-6'>
@@ -107,20 +111,24 @@ export default function PublicTopBar() {
         {isMobileMenuOpen && (
           <div className='border-t md:hidden'>
             <nav className='space-y-3 py-4'>
-              <Link
-                href='/#pricing'
-                onClick={closeMobileMenu}
-                className='text-foreground hover:text-foreground block text-sm font-medium transition-colors'
-              >
-                {t('pricing')}
-              </Link>
-              <Link
-                href='/features'
-                onClick={closeMobileMenu}
-                className='text-foreground hover:text-foreground block text-sm font-medium transition-colors'
-              >
-                {t('features')}
-              </Link>
+              {isCloud && (
+                <>
+                  <Link
+                    href='/#pricing'
+                    onClick={closeMobileMenu}
+                    className='text-foreground hover:text-foreground block text-sm font-medium transition-colors'
+                  >
+                    {t('pricing')}
+                  </Link>
+                  <Link
+                    href='/features'
+                    onClick={closeMobileMenu}
+                    className='text-foreground hover:text-foreground block text-sm font-medium transition-colors'
+                  >
+                    {t('features')}
+                  </Link>
+                </>
+              )}
               <ExternalLink
                 href='https://betterlytics.io/docs'
                 onClick={closeMobileMenu}


### PR DESCRIPTION
## What

Off-cloud (`IS_CLOUD=false`), the public topbar and footers no longer link to routes that redirect home on selfhost deploys.

- New server `CloudOnly` wrapper (`components/CloudOnly.tsx`) on `isFeatureEnabled('isCloud')`.
- `PublicTopBar`: Features and Pricing (desktop + mobile menu) gated via an `isCloud` prop from the `(public)` layout. The topbar is a client component with one render site, so a prop needs no env provider.
- `(public)` layout renders `MinimalFooter` instead of `Footer` off-cloud. `Footer` itself is untouched and cloud-only.
- `MinimalFooter`: privacy/terms/contact are cloud-only; off-cloud it shows Documentation, GitHub and Discord instead (existing `public.footer` keys), so selfhosters keep a docs and community support path. Language selector and copyright stay in both modes.
- No translation changes.

## Why

#155 gated the marketing and legal routes off-cloud, so every one of these links dead-ended through a redirect to `/` and then signin on selfhosted instances.

## Reviewer notes

- Deviates from spec 4 of the issue ("external links stay untouched"): off-cloud the full footer is replaced, so Status and Bluesky go with it. Docs, GitHub and Discord are kept because every open-core reference we checked (Plausible CE, PostHog, Sentry, GitLab) keeps docs plus a community support link on self-host while dropping vendor billing, status and legal.
- On-cloud output is unchanged.
- Verified with `tsc --noEmit`; manual check off-cloud on `/signin`, `/signup`, `/forgot-password`, `/reset-password`, `/accept-invite`, `/verify-email` still to be done.

Closes betterlytics/betterlytics-internal#175